### PR TITLE
fix: cursor disappears after a reconnect

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -423,6 +423,13 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         everConnected = true
         disconnectedSince = nil
         needsKeyframe = true   // new peer needs SPS/PPS + IDR
+        // A reconnect can recreate the phone's video view with no cursor
+        // sprite; the sprite is otherwise only sent on shape change, so the
+        // cursor would stay invisible until the user hovers something that
+        // changes it. Reset the dedup state to re-send sprite + position to
+        // the fresh peer — the cursor analogue of forcing a keyframe.
+        lastCursorPNGHash = 0
+        lastCursorSent = (-1, -1, false)
         lastReceived = Date()  // fresh grace period for the watchdog
         receiveControl(on: conn)
         Task { await self.status("Connected to \(self.endpointName)") }


### PR DESCRIPTION
## Symptom

After streaming starts, the on-device cursor sometimes vanishes and only reappears once you hover something that changes the cursor shape (e.g. a text field → I-beam).

## Cause

The local cursor echo sends the cursor sprite (`cursorImg`) only when its bitmap hash changes (`MacSender.pollCursorImage`), and the phone keeps the cursor hidden while it has no sprite (`cursorLayer.isHidden = … || cursorLayer.contents == nil`). Any reconnect that recreates the phone's video view drops the sprite — but the Mac, seeing an unchanged hash, never resends it. So the cursor stays invisible until the shape next changes.

Latent bug; surfaced more often after #21 because the USB connect/redial path makes early reconnects more likely.

## Fix

Reset the cursor dedup state (`lastCursorPNGHash`, `lastCursorSent`) in `becomeReady`, so a freshly connected peer is re-sent both the sprite and the current position. This is the cursor analogue of `needsKeyframe = true`, which `becomeReady` already sets for video — same idea (a new peer needs the full state, not just deltas), applied to the cursor channel. Works for both transports since `becomeReady` is shared.

## Verification

- Mac Debug builds clean.
- Reproduced and confirmed fixed live: a startup reconnect (two `connection ready` lines) now keeps the cursor visible where it previously blanked it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)