### PR TITLE
feat: editable device name for the WiFi picker

### DIFF
--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -337,6 +337,7 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @AppStorage("showAnalytics") private var showAnalytics = false
     @AppStorage("metalRenderer") private var metalRenderer = false
+    @AppStorage("deviceName") private var deviceName = UIDevice.current.name
 
     private var version: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "dev"
@@ -353,6 +354,19 @@ struct SettingsView: View {
                         LabeledContent("Stream",
                                        value: "\(Int(receiver.videoSize.width))×\(Int(receiver.videoSize.height)) @ \(receiver.fps) fps")
                     }
+                }
+
+                Section {
+                    TextField("Device name", text: $deviceName)
+                        .textInputAutocapitalization(.words)
+                        .autocorrectionDisabled()
+                        .onChange(of: deviceName) { _, name in
+                            receiver.setServiceName(name)
+                        }
+                } header: {
+                    Text("Name")
+                } footer: {
+                    Text("Shown in the Mac app's WiFi connection menu. iOS hides this \(deviceKind)'s real name from apps, so set it here once.")
                 }
 
                 Section {
@@ -425,7 +439,8 @@ final class ReceiverModel: ObservableObject {
         receiver.setNativePanel(long: Int(max(native.width, native.height)),
                                 short: Int(min(native.width, native.height)),
                                 scale: Double(UIScreen.main.nativeScale))
-        receiver.serviceName = UIDevice.current.name
+        let savedName = UserDefaults.standard.string(forKey: "deviceName")
+        receiver.serviceName = (savedName?.isEmpty == false) ? savedName! : UIDevice.current.name
         receiver.objectWillChange
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.objectWillChange.send() }

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -337,7 +337,6 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @AppStorage("showAnalytics") private var showAnalytics = false
     @AppStorage("metalRenderer") private var metalRenderer = false
-    @AppStorage("deviceName") private var deviceName = UIDevice.current.name
 
     private var version: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "dev"
@@ -357,12 +356,12 @@ struct SettingsView: View {
                 }
 
                 Section {
-                    TextField("Device name", text: $deviceName)
-                        .textInputAutocapitalization(.words)
-                        .autocorrectionDisabled()
-                        .onChange(of: deviceName) { _, name in
-                            receiver.setServiceName(name)
-                        }
+                    // Isolated from the receiver: the Status section above
+                    // re-renders on every stream update, and a TextField that
+                    // rebuilds mid-tap loses focus (the "tap twice to edit"
+                    // bug). This subview owns its focus and doesn't observe
+                    // the receiver, so it survives those rebuilds.
+                    DeviceNameField { receiver.setServiceName($0) }
                 } header: {
                     Text("Name")
                 } footer: {
@@ -421,6 +420,22 @@ struct SettingsView: View {
                 }
             }
         }
+    }
+}
+
+/// The device-name editor, deliberately kept out of any high-frequency
+/// @ObservedObject so streaming updates can't rebuild it and steal focus.
+private struct DeviceNameField: View {
+    @AppStorage("deviceName") private var deviceName = UIDevice.current.name
+    @FocusState private var focused: Bool
+    let onChange: (String) -> Void
+
+    var body: some View {
+        TextField("Device name", text: $deviceName)
+            .textInputAutocapitalization(.words)
+            .autocorrectionDisabled()
+            .focused($focused)
+            .onChange(of: deviceName) { _, name in onChange(name) }
     }
 }
 

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -137,7 +137,27 @@ final class PhoneReceiver: ObservableObject {
     private(set) var devicePixelsWide = 0
     private(set) var devicePixelsHigh = 0
     var deviceScale: Double = 2
+    // Name advertised over Bonjour for the Mac's WiFi picker. iOS 16+ returns
+    // a generic "iPhone" from UIDevice.current.name (the user-assigned name
+    // needs an entitlement Apple gates behind approval and personal teams
+    // can't get), so this is user-editable in Settings. The USB picker gets
+    // the real name host-side via lockdownd regardless.
     var serviceName = "OpenSidecar"
+
+    /// Update the advertised name and re-publish if already listening.
+    func setServiceName(_ name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolved = trimmed.isEmpty ? UIDevice.current.name : trimmed
+        queue.async {
+            guard resolved != self.serviceName else { return }
+            self.serviceName = resolved
+            if self.listener != nil {
+                self.listener?.service = NWListener.Service(
+                    name: resolved, type: "_opensidecar._tcp")
+                Log.info("re-advertising as \"\(resolved)\"")
+            }
+        }
+    }
 
     func setNativePanel(long: Int, short: Int, scale: Double) {
         nativeLong = long


### PR DESCRIPTION
## Why

The Mac's **USB** picker shows the real device name ("Philip's iPhone") because it reads it host-side via lockdownd (added in #21). The **WiFi** picker shows a generic "iPhone" — and that asymmetry is the issue reported.

The cause is an iOS restriction, not a bug we can simply fix: since iOS 16, `UIDevice.current.name` returns the model name ("iPhone"), not the user-assigned name. Getting the real name requires the `com.apple.developer.device-information.user-assigned-device-name` entitlement, which **Apple gates behind manual approval and personal/free teams cannot obtain at all** (verified — it fails provisioning on this team). So we can't surface the real name automatically over WiFi.

## What

Add a **Device name** field in the iOS Settings screen:
- Defaults to `UIDevice.current.name` (so behavior is unchanged until edited).
- Persisted as `deviceName`; set it once to "Philip's iPhone".
- `PhoneReceiver.setServiceName` re-publishes the Bonjour service live, so the Mac's WiFi menu reflects the new name without a relaunch.

USB continues to show the lockdownd name regardless.

## Verification

- iOS Debug builds clean and is installed on a device.
- ⚠️ Not yet eyeballed by me end-to-end: set a name in Settings → confirm it appears in the Mac's WiFi Connection menu. (PhoneReceiver re-advertises on change; worth a quick manual check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)