### PR TITLE
feat: built-in USB connectivity (drop the iproxy requirement)

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -72,6 +72,13 @@ struct PhoneInfo: Decodable {
     var kind: String { device ?? "device" }
 }
 
+/// How the sender reaches the receiver. Reconnects re-dial from scratch, so
+/// a USB device that was replugged (new usbmuxd DeviceID) is found again.
+enum SenderTransport {
+    case tcp(NWEndpoint)                   // WiFi (Bonjour) or -host/-port override
+    case usb(udid: String?, port: UInt16)  // native usbmuxd dial; nil = first device
+}
+
 @available(macOS 14.0, *)
 final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
@@ -91,7 +98,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private let queue = DispatchQueue(label: "sender.video")
     private let startCode: [UInt8] = [0, 0, 0, 1]
 
-    private let endpoint: NWEndpoint
+    private let transport: SenderTransport
     private let endpointName: String
     private let mode: CaptureMode
     private let quality: StreamQuality
@@ -118,7 +125,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private var inputInjector: InputInjector?
 
     // Liveness: both sides ping every 2s; if nothing arrives for 5s the link
-    // is half-open (e.g. iproxy accepted but the device is gone) — reconnect.
+    // is half-open (e.g. usbmuxd accepted but the device is gone) — reconnect.
     private var lastReceived = Date()
     private var dropsTotal = 0
 
@@ -153,9 +160,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private var lastPixelBuffer: CVPixelBuffer?
     private var lastCaptureAt = Date.distantPast
 
-    init(endpoint: NWEndpoint, name: String, mode: CaptureMode,
+    init(transport: SenderTransport, name: String, mode: CaptureMode,
          quality: StreamQuality = .best) {
-        self.endpoint = endpoint
+        self.transport = transport
         self.endpointName = name
         self.mode = mode
         self.quality = quality
@@ -166,16 +173,16 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     func start() async throws {
         stopped = false
-        connect()
+        queue.async { self.connect() }   // dial state lives on `queue`
         schedulePing()
         scheduleWatchdog()
 
-        // Screen Recording permission: preflight, request if missing, and poll
-        // until granted (the user flips the toggle in System Settings).
+        // Screen Recording permission: poll until granted. No auto-prompt at
+        // launch — the permission panel's Grant button triggers the system
+        // dialog, so the request always has visible context.
         if !CGPreflightScreenCaptureAccess() {
-            await status("Waiting for Screen Recording permission…")
-            CGRequestScreenCaptureAccess()
-            Log.info("Screen Recording permission missing — requested, polling for grant")
+            await status("Screen Recording permission needed — see Permissions below")
+            Log.info("Screen Recording permission missing — waiting for grant via the permission panel")
             while !CGPreflightScreenCaptureAccess() {
                 try await Task.sleep(for: .seconds(2))
                 if stopped { return }
@@ -201,9 +208,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             try await setupExtend(info)
 
             // Touch back-channel (Milestone 3). Needs Accessibility trust;
-            // the prompt fires once and we keep going — touches start working
-            // the moment the user grants it.
-            if !InputInjector.ensureAccessibilityPermission() {
+            // streaming works without it, so don't interrupt with a prompt —
+            // the permission panel's Grant button asks when the user is ready.
+            if !AXIsProcessTrusted() {
                 await status("Extending — grant Accessibility for touch input")
                 // Event posting is trust-checked per-post, so it starts working
                 // the moment the user grants — poll just to log/report it.
@@ -397,8 +404,31 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     // MARK: - Connection (with retry)
 
+    // Guards against a stale async USB dial adopting after a newer one (or a
+    // manual reconnect) superseded it. Only touched on `queue`.
+    private var dialGeneration = 0
+
     private func connect() {
         guard !stopped else { return }
+        switch transport {
+        case .tcp(let endpoint): connectTCP(endpoint)
+        case .usb(let udid, let port): connectUSB(udid: udid, port: port)
+        }
+    }
+
+    /// Bookkeeping shared by both transports once a connection is live.
+    private func becomeReady(_ conn: NWConnection) {
+        Log.info("connection ready to \(endpointName)")
+        connectionReady = true
+        everConnected = true
+        disconnectedSince = nil
+        needsKeyframe = true   // new peer needs SPS/PPS + IDR
+        lastReceived = Date()  // fresh grace period for the watchdog
+        receiveControl(on: conn)
+        Task { await self.status("Connected to \(self.endpointName)") }
+    }
+
+    private func connectTCP(_ endpoint: NWEndpoint) {
         let options = NWProtocolTCP.Options()
         options.noDelay = true   // latency matters more than throughput here
         let params = NWParameters(tls: nil, tcp: options)
@@ -408,22 +438,15 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             guard let self else { return }
             switch state {
             case .ready:
-                Log.info("connection ready to \(self.endpointName)")
-                self.connectionReady = true
-                self.everConnected = true
-                self.disconnectedSince = nil
-                self.needsKeyframe = true   // new peer needs SPS/PPS + IDR
-                self.lastReceived = Date()  // fresh grace period for the watchdog
-                self.receiveControl(on: conn)
-                Task { await self.status("Connected to \(self.endpointName)") }
+                self.becomeReady(conn)
             case .failed(let error):
                 Log.info("connection failed: \(error)")
                 self.connectionReady = false
                 self.scheduleReconnect()
             case .waiting(let error):
                 // On loopback there is no "path change" to wake us up again
-                // (e.g. iproxy not started yet) — treat waiting as failure
-                // and poll by reconnecting.
+                // (e.g. a manual -host tunnel not started yet) — treat
+                // waiting as failure and poll by reconnecting.
                 Log.info("connection waiting: \(error) — will retry")
                 self.connectionReady = false
                 Task { await self.status("Waiting for receiver at \(self.endpointName)…") }
@@ -435,6 +458,57 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             }
         }
         conn.start(queue: queue)
+    }
+
+    /// Dial through macOS's built-in usbmuxd — no external tunnel needed.
+    /// The handshake is async, so adoption is gated on `dialGeneration`.
+    private func connectUSB(udid: String?, port: UInt16) {
+        dialGeneration += 1
+        let generation = dialGeneration
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let conn = try await Usbmux.dial(udid: udid, port: port, queue: queue)
+                queue.async {
+                    guard generation == self.dialGeneration, !self.stopped else {
+                        conn.cancel()
+                        return
+                    }
+                    self.connection = conn
+                    conn.stateUpdateHandler = { [weak self] state in
+                        guard let self else { return }
+                        switch state {
+                        case .failed(let error):
+                            Log.info("usb connection failed: \(error)")
+                            self.connectionReady = false
+                            self.scheduleReconnect()
+                        case .cancelled:
+                            self.connectionReady = false
+                        default:
+                            break
+                        }
+                    }
+                    self.becomeReady(conn)
+                }
+            } catch {
+                // Distinct guidance per failure: cable missing vs app closed.
+                let hint: String
+                switch error as? Usbmux.Failure {
+                case .noDevice:
+                    hint = "Waiting for a USB device — plug in the iPhone or iPad…"
+                case .refused:
+                    hint = "Device found — open the OpenSidecar app on it…"
+                default:
+                    Log.info("usb dial failed: \(error)")
+                    hint = "USB connection failed: \(error.localizedDescription)"
+                }
+                queue.async {
+                    guard generation == self.dialGeneration, !self.stopped else { return }
+                    Task { await self.status(hint) }
+                    self.scheduleReconnect()
+                }
+            }
+        }
     }
 
     private func scheduleReconnect() {
@@ -452,6 +526,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             }
         }
         connectionReady = false
+        dialGeneration += 1   // a USB dial still in flight must not adopt
         connection?.cancel()
         connection = nil
         pendingSends = 0

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -76,17 +76,13 @@ enum MainWindow {
 }
 
 enum ConnectionTarget: Hashable {
-    case usb                          // iproxy tunnel on localhost
+    case usb(udid: String?)           // wired via built-in usbmuxd; nil = first device
     case wifi(NWBrowser.Result)       // discovered via Bonjour
 
-    var label: String {
-        switch self {
-        case .usb:
-            return "USB (wired)"
-        case .wifi(let result):
-            if case .service(let name, _, _, _) = result.endpoint { return "\(name) (WiFi)" }
-            return "WiFi device"
-        }
+    var wifiLabel: String? {
+        guard case .wifi(let result) = self else { return nil }
+        if case .service(let name, _, _, _) = result.endpoint { return "\(name) (WiFi)" }
+        return "WiFi device"
     }
 }
 
@@ -110,8 +106,10 @@ final class SenderController: ObservableObject {
     @Published var mbps = 0.0
     @Published var running = false
     @Published var discovered: [NWBrowser.Result] = []
-    @Published var target: ConnectionTarget = .usb
-    // `-host x.x.x.x` / `-port n` override the USB tunnel endpoint.
+    @Published var usbDevices: [UsbmuxDevice] = []
+    @Published var target: ConnectionTarget = .usb(udid: nil)
+    // `-host x.x.x.x` / `-port n` bypass usbmuxd with a manual TCP endpoint
+    // (debugging escape hatch, e.g. an iproxy or SSH tunnel).
     @Published var host = UserDefaults.standard.string(forKey: "host") ?? "127.0.0.1"
     @Published var port = UserDefaults.standard.string(forKey: "port") ?? "9000"
     // `-mode mirror` / `-mode extend` launch argument also works.
@@ -122,13 +120,45 @@ final class SenderController: ObservableObject {
 
     private var sender: MacSender?
     private var browser: NWBrowser?
+    private var usbWatcher: UsbmuxDeviceWatcher?
 
     init() {
         startBrowsing()
+        usbWatcher = UsbmuxDeviceWatcher { [weak self] devices in
+            guard let self else { return }
+            self.usbDevices = devices
+            // An explicitly selected device that detached has no picker entry
+            // anymore — fall back to the generic wired target.
+            if case .usb(let udid?) = self.target,
+               !devices.contains(where: { $0.udid == udid }) {
+                self.target = .usb(udid: nil)
+            }
+            self.reselectSavedTarget()
+        }
         // Auto-start unless explicitly disabled (`-autostart NO`).
         if UserDefaults.standard.object(forKey: "autostart") == nil
             || UserDefaults.standard.bool(forKey: "autostart") {
             start()
+        }
+    }
+
+    /// Label for the generic "first wired device" picker entry: the device's
+    /// name once one is attached (and resolved), a neutral fallback otherwise.
+    var usbLabel: String {
+        if usbDevices.count == 1, let device = usbDevices.first { return device.label }
+        return "USB (wired)"
+    }
+
+    /// Human-readable name of the current target, for status messages.
+    func targetLabel() -> String {
+        switch target {
+        case .usb(let udid):
+            if let device = usbDevices.first(where: { $0.udid == udid }) ?? usbDevices.first {
+                return device.label
+            }
+            return "USB (wired)"
+        case .wifi:
+            return target.wifiLabel ?? "WiFi device"
         }
     }
 
@@ -146,11 +176,20 @@ final class SenderController: ObservableObject {
     }
 
     /// The connection choice survives relaunches: if the user last used a
-    /// WiFi device, re-select it as soon as discovery finds it again.
+    /// WiFi or a specific wired device, re-select it as soon as discovery
+    /// (Bonjour / usbmuxd) finds it again.
     private func reselectSavedTarget() {
-        guard case .usb = target,
+        guard case .usb(udid: nil) = target,
               let saved = UserDefaults.standard.string(forKey: "lastTarget"),
               saved != "usb" else { return }
+        if saved.hasPrefix("usb:") {
+            let udid = String(saved.dropFirst(4))
+            if usbDevices.contains(where: { $0.udid == udid }), usbDevices.count > 1 {
+                target = .usb(udid: udid)
+                // Same transport either way — no restart needed.
+            }
+            return
+        }
         for result in discovered {
             if case .service(let name, _, _, _) = result.endpoint, name == saved {
                 target = .wifi(result)
@@ -162,8 +201,8 @@ final class SenderController: ObservableObject {
 
     func rememberTarget() {
         switch target {
-        case .usb:
-            UserDefaults.standard.set("usb", forKey: "lastTarget")
+        case .usb(let udid):
+            UserDefaults.standard.set(udid.map { "usb:\($0)" } ?? "usb", forKey: "lastTarget")
         case .wifi(let result):
             if case .service(let name, _, _, _) = result.endpoint {
                 UserDefaults.standard.set(name, forKey: "lastTarget")
@@ -173,19 +212,24 @@ final class SenderController: ObservableObject {
 
     func start() {
         guard !running else { return }
-        let endpoint: NWEndpoint
+        let transport: SenderTransport
         switch target {
-        case .usb:
+        case .usb(let udid):
             guard let portNum = UInt16(port) else { return }
-            endpoint = .hostPort(host: NWEndpoint.Host(host),
-                                 port: NWEndpoint.Port(rawValue: portNum)!)
+            if UserDefaults.standard.object(forKey: "host") != nil {
+                // Manual override: dial a plain TCP endpoint instead of usbmuxd.
+                transport = .tcp(.hostPort(host: NWEndpoint.Host(host),
+                                           port: NWEndpoint.Port(rawValue: portNum)!))
+            } else {
+                transport = .usb(udid: udid, port: portNum)
+            }
         case .wifi(let result):
-            endpoint = result.endpoint
+            transport = .tcp(result.endpoint)
         }
 
         running = true
         status = "Starting…"
-        let sender = MacSender(endpoint: endpoint, name: target.label, mode: mode, quality: quality)
+        let sender = MacSender(transport: transport, name: targetLabel(), mode: mode, quality: quality)
         sender.onStatus = { [weak self] text in
             self?.status = text
             Log.info("status: \(text)")
@@ -255,6 +299,19 @@ final class PermissionMonitor: ObservableObject {
         accessibility = AXIsProcessTrusted()
     }
 
+    /// Fire the system permission dialog on demand. macOS only shows each
+    /// dialog once per reset — after that the call just (re)registers the
+    /// app in System Settings, so the row exists to toggle manually.
+    func requestScreenRecording() {
+        CGRequestScreenCaptureAccess()
+        refresh()
+    }
+
+    func requestAccessibility() {
+        _ = InputInjector.ensureAccessibilityPermission()
+        refresh()
+    }
+
     static func openPrivacyPane(_ anchor: String) {
         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(anchor)") {
             NSWorkspace.shared.open(url)
@@ -314,9 +371,17 @@ struct ContentView: View {
             // Settings
             Form {
                 Picker("Connection", selection: $controller.target) {
-                    Text(ConnectionTarget.usb.label).tag(ConnectionTarget.usb)
+                    // Generic wired entry — dials the first attached device,
+                    // labeled with its name once usbmuxd/lockdown report it.
+                    Text(controller.usbLabel).tag(ConnectionTarget.usb(udid: nil))
+                    // Explicit per-device entries only matter with 2+ devices.
+                    if controller.usbDevices.count > 1 {
+                        ForEach(controller.usbDevices) { device in
+                            Text(device.label).tag(ConnectionTarget.usb(udid: device.udid))
+                        }
+                    }
                     ForEach(controller.discovered, id: \.self) { result in
-                        Text(ConnectionTarget.wifi(result).label)
+                        Text(ConnectionTarget.wifi(result).wifiLabel ?? "WiFi device")
                             .tag(ConnectionTarget.wifi(result))
                     }
                 }
@@ -372,13 +437,15 @@ struct ContentView: View {
                         "Screen Recording",
                         granted: permissions.screenRecording,
                         help: "Required to capture the display.",
-                        anchor: "Privacy_ScreenCapture"
+                        anchor: "Privacy_ScreenCapture",
+                        request: { permissions.requestScreenRecording() }
                     )
                     permissionRow(
                         "Accessibility",
                         granted: permissions.accessibility,
                         help: "Required for touch input from the device.",
-                        anchor: "Privacy_Accessibility"
+                        anchor: "Privacy_Accessibility",
+                        request: { permissions.requestAccessibility() }
                     )
                     // macOS offers no API to query Local Network access, so
                     // infer from discovery results and let the user check.
@@ -423,7 +490,8 @@ struct ContentView: View {
 
     @ViewBuilder
     private func permissionRow(_ title: String, granted: Bool, uncertain: Bool = false,
-                               help: String, anchor: String) -> some View {
+                               help: String, anchor: String,
+                               request: (() -> Void)? = nil) -> some View {
         HStack(alignment: .firstTextBaseline) {
             Image(systemName: uncertain ? "questionmark.circle.fill"
                             : granted ? "checkmark.circle.fill" : "xmark.circle.fill")
@@ -438,6 +506,11 @@ struct ContentView: View {
             }
             Spacer()
             if uncertain || !granted {
+                if let request {
+                    Button("Grant…") { request() }
+                        .controlSize(.small)
+                        .help("Ask macOS for this permission. If the system dialog was already dismissed once, this registers the app under \(title) in System Settings — flip the toggle there.")
+                }
                 Button("Open Settings") {
                     PermissionMonitor.openPrivacyPane(anchor)
                 }

--- a/Mac/Usbmux.swift
+++ b/Mac/Usbmux.swift
@@ -1,0 +1,282 @@
+// Usbmux — native client for the usbmuxd daemon that ships on every macOS
+// install (Finder sync, Xcode, and Sidecar all ride on it). It multiplexes
+// TCP connections over the USB cable to iOS devices and speaks a plist
+// protocol on a Unix socket:
+//
+//   [UInt32 LE total length][UInt32 LE version=1][UInt32 LE type=8 (plist)]
+//   [UInt32 LE tag][XML plist payload]
+//
+// Three requests matter here: ListDevices, Listen (subscribe to attach/
+// detach events), and Connect(DeviceID, PortNumber) — after an OK result the
+// same socket becomes a transparent byte pipe to that TCP port on the
+// device. That pipe is exactly what `iproxy` (libimobiledevice) provides as
+// an external tool; speaking the protocol directly drops that dependency.
+
+import Foundation
+import Network
+
+struct UsbmuxDevice: Hashable, Identifiable {
+    let deviceID: Int     // usbmuxd's handle — changes on every replug
+    let udid: String      // stable hardware identifier
+    var name: String?     // lockdown DeviceName ("Philip's iPhone"), best-effort
+
+    var id: String { udid }
+    var label: String { "\(name ?? "iPhone / iPad") (USB)" }
+}
+
+enum Usbmux {
+    static let socketPath = "/var/run/usbmuxd"
+    // lockdownd, the device-side service that answers GetValue queries.
+    static let lockdownPort: UInt16 = 62078
+
+    enum Failure: Error, LocalizedError {
+        case noDevice          // nothing attached (or the chosen udid is gone)
+        case refused           // device present, nothing listening on the port
+        case result(Int)       // other usbmuxd result code
+        case protocolError(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .noDevice: return "no USB device attached"
+            case .refused: return "the device is not listening on the port"
+            case .result(let code): return "usbmuxd result \(code)"
+            case .protocolError(let detail): return "usbmuxd protocol error: \(detail)"
+            }
+        }
+    }
+
+    // MARK: - Requests
+
+    static func listDevices(queue: DispatchQueue) async throws -> [UsbmuxDevice] {
+        let conn = try await open(queue: queue)
+        defer { conn.cancel() }
+        try await send(["MessageType": "ListDevices"], on: conn)
+        let reply = try await readMessage(on: conn)
+        let entries = reply["DeviceList"] as? [[String: Any]] ?? []
+        return entries.compactMap {
+            device(fromProperties: $0["Properties"] as? [String: Any] ?? [:])
+        }
+    }
+
+    /// Open a TCP connection to `port` on the device. On success the returned
+    /// connection is a transparent pipe — usbmuxd is out of the picture.
+    static func connect(deviceID: Int, port: UInt16,
+                        queue: DispatchQueue) async throws -> NWConnection {
+        let conn = try await open(queue: queue)
+        do {
+            try await send([
+                "MessageType": "Connect",
+                "DeviceID": deviceID,
+                // usbmuxd expects the port in network byte order.
+                "PortNumber": Int((port << 8) | (port >> 8)),
+            ], on: conn)
+            let reply = try await readMessage(on: conn)
+            guard reply["MessageType"] as? String == "Result" else {
+                throw Failure.protocolError("unexpected reply to Connect")
+            }
+            switch reply["Number"] as? Int ?? -1 {
+            case 0: break
+            case 2: throw Failure.noDevice    // BadDevice — unplugged mid-dial
+            case 3: throw Failure.refused     // nothing listening on the port
+            case let code: throw Failure.result(code)
+            }
+            conn.stateUpdateHandler = nil   // the adopter installs its own
+            return conn
+        } catch {
+            conn.cancel()
+            throw error
+        }
+    }
+
+    /// Resolve a device (specific udid, or the first wired one) and connect
+    /// to `port` on it. One-shot — callers own the retry loop.
+    static func dial(udid: String?, port: UInt16,
+                     queue: DispatchQueue) async throws -> NWConnection {
+        let devices = try await listDevices(queue: queue)
+        let device = udid.map { u in devices.first { $0.udid == u } } ?? devices.first
+        guard let device else { throw Failure.noDevice }
+        return try await connect(deviceID: device.deviceID, port: port, queue: queue)
+    }
+
+    /// Best-effort friendly name ("Philip's iPhone") from lockdownd, which
+    /// answers DeviceName without a pairing session. Note lockdown framing
+    /// differs from usbmuxd framing: [UInt32 BE length][XML plist].
+    static func deviceName(deviceID: Int, queue: DispatchQueue) async throws -> String {
+        let conn = try await connect(deviceID: deviceID, port: lockdownPort, queue: queue)
+        defer { conn.cancel() }
+        let request = try PropertyListSerialization.data(fromPropertyList: [
+            "Request": "GetValue", "Key": "DeviceName", "Label": "OpenSidecar",
+        ] as [String: Any], format: .xml, options: 0)
+        var packet = withUnsafeBytes(of: UInt32(request.count).bigEndian) { Data($0) }
+        packet.append(request)
+        try await send(raw: packet, on: conn)
+        let header = try await receive(exactly: 4, on: conn)
+        let length = Int(UInt32(bigEndian: header.withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }))
+        guard length > 0, length < 1 << 16 else {
+            throw Failure.protocolError("bad lockdown reply length \(length)")
+        }
+        let body = try await receive(exactly: length, on: conn)
+        guard let plist = try? PropertyListSerialization.propertyList(from: body, format: nil)
+                as? [String: Any],
+              let name = plist["Value"] as? String, !name.isEmpty else {
+            throw Failure.protocolError("lockdown GetValue(DeviceName) not answered")
+        }
+        return name
+    }
+
+    static func device(fromProperties props: [String: Any]) -> UsbmuxDevice? {
+        // usbmuxd also lists WiFi-paired devices (ConnectionType "Network");
+        // those are served by the app's Bonjour path — wired only here.
+        guard props["ConnectionType"] as? String == "USB",
+              let deviceID = props["DeviceID"] as? Int,
+              let udid = props["SerialNumber"] as? String else { return nil }
+        return UsbmuxDevice(deviceID: deviceID, udid: udid, name: nil)
+    }
+
+    // MARK: - Socket plumbing
+
+    static func open(queue: DispatchQueue) async throws -> NWConnection {
+        let conn = NWConnection(to: .unix(path: socketPath), using: .tcp)
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            var resumed = false   // the handler fires on `queue` (serial)
+            conn.stateUpdateHandler = { state in
+                guard !resumed else { return }
+                switch state {
+                case .ready:
+                    resumed = true
+                    cont.resume()
+                case .failed(let error), .waiting(let error):
+                    // No path updates on a Unix socket — .waiting would hang
+                    // forever, so treat it as failure and let callers retry.
+                    resumed = true
+                    conn.cancel()
+                    cont.resume(throwing: error)
+                default:
+                    break
+                }
+            }
+            conn.start(queue: queue)
+        }
+        conn.stateUpdateHandler = nil
+        return conn
+    }
+
+    static func send(_ message: [String: Any], on conn: NWConnection) async throws {
+        var message = message
+        message["ProgName"] = "OpenSidecar"
+        message["ClientVersionString"] = "OpenSidecar"
+        let body = try PropertyListSerialization.data(
+            fromPropertyList: message, format: .xml, options: 0)
+        var packet = Data(capacity: 16 + body.count)
+        for field in [UInt32(16 + body.count), 1, 8, 1] {   // length, version, plist, tag
+            withUnsafeBytes(of: field.littleEndian) { packet.append(contentsOf: $0) }
+        }
+        packet.append(body)
+        try await send(raw: packet, on: conn)
+    }
+
+    static func readMessage(on conn: NWConnection) async throws -> [String: Any] {
+        let header = try await receive(exactly: 16, on: conn)
+        let total = Int(UInt32(littleEndian: header.withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }))
+        guard total >= 16, total < 1 << 20 else {
+            throw Failure.protocolError("bad message length \(total)")
+        }
+        guard total > 16 else { return [:] }
+        let body = try await receive(exactly: total - 16, on: conn)
+        guard let plist = try? PropertyListSerialization.propertyList(from: body, format: nil)
+                as? [String: Any] else {
+            throw Failure.protocolError("non-dictionary message")
+        }
+        return plist
+    }
+
+    private static func send(raw data: Data, on conn: NWConnection) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            conn.send(content: data, completion: .contentProcessed { error in
+                if let error { cont.resume(throwing: error) } else { cont.resume() }
+            })
+        }
+    }
+
+    private static func receive(exactly count: Int, on conn: NWConnection) async throws -> Data {
+        try await withCheckedThrowingContinuation { cont in
+            conn.receive(minimumIncompleteLength: count, maximumLength: count) { data, _, _, error in
+                if let data, data.count == count {
+                    cont.resume(returning: data)
+                } else {
+                    cont.resume(throwing: error ?? Failure.protocolError("socket closed"))
+                }
+            }
+        }
+    }
+}
+
+/// Long-lived Listen subscription: keeps the wired device list current for
+/// the connection picker (attach/detach events, names resolved best-effort
+/// via lockdown) and re-subscribes if the daemon connection drops.
+@MainActor
+final class UsbmuxDeviceWatcher {
+    private let queue = DispatchQueue(label: "usbmux.watcher")
+    private var devices: [Int: UsbmuxDevice] = [:]
+    private let onChange: ([UsbmuxDevice]) -> Void
+
+    init(onChange: @escaping ([UsbmuxDevice]) -> Void) {
+        self.onChange = onChange
+        Task { await listenLoop() }
+    }
+
+    private func listenLoop() async {
+        while true {
+            do {
+                let conn = try await Usbmux.open(queue: queue)
+                defer { conn.cancel() }
+                try await Usbmux.send(["MessageType": "Listen"], on: conn)
+                while true {
+                    // First reply is the Result for Listen itself; it has no
+                    // Properties so handle() ignores it.
+                    handle(try await Usbmux.readMessage(on: conn))
+                }
+            } catch {
+                Log.info("usbmux watcher: \(error) — retrying in 3s")
+                if !devices.isEmpty {
+                    devices = [:]
+                    publish()
+                }
+                try? await Task.sleep(for: .seconds(3))
+            }
+        }
+    }
+
+    private func handle(_ message: [String: Any]) {
+        guard let deviceID = message["DeviceID"] as? Int else { return }
+        switch message["MessageType"] as? String {
+        case "Attached":
+            guard let device = Usbmux.device(
+                fromProperties: message["Properties"] as? [String: Any] ?? [:]) else { return }
+            Log.info("usbmux attached: \(device.udid)")
+            devices[deviceID] = device
+            publish()
+            resolveName(deviceID: deviceID)
+        case "Detached":
+            if let device = devices.removeValue(forKey: deviceID) {
+                Log.info("usbmux detached: \(device.udid)")
+                publish()
+            }
+        default:
+            break
+        }
+    }
+
+    private func resolveName(deviceID: Int) {
+        Task {
+            guard let name = try? await Usbmux.deviceName(deviceID: deviceID, queue: queue),
+                  devices[deviceID] != nil else { return }
+            devices[deviceID]?.name = name
+            publish()
+        }
+    }
+
+    private func publish() {
+        onChange(devices.values.sorted { $0.udid < $1.udid })
+    }
+}

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ pipeline, USB transport, input injection) are already working.
   monitor (drag windows to it, arrange it in System Settings), not a mirror.
   Mirroring is also available as a mode.
 - 🔌 **USB-wired for lowest latency** — streams over the Lightning/USB-C
-  cable via `usbmux`; no network required, no WiFi jitter.
+  cable via macOS's built-in `usbmuxd`; plug in and go, no network, no
+  WiFi jitter, no helper tools.
 - 📶 **WiFi with zero config** — the iPhone advertises itself via Bonjour;
   pick it from a dropdown on the Mac.
 - 🔍 **Retina / HiDPI** — the virtual display matches the device panel
@@ -69,7 +70,8 @@ CGVirtualDisplay  ← macOS believes a monitor is attached
 ```
 
 The **phone listens and the Mac connects** — that ordering is what makes the
-exact same code work over USB (via `usbmux`/`iproxy`) and WiFi. The phone
+exact same code work over USB (via the `usbmuxd` daemon built into every
+macOS install) and WiFi. The phone
 announces its native panel size; the Mac creates a `CGVirtualDisplay` at
 exactly half that in points (@2x HiDPI) and streams the pixels back.
 
@@ -113,7 +115,7 @@ account ($99/yr) removes that limit.
 ### Prerequisites
 
 ```sh
-brew install xcodegen libimobiledevice   # project generation + USB tunnel
+brew install xcodegen   # project generation
 ```
 
 Xcode 15+ and a free or paid Apple developer account (to sideload the iOS
@@ -140,8 +142,9 @@ under Membership, or just pick your team in Xcode's Signing pane.)
 ### Run (USB — recommended)
 
 1. Install + open **OpenSidecar** on the iPhone (it listens on port 9000).
-2. On the Mac, run `./run.sh` — starts the `iproxy` USB tunnel and the Mac
-   app, which auto-connects.
+2. On the Mac, run `./run.sh` (or just open the app) — it talks to macOS's
+   built-in `usbmuxd` directly and auto-connects over the cable. No tunnel
+   tools needed.
 3. Grant **Screen Recording** (for capture) and **Accessibility** (for touch)
    when macOS asks — one time each.
 4. Drag a window onto your new display. Done.
@@ -221,7 +224,6 @@ The capture/streaming pipeline itself uses only public APIs.
 Tracked as [roadmap issues](https://github.com/peetzweg/opensidecar/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap) — pick one up if you'd like to contribute!
 
 **Connectivity & distribution**
-- [#3](https://github.com/peetzweg/opensidecar/issues/3) Built-in USB connectivity — plug in and go, no helper tools
 - [#16](https://github.com/peetzweg/opensidecar/issues/16) Encrypted WiFi transport with pairing code
 - [ ] App Store release of the iOS app + notarized Mac downloads
 
@@ -246,7 +248,7 @@ Tracked as [roadmap issues](https://github.com/peetzweg/opensidecar/issues?q=is%
 - [#14](https://github.com/peetzweg/opensidecar/issues/14) Remote access beyond the local network
 - [#15](https://github.com/peetzweg/opensidecar/issues/15) Additional client platforms
 
-Done: prebuilt releases, WiFi via Bonjour, portrait mode, touch + two-finger scroll, performance overlay, iPad support.
+Done: prebuilt releases, built-in USB connectivity (no helper tools), WiFi via Bonjour, portrait mode, touch + two-finger scroll, performance overlay, iPad support.
 
 ## Contributing
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -143,7 +143,7 @@
       Two small apps, built from source with standard Apple tooling: a Mac app
       (captures &amp; sends) and an iOS app (receives &amp; displays).
     </p>
-    <pre><code>brew install xcodegen libimobiledevice
+    <pre><code>brew install xcodegen
 git clone https://github.com/peetzweg/opensidecar.git
 cd opensidecar &amp;&amp; xcodegen generate
 # build &amp; run both targets from Xcode, then:

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -161,7 +161,9 @@ struct PerfOverlay: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            HStack(spacing: 14) {
+            // Metrics wrap onto extra rows when the width doesn't fit —
+            // portrait iPhone is ~390pt, far less than one full row.
+            FlowLayout(hSpacing: 14, vSpacing: 8) {
                 // Transport badge — the question "is this cable or WiFi?"
                 Text(stats.transport)
                     .font(.system(size: 12, weight: .bold, design: .monospaced))
@@ -207,18 +209,27 @@ struct PerfOverlay: View {
                 }
                 metric("res", "\(Int(videoSize.width))×\(Int(videoSize.height))")
             }
-            HStack(spacing: 14) {
-                graph("latency ms (cap→display)",
-                      BarGraph(samples: stats.e2eSamples, ceiling: 80,
-                               good: 25, warn: 40, reference: nil))
-                graph("frame interval ms",
-                      BarGraph(samples: stats.samples, ceiling: 60,
-                               good: 25, warn: 50, reference: 16.7))
+            // Two graphs side by side where they fit (landscape), stacked
+            // where they don't (portrait).
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 14) { graphs }
+                VStack(spacing: 8) { graphs }
             }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 9)
         .background(.black.opacity(0.55), in: RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 8)
+    }
+
+    @ViewBuilder
+    private var graphs: some View {
+        graph("latency ms (cap→display)",
+              BarGraph(samples: stats.e2eSamples, ceiling: 80,
+                       good: 25, warn: 40, reference: nil))
+        graph("frame interval ms",
+              BarGraph(samples: stats.samples, ceiling: 60,
+                       good: 25, warn: 50, reference: 16.7))
     }
 
     private func metric(_ label: String, _ value: String) -> some View {
@@ -238,6 +249,50 @@ struct PerfOverlay: View {
             Text(label)
                 .font(.system(size: 8, design: .monospaced))
                 .foregroundStyle(.white.opacity(0.5))
+        }
+    }
+}
+
+/// Left-aligned wrapping row: children flow onto as many rows as the
+/// proposed width requires. Keeps the perf overlay inside the screen in
+/// portrait instead of clipping off both edges.
+struct FlowLayout: Layout {
+    var hSpacing: CGFloat = 14
+    var vSpacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews,
+                      cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var x: CGFloat = 0, y: CGFloat = 0
+        var rowHeight: CGFloat = 0, width: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > 0, x + size.width > maxWidth {
+                x = 0
+                y += rowHeight + vSpacing
+                rowHeight = 0
+            }
+            x += size.width + hSpacing
+            rowHeight = max(rowHeight, size.height)
+            width = max(width, x - hSpacing)
+        }
+        return CGSize(width: width, height: y + rowHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize,
+                       subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX, y = bounds.minY
+        var rowHeight: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > bounds.minX, x + size.width > bounds.maxX {
+                x = bounds.minX
+                y += rowHeight + vSpacing
+                rowHeight = 0
+            }
+            subview.place(at: CGPoint(x: x, y: y), proposal: .unspecified)
+            x += size.width + hSpacing
+            rowHeight = max(rowHeight, size.height)
         }
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -19,6 +19,7 @@ targets:
       path: Mac/Info.plist
       properties:
         NSPrincipalClass: NSApplication
+        CFBundleDisplayName: $(BUNDLE_DISPLAY_NAME)
         LSUIElement: true
         NSLocalNetworkUsageDescription: OpenSidecar connects to your iPad or iPhone over the local network in WiFi mode.
         NSBonjourServices: ["_opensidecar._tcp"]
@@ -27,9 +28,20 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: sh.peet.opensidecar.mac
         PRODUCT_NAME: OpenSidecar
+        BUNDLE_DISPLAY_NAME: OpenSidecar
         SWIFT_OBJC_BRIDGING_HEADER: Mac/OpenSidecarMac-Bridging-Header.h
         ENABLE_HARDENED_RUNTIME: NO
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+      configs:
+        # Local dev builds get their own identity: TCC keys permission
+        # grants by bundle ID + code signature, so a Debug build sharing
+        # the release bundle ID knocks out the release app's Screen
+        # Recording/Accessibility grants every time the binary changes.
+        # The distinct display name keeps the two telling apart in the
+        # System Settings permission lists.
+        Debug:
+          PRODUCT_BUNDLE_IDENTIFIER: sh.peet.opensidecar.mac.debug
+          BUNDLE_DISPLAY_NAME: OpenSidecar Dev
   OpenSidecariOS:
     type: application
     platform: iOS

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,7 @@
 #!/bin/zsh
-# Start the USB tunnel and the Mac sender app. The phone app must be running
-# (it listens on :9000); the Mac app retries until the tunnel is up.
+# Start the Mac sender app. The phone app must be running (it listens on
+# :9000); USB connectivity goes through macOS's built-in usbmuxd — no tunnel
+# tool needed. The Mac app retries until the device shows up.
 set -e
 cd "$(dirname "$0")"
 
@@ -10,13 +11,5 @@ if [[ ! -d $APP ]]; then
   exit 1
 fi
 
-if ! pgrep -fq "iproxy 9000"; then
-  echo "starting iproxy 9000 9000…"
-  iproxy 9000 9000 &
-  IPROXY_PID=$!
-  trap "kill $IPROXY_PID 2>/dev/null" EXIT
-fi
-
 open "$APP"
-echo "OpenSidecar running — logs at /tmp/opensidecar-mac.log. Ctrl-C to stop the tunnel."
-wait
+echo "OpenSidecar running — logs at /tmp/opensidecar-mac.log."


### PR DESCRIPTION
Closes #3.

## What

Replaces the external `iproxy`/libimobiledevice dependency with a native client for `usbmuxd`, the daemon built into every macOS install. A fresh Mac can now download the app, plug in an iPhone/iPad, open both apps, and stream — no Homebrew, no terminal, no tunnel.

## How

`Mac/Usbmux.swift` (new) speaks the usbmux plist protocol over `/var/run/usbmuxd`:
- `ListDevices` + a `Listen` subscription drive the connection picker (attach/detach live).
- `Connect(DeviceID, 9000)` turns the daemon socket into a transparent TCP pipe to the device — exactly what `iproxy` did, in-process.
- Device names resolved best-effort via lockdownd, so the picker reads "Philip's iPhone (USB)".

`MacSender` now takes a `SenderTransport` — `.tcp` for WiFi/Bonjour (unchanged) or `.usb` for the native dial. All existing retry / watchdog / grace-period / disconnect logic is untouched. A generation counter guards against a stale async dial adopting after a newer one. `-host`/`-port` remains as a manual TCP escape hatch.

## Also in this PR (surfaced while testing on a real device)

- **`build:` dev-build identity** — Debug builds use `sh.peet.opensidecar.mac.debug` / display as "OpenSidecar Dev". TCC keys permission grants by bundle id + signature, so a dev build sharing the release id was silently knocking out the downloaded app's Screen Recording / Accessibility grants. Release config (what CI ships) is untouched.
- **In-app permission requests** — no more jumpscare system dialog at launch; the permission panel has explicit "Grant…" buttons so the request has context.
- **`fix:` portrait perf overlay** — metrics now wrap (FlowLayout) and graphs stack (ViewThatFits) instead of clipping off both edges on a portrait iPhone.

## Acceptance (issue #3)

- [x] Fresh Mac, no dev tools: native usbmux dial connects (verified live — `connection ready to USB (wired)`, device enumerated and named, `Connect :9000 → OK`)
- [x] Device picker shows wired devices by name alongside WiFi
- [x] `run.sh` / README no longer mention iproxy

## Verification

- Native usbmux path smoke-tested against the live daemon **with a device attached**: ListDevices → 1, lockdown DeviceName → "Philip's iPhone", Connect :9000 → OK.
- Mac + iOS Debug targets build clean.
- ⚠️ **Not yet visually confirmed:** full end-to-end streaming (was gated on a macOS-26 Screen Recording TCC quirk — running from `/Applications` resolves it) and the portrait overlay layout on-device. Both are code-complete; worth a final eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)