### PR TITLE
feat: multiple devices as simultaneous extended displays

### DIFF
--- a/Mac/InputInjector.swift
+++ b/Mac/InputInjector.swift
@@ -8,6 +8,11 @@ final class InputInjector {
 
     private let displayID: CGDirectDisplayID
     private var isDown = false
+    // A real event source (vs nil) plus clickState=1 below: menu tracking
+    // treats sourceless/zero-click synthetic clicks as malformed — menus
+    // open but their tracking session breaks, leaving zombie menu windows
+    // composited on the display (visible in the stream, unclickable).
+    private let source = CGEventSource(stateID: .hidSystemState)
 
     init(displayID: CGDirectDisplayID) {
         self.displayID = displayID
@@ -45,8 +50,9 @@ final class InputInjector {
             return
         }
 
-        guard let event = CGEvent(mouseEventSource: nil, mouseType: type,
+        guard let event = CGEvent(mouseEventSource: source, mouseType: type,
                                   mouseCursorPosition: point, mouseButton: .left) else { return }
+        event.setIntegerValueField(.mouseEventClickState, value: 1)
         event.post(tap: .cghidEventTap)
     }
 
@@ -55,7 +61,7 @@ final class InputInjector {
     func handleScroll(dx: Double, dy: Double) {
         let bounds = CGDisplayBounds(displayID)
         let scale = bounds.width > 0 ? Double(CGDisplayPixelsWide(displayID)) / bounds.width : 2
-        guard let event = CGEvent(scrollWheelEvent2Source: nil, units: .pixel,
+        guard let event = CGEvent(scrollWheelEvent2Source: source, units: .pixel,
                                   wheelCount: 2,
                                   wheel1: Int32((dy / scale).rounded()),
                                   wheel2: Int32((dx / scale).rounded()),

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -253,10 +253,17 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         let displayName = endpointName.hasPrefix("iPhone / iPad")
             ? "OpenSidecar — \(info.kind)"
             : "OpenSidecar — \(endpointName)"
-        let vd = await MainActor.run { [displaySerial] in
+        // Orientation-specific serial: macOS persists the chosen mode per
+        // serial, and a portrait mode restored onto a landscape display
+        // pillarboxes the desktop INTO the framebuffer (streamed as-is).
+        // Distinct serials per orientation keep the two configs apart.
+        let serial = info.pixelsWide >= info.pixelsHigh
+            ? displaySerial
+            : displaySerial ^ 0x8000_0000
+        let vd = await MainActor.run {
             VirtualDisplay(name: displayName,
                            pointsWide: pointsWide, pointsHigh: pointsHigh,
-                           sizeInMillimeters: mm, serialNum: displaySerial)
+                           sizeInMillimeters: mm, serialNum: serial)
         }
         guard let vd else {
             throw NSError(domain: "MacSender", code: 2,

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -149,7 +149,6 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private var lastCursorSent: (x: Double, y: Double, visible: Bool) = (-1, -1, false)
     private var lastCursorPNGHash = 0
     private var captureDisplayID: CGDirectDisplayID = 0
-    private var displayPointsSize = CGSize.zero
 
     // Input latency: touches arrive stamped in our clock (the phone applies
     // its sync offset); delta to now = network + deframe + dispatch.
@@ -361,7 +360,6 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         try await stream.startCapture()
         self.stream = stream
         captureDisplayID = display.displayID
-        displayPointsSize = CGSize(width: display.width, height: display.height)
         lastCursorPNGHash = 0      // rotation rebuilds: re-send the sprite
         lastCursorSent = (-1, -1, false)
         startCursorEcho()
@@ -648,11 +646,18 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     }
 
     private func pollCursorImage() {
-        guard connectionReady, displayPointsSize != .zero,
+        // Display size read LIVE, not snapshotted at capture start: the
+        // HiDPI mode settles (and macOS re-flips it) asynchronously, and a
+        // sprite normalized against the 1x size renders at half size on the
+        // device. Mixing the size into the dedup hash re-sends the sprite
+        // whenever the mode flips, so the proportion always heals.
+        guard connectionReady, captureDisplayID != 0,
               let cursor = NSCursor.currentSystem else { return }
+        let displaySize = CGDisplayBounds(captureDisplayID).size   // points, current mode
+        guard displaySize.width > 0, displaySize.height > 0 else { return }
         let image = cursor.image
         guard let tiff = image.tiffRepresentation else { return }
-        let hash = tiff.hashValue
+        let hash = tiff.hashValue ^ Int(displaySize.width) &* 31
         guard hash != lastCursorPNGHash else { return }
         guard let rep = NSBitmapImageRep(data: tiff),
               let png = rep.representation(using: .png, properties: [:]),
@@ -664,8 +669,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // sprite without knowing capture scale or HiDPI factor.
         let msg = String(format:
             "{\"type\":\"cursorImg\",\"nw\":%.5f,\"nh\":%.5f,\"ax\":%.3f,\"ay\":%.3f,\"png\":\"%@\"}",
-            size.width / displayPointsSize.width,
-            size.height / displayPointsSize.height,
+            size.width / displaySize.width,
+            size.height / displaySize.height,
             size.width > 0 ? hot.x / size.width : 0,
             size.height > 0 ? hot.y / size.height : 0,
             png.base64EncodedString())

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -68,6 +68,9 @@ struct PhoneInfo: Decodable {
     let pixelsHigh: Int
     let scale: Double
     let device: String?   // "iPad" / "iPhone" (older receivers omit it)
+    let id: String?       // per-install identity (older receivers omit it) —
+                          // lets the controller match the same physical device
+                          // across USB and WiFi
 
     var kind: String { device ?? "device" }
 }
@@ -90,6 +93,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // recording indicator all torn down) instead of dialing forever or
     // silently coming back over a different transport.
     @MainActor var onDisconnected: (() -> Void)?
+    // Fired on every hello — carries the receiver's install id so the
+    // controller can deduplicate USB/WiFi sessions to the same device.
+    @MainActor var onHello: ((PhoneInfo) -> Void)?
 
     private var stream: SCStream?
     private var encoder: VTCompressionSession?
@@ -242,8 +248,13 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             ? CGSize(width: 147, height: 68)
             : CGSize(width: 68, height: 147)
 
-        let vd = await MainActor.run { [endpointName, displaySerial] in
-            VirtualDisplay(name: "OpenSidecar — \(endpointName)",
+        // USB sessions can start before lockdown resolves the device name —
+        // fall back to the kind from the hello rather than the generic label.
+        let displayName = endpointName.hasPrefix("iPhone / iPad")
+            ? "OpenSidecar — \(info.kind)"
+            : "OpenSidecar — \(endpointName)"
+        let vd = await MainActor.run { [displaySerial] in
+            VirtualDisplay(name: displayName,
                            pointsWide: pointsWide, pointsHigh: pointsHigh,
                            sizeInMillimeters: mm, serialNum: displaySerial)
         }
@@ -696,6 +707,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             if let info = try? JSONDecoder().decode(PhoneInfo.self, from: payload) {
                 let previous = lastHello
                 lastHello = info
+                Task { @MainActor in self.onHello?(info) }
                 if let continuation = helloContinuation {
                     helloContinuation = nil
                     continuation.resume(returning: info)

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -102,6 +102,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private let endpointName: String
     private let mode: CaptureMode
     private let quality: StreamQuality
+    // Stable per-device serial for the virtual display, so macOS can tell
+    // multiple OpenSidecar monitors apart and persist their arrangement.
+    private let displaySerial: UInt32
 
     // Backpressure: outstanding sends. If the socket can't keep up we drop
     // frames instead of queueing latency, then force a keyframe to resync.
@@ -161,11 +164,12 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private var lastCaptureAt = Date.distantPast
 
     init(transport: SenderTransport, name: String, mode: CaptureMode,
-         quality: StreamQuality = .best) {
+         quality: StreamQuality = .best, displaySerial: UInt32 = 0x0001) {
         self.transport = transport
         self.endpointName = name
         self.mode = mode
         self.quality = quality
+        self.displaySerial = displaySerial
         super.init()
     }
 
@@ -238,10 +242,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             ? CGSize(width: 147, height: 68)
             : CGSize(width: 68, height: 147)
 
-        let vd = await MainActor.run {
-            VirtualDisplay(name: "OpenSidecar",
+        let vd = await MainActor.run { [endpointName, displaySerial] in
+            VirtualDisplay(name: "OpenSidecar — \(endpointName)",
                            pointsWide: pointsWide, pointsHigh: pointsHigh,
-                           sizeInMillimeters: mm)
+                           sizeInMillimeters: mm, serialNum: displaySerial)
         }
         guard let vd else {
             throw NSError(domain: "MacSender", code: 2,

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -79,12 +79,6 @@ enum ConnectionTarget: Hashable {
     case usb(udid: String?)           // wired via built-in usbmuxd; nil = first device
     case wifi(NWBrowser.Result)       // discovered via Bonjour
 
-    var wifiLabel: String? {
-        guard case .wifi(let result) = self else { return nil }
-        if case .service(let name, _, _, _) = result.endpoint { return "\(name) (WiFi)" }
-        return "WiFi device"
-    }
-
     /// Stable identity for sessions and persistence — survives Bonjour
     /// re-discovery (fresh NWBrowser.Result) and USB replugs (new DeviceID).
     var sessionID: String {
@@ -111,9 +105,14 @@ final class DeviceSession: ObservableObject, Identifiable {
     @Published var status = "Starting…"
     @Published var framesSent = 0
     @Published var mbps = 0.0
-    // Receiver's per-install identity (from hello) — the key for matching
+    // Receiver's per-install identity (from hello) — the key for recognizing
     // the same physical device across USB and WiFi.
     var deviceID: String?
+
+    var transportLabel: String {
+        if case .usb = target { return "USB" }
+        return "WiFi"
+    }
 
     init(id: String, target: ConnectionTarget, name: String, sender: MacSender) {
         self.id = id
@@ -156,11 +155,18 @@ final class SenderController: ObservableObject {
     private var browser: NWBrowser?
     private var usbWatcher: UsbmuxDeviceWatcher?
 
-    // Auto-connect policy, persisted:
+    // Connection policy — deliberately simple, no automatic transport
+    // switching. One session per physical device; whichever transport
+    // connected first keeps the device until the session ends. Unplugging
+    // the cable ENDS the session (it does not migrate to WiFi), and a WiFi
+    // drop does not migrate to the cable: silent transport handover
+    // surprised users more than it helped (and every virtual-display
+    // create/destroy flashes all screens).
+    //
     //  - USB devices connect on attach ("plug in and go") unless the user
     //    explicitly disconnected them once (usbDisabled).
-    //  - WiFi devices connect only after the user connected them once
-    //    (wifiRemembered) — never auto-grab a stranger's device.
+    //  - WiFi devices the user connected before (wifiRemembered) reconnect
+    //    in a short window at LAUNCH only — never mid-session.
     // `-autostart NO` disables all auto-connecting.
     private var usbDisabled = Set(UserDefaults.standard.stringArray(forKey: "usbDisabled") ?? []) {
         didSet { UserDefaults.standard.set(Array(usbDisabled), forKey: "usbDisabled") }
@@ -168,13 +174,24 @@ final class SenderController: ObservableObject {
     private var wifiRemembered = Set(UserDefaults.standard.stringArray(forKey: "wifiRemembered") ?? []) {
         didSet { UserDefaults.standard.set(Array(wifiRemembered), forKey: "wifiRemembered") }
     }
+    // Install id learned from each USB device's hello, persisted, so the
+    // same hardware is recognized across transports even when the user
+    // renamed the advertised service. @Published so the device list regroups
+    // the moment an identity is learned.
+    @Published private var installIDByUDID: [String: String] =
+        UserDefaults.standard.dictionary(forKey: "installIDByUDID") as? [String: String] ?? [:] {
+        didSet { UserDefaults.standard.set(installIDByUDID, forKey: "installIDByUDID") }
+    }
     private let autoConnectEnabled = UserDefaults.standard.object(forKey: "autostart") == nil
         || UserDefaults.standard.bool(forKey: "autostart")
 
-    // Bonjour usually reports devices before usbmuxd does — hold WiFi
-    // auto-connects briefly at launch so a cabled device is dialed over
-    // USB first instead of connecting via WiFi and migrating a second later.
+    // Bonjour usually reports devices before usbmuxd does — WiFi reconnects
+    // wait out this window so a cabled device is dialed over USB first. The
+    // deadline closes the window for good: a remembered WiFi device that
+    // appears later was brought near the Mac mid-session, which is a user
+    // action to confirm, not auto-grab.
     private var wifiAutoConnectArmed = false
+    private let wifiAutoConnectDeadline = Date().addingTimeInterval(12)
 
     init() {
         startBrowsing()
@@ -204,71 +221,123 @@ final class SenderController: ObservableObject {
         self.browser = browser
     }
 
+    // MARK: - Physical-device identity
+
+    private func serviceName(of result: NWBrowser.Result) -> String? {
+        if case .service(let name, _, _, _) = result.endpoint { return name }
+        return nil
+    }
+
+    private func txtID(of result: NWBrowser.Result) -> String? {
+        if case .bonjour(let txt) = result.metadata { return txt["id"] }
+        return nil
+    }
+
+    /// Same hardware? Strong match: the service's install id equals the id
+    /// this USB device announced in a (past or present) hello. Fallback for
+    /// old receivers: lockdown device name equals the service name.
+    private func sameDevice(_ result: NWBrowser.Result, _ device: UsbmuxDevice) -> Bool {
+        if let id = txtID(of: result), installIDByUDID[device.udid] == id { return true }
+        if let name = serviceName(of: result), let usbName = device.name,
+           usbName == name { return true }
+        return false
+    }
+
+    /// The session (over either transport) already serving this USB device.
+    private func activeSession(coveringUSB device: UsbmuxDevice) -> DeviceSession? {
+        if let direct = session(for: "usb:\(device.udid)") { return direct }
+        return sessions.first { s in
+            guard case .wifi(let result) = s.target else { return false }
+            if let id = installIDByUDID[device.udid],
+               s.deviceID == id || txtID(of: result) == id { return true }
+            return serviceName(of: result) != nil && device.name == serviceName(of: result)
+        }
+    }
+
+    /// The session (over either transport) already serving this WiFi service.
+    private func activeSession(coveringWiFi result: NWBrowser.Result) -> DeviceSession? {
+        if let name = serviceName(of: result), let direct = session(for: "wifi:\(name)") {
+            return direct
+        }
+        return sessions.first { s in
+            guard case .usb(let udid) = s.target else { return false }
+            if let id = txtID(of: result), s.deviceID == id { return true }
+            guard let udid, let device = usbDevices.first(where: { $0.udid == udid })
+            else { return false }
+            return sameDevice(result, device)
+        }
+    }
+
+    // MARK: - Connection policy
+
     private func autoConnect() {
         guard autoConnectEnabled else { return }
+        dedupeSessions()
         // The -host/-port escape hatch is an explicit choice — dial it like
         // the wired devices (it joins them, not replaces them).
         if UserDefaults.standard.object(forKey: "host") != nil,
-           !usbDisabled.contains("usb:first") {
+           !usbDisabled.contains("usb:first"), session(for: "usb:first") == nil {
             connect(to: .usb(udid: nil))
         }
-        for device in usbDevices where !usbDisabled.contains("usb:\(device.udid)") {
+        for device in usbDevices
+            where !usbDisabled.contains("usb:\(device.udid)")
+            && activeSession(coveringUSB: device) == nil {
             connect(to: .usb(udid: device.udid))
         }
-        // The same physical device can be reachable over both transports —
-        // its Bonjour service name equals its lockdown DeviceName. The
-        // receiver accepts ONE connection (new replaces old), so dialing
-        // both makes the transports steal the link from each other forever.
-        // Prefer USB; WiFi auto-connect waits until all wired names are
-        // resolved (lockdown is async) so a cabled device is never grabbed
-        // over WiFi in the launch race.
-        // Reconcile: a WiFi session whose device is now cabled (names resolve
-        // async, so this can be discovered late) hands over to USB.
-        for session in sessions where reachableOverUSB(session.target) {
-            Log.info("\(session.id) is reachable over USB — handing over to the cable")
-            end(session, keepRemembered: true)
-        }
-        guard wifiAutoConnectArmed,
-              !usbDevices.contains(where: { $0.name == nil }) else { return }
+        guard wifiAutoConnectArmed, Date() < wifiAutoConnectDeadline else { return }
         for result in discovered {
             let target = ConnectionTarget.wifi(result)
-            if wifiRemembered.contains(target.sessionID), !reachableOverUSB(target) {
+            if wifiRemembered.contains(target.sessionID),
+               activeSession(coveringWiFi: result) == nil,
+               !cabled(result) {
                 connect(to: target)
             }
         }
     }
 
-    /// True when a WiFi target is the same physical device as one already
-    /// served over the cable. Strong match: install id from the Bonjour TXT
-    /// record vs the id the USB session's hello announced (survives renamed
-    /// services). Fallback for old receivers: lockdown device name equals
-    /// the service name.
-    private func reachableOverUSB(_ target: ConnectionTarget) -> Bool {
-        guard case .wifi(let result) = target,
-              case .service(let name, _, _, _) = result.endpoint else { return false }
-        if case .bonjour(let txt) = result.metadata, let installID = txt["id"],
-           sessions.contains(where: { session in
-               if case .usb = session.target { return session.deviceID == installID }
-               return false
-           }) {
-            return true
-        }
-        return usbDevices.contains {
-            $0.name == name && !usbDisabled.contains("usb:\($0.udid)")
+    /// An attached, auto-connectable USB device is (about to be) dialed over
+    /// the cable — its WiFi service must not be grabbed in the launch race.
+    private func cabled(_ result: NWBrowser.Result) -> Bool {
+        usbDevices.contains {
+            sameDevice(result, $0) && !usbDisabled.contains("usb:\($0.udid)")
         }
     }
 
-    /// Human-readable name for a target, used for the session row, status
-    /// messages, and the virtual display name in System Settings → Displays.
+    /// Safety net, not a feature: if identity was learned too late (old
+    /// receiver, renamed service) and one physical device ended up with two
+    /// sessions, the transports steal the receiver's single connection from
+    /// each other forever. Keep the cable, drop the WiFi twin.
+    private func dedupeSessions() {
+        let usbSessionIDs = Set(sessions.compactMap { s -> String? in
+            if case .usb = s.target { return s.deviceID }
+            return nil
+        })
+        let cabledNames = Set(usbDevices.compactMap { device in
+            session(for: "usb:\(device.udid)") != nil ? device.name : nil
+        })
+        for s in sessions {
+            guard case .wifi(let result) = s.target else { continue }
+            let duplicate = (s.deviceID.map { usbSessionIDs.contains($0) } ?? false)
+                || (txtID(of: result).map { usbSessionIDs.contains($0) } ?? false)
+                || (serviceName(of: result).map { cabledNames.contains($0) } ?? false)
+            if duplicate {
+                Log.info("two sessions for one device — keeping the cable, dropping \(s.id)")
+                end(s)
+            }
+        }
+    }
+
+    /// Human-readable device name for a target (no transport suffix — the
+    /// UI shows transports separately).
     func label(for target: ConnectionTarget) -> String {
         switch target {
         case .usb(let udid):
-            if let device = usbDevices.first(where: { $0.udid == udid }) {
-                return device.label
+            if let device = usbDevices.first(where: { $0.udid == udid }), let name = device.name {
+                return name
             }
-            return udid == nil ? "Manual (\(host):\(port))" : "USB (wired)"
-        case .wifi:
-            return target.wifiLabel ?? "WiFi device"
+            return udid == nil ? "Manual (\(host):\(port))" : "iPhone / iPad"
+        case .wifi(let result):
+            return serviceName(of: result) ?? "WiFi device"
         }
     }
 
@@ -289,18 +358,19 @@ final class SenderController: ObservableObject {
         let id = target.sessionID
         guard session(for: id) == nil else { return }
 
-        // One session per physical device: a WiFi dial to a device that's
-        // already streaming over the cable would steal its connection.
-        if reachableOverUSB(target) { return }
-        // Conversely, plugging in a device that streams over WiFi upgrades
-        // it to USB: drop the WiFi session, the cable takes over.
-        if case .usb(let udid?) = target,
-           let usbName = usbDevices.first(where: { $0.udid == udid })?.name,
-           let wifiSession = sessions.first(where: { $0.id == "wifi:\(usbName)" }) {
-            end(wifiSession, keepRemembered: true)
+        // Never create a second session for the same physical device — the
+        // receiver holds one connection, so a twin would steal it.
+        switch target {
+        case .usb(let udid?):
+            if let device = usbDevices.first(where: { $0.udid == udid }),
+               activeSession(coveringUSB: device) != nil { return }
+        case .wifi(let result):
+            if activeSession(coveringWiFi: result) != nil { return }
+        default:
+            break
         }
 
-        // Reconnecting a device clears its "don't auto-connect" state.
+        // Connecting a device clears its "don't auto-connect" state.
         switch target {
         case .usb: usbDisabled.remove(id)
         case .wifi: wifiRemembered.insert(id)
@@ -330,10 +400,12 @@ final class SenderController: ObservableObject {
             Log.info("status[\(id)]: \(text)")
         }
         sender.onHello = { [weak self, weak session] info in
-            session?.deviceID = info.id
-            // A USB session learning its identity may reveal a WiFi
-            // duplicate to hand over — reconcile.
-            self?.autoConnect()
+            guard let self, let session else { return }
+            session.deviceID = info.id
+            if case .usb(let udid?) = session.target, let installID = info.id {
+                self.installIDByUDID[udid] = installID
+            }
+            self.dedupeSessions()
         }
         sender.onStats = { [weak session] frames, mbps in
             session?.framesSent = frames
@@ -341,11 +413,11 @@ final class SenderController: ObservableObject {
         }
         sender.onDisconnected = { [weak self, weak session] in
             // Device unplugged / left the network and stayed gone: end this
-            // session fully (virtual display + capture + indicator). The
-            // device stays remembered, so it reconnects when it reappears.
+            // session fully (virtual display + capture + indicator). No
+            // transport fallback — reconnecting is the user's call.
             guard let self, let session else { return }
             Log.info("device disconnected — session \(session.id) stopped")
-            self.end(session, keepRemembered: true)
+            self.end(session)
         }
         sessions.append(session)
         Task {
@@ -366,19 +438,16 @@ final class SenderController: ObservableObject {
         case .usb: usbDisabled.insert(session.id)
         case .wifi: wifiRemembered.remove(session.id)
         }
-        end(session, keepRemembered: false)
+        end(session)
     }
 
     func disconnectAll() {
         sessions.forEach { disconnect($0) }
     }
 
-    private func end(_ session: DeviceSession, keepRemembered: Bool) {
+    private func end(_ session: DeviceSession) {
         session.sender.stop()
         sessions.removeAll { $0.id == session.id }
-        // A USB session ending may unblock the WiFi fallback for the same
-        // device (and vice versa) — re-run the policy.
-        if keepRemembered { autoConnect() }
     }
 
     /// Mode/quality apply per-pipeline at construction — rebuild every session.
@@ -390,43 +459,72 @@ final class SenderController: ObservableObject {
         targets.forEach { connect(to: $0) }
     }
 
-    // MARK: - Device list entries (available + connected, merged)
+    // MARK: - Device list (one row per physical device)
 
     struct DeviceEntry: Identifiable {
         let id: String
         let name: String
-        let target: ConnectionTarget?   // nil: connected but no longer discoverable
+        let usbTarget: ConnectionTarget?
+        let wifiTarget: ConnectionTarget?
+
+        var transportLabel: String {
+            switch (usbTarget != nil, wifiTarget != nil) {
+            case (true, true): return "USB · WiFi"
+            case (true, false): return "USB"
+            case (false, true): return "WiFi"
+            default: return ""
+            }
+        }
+        /// Lowest latency first.
+        var preferredTarget: ConnectionTarget? { usbTarget ?? wifiTarget }
     }
 
     var deviceEntries: [DeviceEntry] {
         var entries: [DeviceEntry] = []
-        var seen = Set<String>()
+        var mergedServices = Set<String>()
+        var coveredSessionIDs = Set<String>()
+
         for device in usbDevices {
-            let target = ConnectionTarget.usb(udid: device.udid)
-            entries.append(DeviceEntry(id: target.sessionID, name: device.label, target: target))
-            seen.insert(target.sessionID)
+            // A discovered WiFi service for the same hardware folds into
+            // this row instead of appearing as a second device.
+            let twin = discovered.first { sameDevice($0, device) }
+            if let twin, let name = serviceName(of: twin) { mergedServices.insert(name) }
+            let usbTarget = ConnectionTarget.usb(udid: device.udid)
+            coveredSessionIDs.insert(usbTarget.sessionID)
+            if let twin { coveredSessionIDs.insert(ConnectionTarget.wifi(twin).sessionID) }
+            entries.append(DeviceEntry(
+                id: "device:\(device.udid)",
+                name: device.name ?? twin.flatMap(serviceName) ?? "iPhone / iPad",
+                usbTarget: usbTarget,
+                wifiTarget: twin.map { .wifi($0) }))
         }
         if UserDefaults.standard.object(forKey: "host") != nil {
             let target = ConnectionTarget.usb(udid: nil)
-            entries.append(DeviceEntry(id: target.sessionID, name: label(for: target), target: target))
-            seen.insert(target.sessionID)
+            coveredSessionIDs.insert(target.sessionID)
+            entries.append(DeviceEntry(id: target.sessionID, name: label(for: target),
+                                       usbTarget: target, wifiTarget: nil))
         }
         for result in discovered {
+            guard let name = serviceName(of: result), !mergedServices.contains(name)
+            else { continue }
             let target = ConnectionTarget.wifi(result)
-            guard !seen.contains(target.sessionID) else { continue }
-            // Same physical device as an attached USB entry: one row only —
-            // the wired one. The WiFi row reappears as a fallback the moment
-            // the cable is gone.
-            if reachableOverUSB(target) { continue }
-            entries.append(DeviceEntry(id: target.sessionID, name: label(for: target), target: target))
-            seen.insert(target.sessionID)
+            coveredSessionIDs.insert(target.sessionID)
+            entries.append(DeviceEntry(id: "service:\(name)", name: name,
+                                       usbTarget: nil, wifiTarget: target))
         }
         // Sessions whose device vanished from discovery (e.g. Bonjour record
         // gone while the stream is still alive) keep a row to disconnect.
-        for session in sessions where !seen.contains(session.id) {
-            entries.append(DeviceEntry(id: session.id, name: session.name, target: nil))
+        for session in sessions where !coveredSessionIDs.contains(session.id) {
+            entries.append(DeviceEntry(id: session.id, name: session.name,
+                                       usbTarget: nil, wifiTarget: nil))
         }
         return entries
+    }
+
+    func session(for entry: DeviceEntry) -> DeviceSession? {
+        if let target = entry.usbTarget, let s = session(for: target.sessionID) { return s }
+        if let target = entry.wifiTarget, let s = session(for: target.sessionID) { return s }
+        return session(for: entry.id)   // dangling-session rows
     }
 }
 
@@ -507,16 +605,21 @@ struct ContentView: View {
                             .foregroundStyle(.secondary)
                     }
                     ForEach(controller.deviceEntries) { entry in
-                        if let session = controller.session(for: entry.id) {
+                        if let session = controller.session(for: entry) {
                             SessionRow(session: session, controller: controller)
                         } else {
-                            HStack {
+                            HStack(alignment: .firstTextBaseline) {
                                 Circle()
                                     .fill(.secondary.opacity(0.5))
                                     .frame(width: 9, height: 9)
-                                Text(entry.name)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(entry.name)
+                                    Text(entry.transportLabel)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
                                 Spacer()
-                                if let target = entry.target {
+                                if let target = entry.preferredTarget {
                                     Button("Connect") { controller.connect(to: target) }
                                         .controlSize(.small)
                                 }
@@ -675,7 +778,7 @@ struct SessionRow: View {
                 .frame(width: 9, height: 9)
             VStack(alignment: .leading, spacing: 2) {
                 Text(session.name)
-                Text(session.status)
+                Text("\(session.transportLabel) · \(session.status)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(2)

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -108,6 +108,9 @@ final class DeviceSession: ObservableObject, Identifiable {
     // Receiver's per-install identity (from hello) — the key for recognizing
     // the same physical device across USB and WiFi.
     var deviceID: String?
+    // "iPhone" / "iPad" from hello — naming fallback while (or in case)
+    // lockdown hasn't resolved the device's real name.
+    var deviceKind: String?
 
     var transportLabel: String {
         if case .usb = target { return "USB" }
@@ -402,6 +405,7 @@ final class SenderController: ObservableObject {
         sender.onHello = { [weak self, weak session] info in
             guard let self, let session else { return }
             session.deviceID = info.id
+            session.deviceKind = info.device
             if case .usb(let udid?) = session.target, let installID = info.id {
                 self.installIDByUDID[udid] = installID
             }
@@ -494,7 +498,10 @@ final class SenderController: ObservableObject {
             if let twin { coveredSessionIDs.insert(ConnectionTarget.wifi(twin).sessionID) }
             entries.append(DeviceEntry(
                 id: "device:\(device.udid)",
-                name: device.name ?? twin.flatMap(serviceName) ?? "iPhone / iPad",
+                name: device.name
+                    ?? twin.flatMap(serviceName)
+                    ?? session(for: usbTarget.sessionID)?.deviceKind
+                    ?? "iPhone / iPad",
                 usbTarget: usbTarget,
                 wifiTarget: twin.map { .wifi($0) }))
         }
@@ -606,7 +613,11 @@ struct ContentView: View {
                     }
                     ForEach(controller.deviceEntries) { entry in
                         if let session = controller.session(for: entry) {
-                            SessionRow(session: session, controller: controller)
+                            // Title from the entry, not the session: the
+                            // session name was snapshotted at connect time,
+                            // often before lockdown resolved the real name.
+                            SessionRow(title: entry.name, session: session,
+                                       controller: controller)
                         } else {
                             HStack(alignment: .firstTextBaseline) {
                                 Circle()
@@ -757,6 +768,7 @@ struct ContentView: View {
 
 /// One connected device: live status, throughput, reconnect + disconnect.
 struct SessionRow: View {
+    let title: String
     @ObservedObject var session: DeviceSession
     let controller: SenderController
 
@@ -777,7 +789,7 @@ struct SessionRow: View {
                 .fill(statusColor)
                 .frame(width: 9, height: 9)
             VStack(alignment: .leading, spacing: 2) {
-                Text(session.name)
+                Text(title)
                 Text("\(session.transportLabel) · \(session.status)")
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -111,6 +111,9 @@ final class DeviceSession: ObservableObject, Identifiable {
     @Published var status = "Starting…"
     @Published var framesSent = 0
     @Published var mbps = 0.0
+    // Receiver's per-install identity (from hello) — the key for matching
+    // the same physical device across USB and WiFi.
+    var deviceID: String?
 
     init(id: String, target: ConnectionTarget, name: String, sender: MacSender) {
         self.id = id
@@ -168,6 +171,11 @@ final class SenderController: ObservableObject {
     private let autoConnectEnabled = UserDefaults.standard.object(forKey: "autostart") == nil
         || UserDefaults.standard.bool(forKey: "autostart")
 
+    // Bonjour usually reports devices before usbmuxd does — hold WiFi
+    // auto-connects briefly at launch so a cabled device is dialed over
+    // USB first instead of connecting via WiFi and migrating a second later.
+    private var wifiAutoConnectArmed = false
+
     init() {
         startBrowsing()
         usbWatcher = UsbmuxDeviceWatcher { [weak self] devices in
@@ -175,10 +183,16 @@ final class SenderController: ObservableObject {
             self.usbDevices = devices
             self.autoConnect()
         }
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2))
+            self.wifiAutoConnectArmed = true
+            self.autoConnect()
+        }
     }
 
     private func startBrowsing() {
-        let browser = NWBrowser(for: .bonjour(type: "_opensidecar._tcp", domain: nil), using: .tcp)
+        // TXT records carry the receiver's install id (new receivers).
+        let browser = NWBrowser(for: .bonjourWithTXTRecord(type: "_opensidecar._tcp", domain: nil), using: .tcp)
         browser.browseResultsChangedHandler = { [weak self] results, _ in
             DispatchQueue.main.async {
                 guard let self else { return }
@@ -195,11 +209,46 @@ final class SenderController: ObservableObject {
         for device in usbDevices where !usbDisabled.contains("usb:\(device.udid)") {
             connect(to: .usb(udid: device.udid))
         }
+        // The same physical device can be reachable over both transports —
+        // its Bonjour service name equals its lockdown DeviceName. The
+        // receiver accepts ONE connection (new replaces old), so dialing
+        // both makes the transports steal the link from each other forever.
+        // Prefer USB; WiFi auto-connect waits until all wired names are
+        // resolved (lockdown is async) so a cabled device is never grabbed
+        // over WiFi in the launch race.
+        // Reconcile: a WiFi session whose device is now cabled (names resolve
+        // async, so this can be discovered late) hands over to USB.
+        for session in sessions where reachableOverUSB(session.target) {
+            Log.info("\(session.id) is reachable over USB — handing over to the cable")
+            end(session, keepRemembered: true)
+        }
+        guard wifiAutoConnectArmed,
+              !usbDevices.contains(where: { $0.name == nil }) else { return }
         for result in discovered {
             let target = ConnectionTarget.wifi(result)
-            if wifiRemembered.contains(target.sessionID) {
+            if wifiRemembered.contains(target.sessionID), !reachableOverUSB(target) {
                 connect(to: target)
             }
+        }
+    }
+
+    /// True when a WiFi target is the same physical device as one already
+    /// served over the cable. Strong match: install id from the Bonjour TXT
+    /// record vs the id the USB session's hello announced (survives renamed
+    /// services). Fallback for old receivers: lockdown device name equals
+    /// the service name.
+    private func reachableOverUSB(_ target: ConnectionTarget) -> Bool {
+        guard case .wifi(let result) = target,
+              case .service(let name, _, _, _) = result.endpoint else { return false }
+        if case .bonjour(let txt) = result.metadata, let installID = txt["id"],
+           sessions.contains(where: { session in
+               if case .usb = session.target { return session.deviceID == installID }
+               return false
+           }) {
+            return true
+        }
+        return usbDevices.contains {
+            $0.name == name && !usbDisabled.contains("usb:\($0.udid)")
         }
     }
 
@@ -234,6 +283,17 @@ final class SenderController: ObservableObject {
         let id = target.sessionID
         guard session(for: id) == nil else { return }
 
+        // One session per physical device: a WiFi dial to a device that's
+        // already streaming over the cable would steal its connection.
+        if reachableOverUSB(target) { return }
+        // Conversely, plugging in a device that streams over WiFi upgrades
+        // it to USB: drop the WiFi session, the cable takes over.
+        if case .usb(let udid?) = target,
+           let usbName = usbDevices.first(where: { $0.udid == udid })?.name,
+           let wifiSession = sessions.first(where: { $0.id == "wifi:\(usbName)" }) {
+            end(wifiSession, keepRemembered: true)
+        }
+
         // Reconnecting a device clears its "don't auto-connect" state.
         switch target {
         case .usb: usbDisabled.remove(id)
@@ -262,6 +322,12 @@ final class SenderController: ObservableObject {
         sender.onStatus = { [weak session] text in
             session?.status = text
             Log.info("status[\(id)]: \(text)")
+        }
+        sender.onHello = { [weak self, weak session] info in
+            session?.deviceID = info.id
+            // A USB session learning its identity may reveal a WiFi
+            // duplicate to hand over — reconcile.
+            self?.autoConnect()
         }
         sender.onStats = { [weak session] frames, mbps in
             session?.framesSent = frames
@@ -304,6 +370,9 @@ final class SenderController: ObservableObject {
     private func end(_ session: DeviceSession, keepRemembered: Bool) {
         session.sender.stop()
         sessions.removeAll { $0.id == session.id }
+        // A USB session ending may unblock the WiFi fallback for the same
+        // device (and vice versa) — re-run the policy.
+        if keepRemembered { autoConnect() }
     }
 
     /// Mode/quality apply per-pipeline at construction — rebuild every session.
@@ -339,6 +408,10 @@ final class SenderController: ObservableObject {
         for result in discovered {
             let target = ConnectionTarget.wifi(result)
             guard !seen.contains(target.sessionID) else { continue }
+            // Same physical device as an attached USB entry: one row only —
+            // the wired one. The WiFi row reappears as a fallback the moment
+            // the cable is gone.
+            if reachableOverUSB(target) { continue }
             entries.append(DeviceEntry(id: target.sessionID, name: label(for: target), target: target))
             seen.insert(target.sessionID)
         }

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -206,6 +206,12 @@ final class SenderController: ObservableObject {
 
     private func autoConnect() {
         guard autoConnectEnabled else { return }
+        // The -host/-port escape hatch is an explicit choice — dial it like
+        // the wired devices (it joins them, not replaces them).
+        if UserDefaults.standard.object(forKey: "host") != nil,
+           !usbDisabled.contains("usb:first") {
+            connect(to: .usb(udid: nil))
+        }
         for device in usbDevices where !usbDisabled.contains("usb:\(device.udid)") {
             connect(to: .usb(udid: device.udid))
         }

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -357,20 +357,29 @@ final class SenderController: ObservableObject {
         return hash == 0 ? 1 : hash
     }
 
-    func connect(to target: ConnectionTarget) {
+    func connect(to target: ConnectionTarget, userInitiated: Bool = false) {
         let id = target.sessionID
         guard session(for: id) == nil else { return }
 
         // Never create a second session for the same physical device — the
-        // receiver holds one connection, so a twin would steal it.
+        // receiver holds one connection, so a twin would steal it. But an
+        // explicit user click overrides: e.g. right after unplugging the
+        // cable, the dying USB session sits in its 10s reconnect grace and
+        // would otherwise swallow the tap on the WiFi row.
+        let covering: DeviceSession?
         switch target {
         case .usb(let udid?):
-            if let device = usbDevices.first(where: { $0.udid == udid }),
-               activeSession(coveringUSB: device) != nil { return }
+            covering = usbDevices.first(where: { $0.udid == udid })
+                .flatMap { activeSession(coveringUSB: $0) }
         case .wifi(let result):
-            if activeSession(coveringWiFi: result) != nil { return }
+            covering = activeSession(coveringWiFi: result)
         default:
-            break
+            covering = nil
+        }
+        if let covering {
+            guard userInitiated else { return }
+            Log.info("user chose \(id) — taking over from \(covering.id)")
+            end(covering)
         }
 
         // Connecting a device clears its "don't auto-connect" state.
@@ -631,8 +640,10 @@ struct ContentView: View {
                                 }
                                 Spacer()
                                 if let target = entry.preferredTarget {
-                                    Button("Connect") { controller.connect(to: target) }
-                                        .controlSize(.small)
+                                    Button("Connect") {
+                                        controller.connect(to: target, userInitiated: true)
+                                    }
+                                    .controlSize(.small)
                                 }
                             }
                         }

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -84,6 +84,40 @@ enum ConnectionTarget: Hashable {
         if case .service(let name, _, _, _) = result.endpoint { return "\(name) (WiFi)" }
         return "WiFi device"
     }
+
+    /// Stable identity for sessions and persistence — survives Bonjour
+    /// re-discovery (fresh NWBrowser.Result) and USB replugs (new DeviceID).
+    var sessionID: String {
+        switch self {
+        case .usb(let udid): return "usb:\(udid ?? "first")"
+        case .wifi(let result):
+            if case .service(let name, _, _, _) = result.endpoint { return "wifi:\(name)" }
+            return "wifi:unknown"
+        }
+    }
+}
+
+/// One connected (or connecting) device: its target, its sender pipeline,
+/// and the per-device status the UI shows. Each session owns a full pipeline
+/// — virtual display, capture, encoder, socket — so devices are independent:
+/// one disconnecting never stalls the others.
+@MainActor
+final class DeviceSession: ObservableObject, Identifiable {
+    nonisolated let id: String
+    let target: ConnectionTarget
+    let name: String
+    let sender: MacSender
+
+    @Published var status = "Starting…"
+    @Published var framesSent = 0
+    @Published var mbps = 0.0
+
+    init(id: String, target: ConnectionTarget, name: String, sender: MacSender) {
+        self.id = id
+        self.target = target
+        self.name = name
+        self.sender = sender
+    }
 }
 
 @MainActor
@@ -101,13 +135,9 @@ final class SenderController: ObservableObject {
         }
     }
 
-    @Published var status = "Idle"
-    @Published var framesSent = 0
-    @Published var mbps = 0.0
-    @Published var running = false
+    @Published var sessions: [DeviceSession] = []
     @Published var discovered: [NWBrowser.Result] = []
     @Published var usbDevices: [UsbmuxDevice] = []
-    @Published var target: ConnectionTarget = .usb(udid: nil)
     // `-host x.x.x.x` / `-port n` bypass usbmuxd with a manual TCP endpoint
     // (debugging escape hatch, e.g. an iproxy or SSH tunnel).
     @Published var host = UserDefaults.standard.string(forKey: "host") ?? "127.0.0.1"
@@ -118,47 +148,32 @@ final class SenderController: ObservableObject {
         didSet { UserDefaults.standard.set(quality.rawValue, forKey: "quality") }
     }
 
-    private var sender: MacSender?
+    var running: Bool { !sessions.isEmpty }
+
     private var browser: NWBrowser?
     private var usbWatcher: UsbmuxDeviceWatcher?
+
+    // Auto-connect policy, persisted:
+    //  - USB devices connect on attach ("plug in and go") unless the user
+    //    explicitly disconnected them once (usbDisabled).
+    //  - WiFi devices connect only after the user connected them once
+    //    (wifiRemembered) — never auto-grab a stranger's device.
+    // `-autostart NO` disables all auto-connecting.
+    private var usbDisabled = Set(UserDefaults.standard.stringArray(forKey: "usbDisabled") ?? []) {
+        didSet { UserDefaults.standard.set(Array(usbDisabled), forKey: "usbDisabled") }
+    }
+    private var wifiRemembered = Set(UserDefaults.standard.stringArray(forKey: "wifiRemembered") ?? []) {
+        didSet { UserDefaults.standard.set(Array(wifiRemembered), forKey: "wifiRemembered") }
+    }
+    private let autoConnectEnabled = UserDefaults.standard.object(forKey: "autostart") == nil
+        || UserDefaults.standard.bool(forKey: "autostart")
 
     init() {
         startBrowsing()
         usbWatcher = UsbmuxDeviceWatcher { [weak self] devices in
             guard let self else { return }
             self.usbDevices = devices
-            // An explicitly selected device that detached has no picker entry
-            // anymore — fall back to the generic wired target.
-            if case .usb(let udid?) = self.target,
-               !devices.contains(where: { $0.udid == udid }) {
-                self.target = .usb(udid: nil)
-            }
-            self.reselectSavedTarget()
-        }
-        // Auto-start unless explicitly disabled (`-autostart NO`).
-        if UserDefaults.standard.object(forKey: "autostart") == nil
-            || UserDefaults.standard.bool(forKey: "autostart") {
-            start()
-        }
-    }
-
-    /// Label for the generic "first wired device" picker entry: the device's
-    /// name once one is attached (and resolved), a neutral fallback otherwise.
-    var usbLabel: String {
-        if usbDevices.count == 1, let device = usbDevices.first { return device.label }
-        return "USB (wired)"
-    }
-
-    /// Human-readable name of the current target, for status messages.
-    func targetLabel() -> String {
-        switch target {
-        case .usb(let udid):
-            if let device = usbDevices.first(where: { $0.udid == udid }) ?? usbDevices.first {
-                return device.label
-            }
-            return "USB (wired)"
-        case .wifi:
-            return target.wifiLabel ?? "WiFi device"
+            self.autoConnect()
         }
     }
 
@@ -168,55 +183,68 @@ final class SenderController: ObservableObject {
             DispatchQueue.main.async {
                 guard let self else { return }
                 self.discovered = Array(results)
-                self.reselectSavedTarget()
+                self.autoConnect()
             }
         }
         browser.start(queue: .main)
         self.browser = browser
     }
 
-    /// The connection choice survives relaunches: if the user last used a
-    /// WiFi or a specific wired device, re-select it as soon as discovery
-    /// (Bonjour / usbmuxd) finds it again.
-    private func reselectSavedTarget() {
-        guard case .usb(udid: nil) = target,
-              let saved = UserDefaults.standard.string(forKey: "lastTarget"),
-              saved != "usb" else { return }
-        if saved.hasPrefix("usb:") {
-            let udid = String(saved.dropFirst(4))
-            if usbDevices.contains(where: { $0.udid == udid }), usbDevices.count > 1 {
-                target = .usb(udid: udid)
-                // Same transport either way — no restart needed.
-            }
-            return
+    private func autoConnect() {
+        guard autoConnectEnabled else { return }
+        for device in usbDevices where !usbDisabled.contains("usb:\(device.udid)") {
+            connect(to: .usb(udid: device.udid))
         }
         for result in discovered {
-            if case .service(let name, _, _, _) = result.endpoint, name == saved {
-                target = .wifi(result)
-                restartIfRunning()
-                return
+            let target = ConnectionTarget.wifi(result)
+            if wifiRemembered.contains(target.sessionID) {
+                connect(to: target)
             }
         }
     }
 
-    func rememberTarget() {
+    /// Human-readable name for a target, used for the session row, status
+    /// messages, and the virtual display name in System Settings → Displays.
+    func label(for target: ConnectionTarget) -> String {
         switch target {
         case .usb(let udid):
-            UserDefaults.standard.set(udid.map { "usb:\($0)" } ?? "usb", forKey: "lastTarget")
-        case .wifi(let result):
-            if case .service(let name, _, _, _) = result.endpoint {
-                UserDefaults.standard.set(name, forKey: "lastTarget")
+            if let device = usbDevices.first(where: { $0.udid == udid }) {
+                return device.label
             }
+            return udid == nil ? "Manual (\(host):\(port))" : "USB (wired)"
+        case .wifi:
+            return target.wifiLabel ?? "WiFi device"
         }
     }
 
-    func start() {
-        guard !running else { return }
+    func session(for id: String) -> DeviceSession? {
+        sessions.first { $0.id == id }
+    }
+
+    /// Derive a stable, per-device display serial from the session identity.
+    /// FNV-1a over the id string; macOS keys saved display arrangement on
+    /// vendor/product/serial, so each device keeps its screen position.
+    private static func displaySerial(for id: String) -> UInt32 {
+        var hash: UInt32 = 2_166_136_261
+        for byte in id.utf8 { hash = (hash ^ UInt32(byte)) &* 16_777_619 }
+        return hash == 0 ? 1 : hash
+    }
+
+    func connect(to target: ConnectionTarget) {
+        let id = target.sessionID
+        guard session(for: id) == nil else { return }
+
+        // Reconnecting a device clears its "don't auto-connect" state.
+        switch target {
+        case .usb: usbDisabled.remove(id)
+        case .wifi: wifiRemembered.insert(id)
+        }
+
         let transport: SenderTransport
         switch target {
         case .usb(let udid):
             guard let portNum = UInt16(port) else { return }
-            if UserDefaults.standard.object(forKey: "host") != nil {
+            if UserDefaults.standard.object(forKey: "host") != nil, udid == nil {
                 // Manual override: dial a plain TCP endpoint instead of usbmuxd.
                 transport = .tcp(.hostPort(host: NWEndpoint.Host(host),
                                            port: NWEndpoint.Port(rawValue: portNum)!))
@@ -227,26 +255,27 @@ final class SenderController: ObservableObject {
             transport = .tcp(result.endpoint)
         }
 
-        running = true
-        status = "Starting…"
-        let sender = MacSender(transport: transport, name: targetLabel(), mode: mode, quality: quality)
-        sender.onStatus = { [weak self] text in
-            self?.status = text
-            Log.info("status: \(text)")
+        let name = label(for: target)
+        let sender = MacSender(transport: transport, name: name, mode: mode,
+                               quality: quality, displaySerial: Self.displaySerial(for: id))
+        let session = DeviceSession(id: id, target: target, name: name, sender: sender)
+        sender.onStatus = { [weak session] text in
+            session?.status = text
+            Log.info("status[\(id)]: \(text)")
         }
-        sender.onStats = { [weak self] frames, mbps in
-            self?.framesSent = frames
-            self?.mbps = mbps
+        sender.onStats = { [weak session] frames, mbps in
+            session?.framesSent = frames
+            session?.mbps = mbps
         }
-        sender.onDisconnected = { [weak self] in
-            // Device unplugged / left the network and stayed gone: end the
-            // session fully (virtual display + capture + indicator) rather
-            // than dialing forever or silently switching transports.
-            Log.info("device disconnected — session stopped")
-            self?.stop()
-            self?.status = "Disconnected — session stopped"
+        sender.onDisconnected = { [weak self, weak session] in
+            // Device unplugged / left the network and stayed gone: end this
+            // session fully (virtual display + capture + indicator). The
+            // device stays remembered, so it reconnects when it reappears.
+            guard let self, let session else { return }
+            Log.info("device disconnected — session \(session.id) stopped")
+            self.end(session, keepRemembered: true)
         }
-        self.sender = sender
+        sessions.append(session)
         Task {
             do {
                 try await sender.start()
@@ -254,28 +283,71 @@ final class SenderController: ObservableObject {
                 // stopped by the user while waiting — nothing to report
             } catch {
                 Log.info("sender failed to start: \(error)")
-                self.status = "Failed: \(error.localizedDescription)"
-                self.running = false
+                session.status = "Failed: \(error.localizedDescription)"
             }
         }
     }
 
-    func stop() {
-        sender?.stop()
-        sender = nil
-        running = false
-        status = "Stopped"
-    }
-
-    func reconnect() {
-        sender?.forceReconnect()
-    }
-
-    func restartIfRunning() {
-        if running {
-            stop()
-            start()
+    /// User-initiated disconnect: also opt the device out of auto-connect.
+    func disconnect(_ session: DeviceSession) {
+        switch session.target {
+        case .usb: usbDisabled.insert(session.id)
+        case .wifi: wifiRemembered.remove(session.id)
         }
+        end(session, keepRemembered: false)
+    }
+
+    func disconnectAll() {
+        sessions.forEach { disconnect($0) }
+    }
+
+    private func end(_ session: DeviceSession, keepRemembered: Bool) {
+        session.sender.stop()
+        sessions.removeAll { $0.id == session.id }
+    }
+
+    /// Mode/quality apply per-pipeline at construction — rebuild every session.
+    func restartAll() {
+        guard running else { return }
+        let targets = sessions.map(\.target)
+        sessions.forEach { $0.sender.stop() }
+        sessions.removeAll()
+        targets.forEach { connect(to: $0) }
+    }
+
+    // MARK: - Device list entries (available + connected, merged)
+
+    struct DeviceEntry: Identifiable {
+        let id: String
+        let name: String
+        let target: ConnectionTarget?   // nil: connected but no longer discoverable
+    }
+
+    var deviceEntries: [DeviceEntry] {
+        var entries: [DeviceEntry] = []
+        var seen = Set<String>()
+        for device in usbDevices {
+            let target = ConnectionTarget.usb(udid: device.udid)
+            entries.append(DeviceEntry(id: target.sessionID, name: device.label, target: target))
+            seen.insert(target.sessionID)
+        }
+        if UserDefaults.standard.object(forKey: "host") != nil {
+            let target = ConnectionTarget.usb(udid: nil)
+            entries.append(DeviceEntry(id: target.sessionID, name: label(for: target), target: target))
+            seen.insert(target.sessionID)
+        }
+        for result in discovered {
+            let target = ConnectionTarget.wifi(result)
+            guard !seen.contains(target.sessionID) else { continue }
+            entries.append(DeviceEntry(id: target.sessionID, name: label(for: target), target: target))
+            seen.insert(target.sessionID)
+        }
+        // Sessions whose device vanished from discovery (e.g. Bonjour record
+        // gone while the stream is still alive) keep a row to disconnect.
+        for session in sessions where !seen.contains(session.id) {
+            entries.append(DeviceEntry(id: session.id, name: session.name, target: nil))
+        }
+        return entries
     }
 }
 
@@ -323,17 +395,6 @@ struct ContentView: View {
     @ObservedObject var controller: SenderController
     @StateObject private var permissions = PermissionMonitor()
 
-    private var statusColor: Color {
-        if !controller.running { return .secondary.opacity(0.5) }
-        if controller.status.hasPrefix("Extending") || controller.status.hasPrefix("Mirroring") {
-            return .green
-        }
-        if controller.status.hasPrefix("Failed") || controller.status.contains("stopped") {
-            return .red
-        }
-        return .orange
-    }
-
     var body: some View {
         VStack(spacing: 0) {
             // Header
@@ -344,25 +405,15 @@ struct ContentView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("OpenSidecar")
                         .font(.title3.bold())
-                    Text("Your iPad or iPhone as a second display")
+                    Text("Your iPads and iPhones as extra displays")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
                 if controller.running {
-                    Button {
-                        controller.reconnect()
-                    } label: {
-                        Image(systemName: "arrow.clockwise")
-                    }
-                    .controlSize(.large)
-                    .help("Drop the connection and pair with the device again")
+                    Button("Disconnect All") { controller.disconnectAll() }
+                        .controlSize(.large)
                 }
-                Button(controller.running ? "Stop" : "Start") {
-                    controller.running ? controller.stop() : controller.start()
-                }
-                .controlSize(.large)
-                .keyboardShortcut(.defaultAction)
             }
             .padding(16)
 
@@ -370,24 +421,29 @@ struct ContentView: View {
 
             // Settings
             Form {
-                Picker("Connection", selection: $controller.target) {
-                    // Generic wired entry — dials the first attached device,
-                    // labeled with its name once usbmuxd/lockdown report it.
-                    Text(controller.usbLabel).tag(ConnectionTarget.usb(udid: nil))
-                    // Explicit per-device entries only matter with 2+ devices.
-                    if controller.usbDevices.count > 1 {
-                        ForEach(controller.usbDevices) { device in
-                            Text(device.label).tag(ConnectionTarget.usb(udid: device.udid))
+                Section("Devices") {
+                    if controller.deviceEntries.isEmpty {
+                        Text("No devices found — plug one in via USB, or open the OpenSidecar app on a device on this WiFi network.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    ForEach(controller.deviceEntries) { entry in
+                        if let session = controller.session(for: entry.id) {
+                            SessionRow(session: session, controller: controller)
+                        } else {
+                            HStack {
+                                Circle()
+                                    .fill(.secondary.opacity(0.5))
+                                    .frame(width: 9, height: 9)
+                                Text(entry.name)
+                                Spacer()
+                                if let target = entry.target {
+                                    Button("Connect") { controller.connect(to: target) }
+                                        .controlSize(.small)
+                                }
+                            }
                         }
                     }
-                    ForEach(controller.discovered, id: \.self) { result in
-                        Text(ConnectionTarget.wifi(result).wifiLabel ?? "WiFi device")
-                            .tag(ConnectionTarget.wifi(result))
-                    }
-                }
-                .onChange(of: controller.target) {
-                    controller.rememberTarget()
-                    controller.restartIfRunning()
                 }
 
                 Picker("Mode", selection: $controller.mode) {
@@ -395,7 +451,7 @@ struct ContentView: View {
                     Text("Mirror").tag(CaptureMode.mirror)
                 }
                 .pickerStyle(.segmented)
-                .onChange(of: controller.mode) { controller.restartIfRunning() }
+                .onChange(of: controller.mode) { controller.restartAll() }
 
                 VStack(alignment: .leading, spacing: 4) {
                     Picker("Quality", selection: $controller.quality) {
@@ -403,7 +459,7 @@ struct ContentView: View {
                             Text(q.label).tag(q)
                         }
                     }
-                    .onChange(of: controller.quality) { controller.restartIfRunning() }
+                    .onChange(of: controller.quality) { controller.restartAll() }
                     Text(controller.quality.explanation)
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -430,7 +486,7 @@ struct ContentView: View {
                     }
                     .controlSize(.small)
                 }
-                .help("Opens System Settings → Displays, where you can position the extended display relative to your Mac screen (Arrange…).")
+                .help("Opens System Settings → Displays, where you can position the extended displays relative to your Mac screen (Arrange…). Each device shows up as its own display, named after the device.")
 
                 Section("Permissions") {
                     permissionRow(
@@ -453,7 +509,7 @@ struct ContentView: View {
                         "Local Network",
                         granted: !controller.discovered.isEmpty,
                         uncertain: controller.discovered.isEmpty,
-                        help: "Required for WiFi mode. If no device appears in the Connection menu, allow OpenSidecar under Privacy & Security → Local Network on this Mac AND on the device — and keep the OpenSidecar app open there.",
+                        help: "Required for WiFi mode. If no device appears in the Devices list, allow OpenSidecar under Privacy & Security → Local Network on this Mac AND on the device — and keep the OpenSidecar app open there.",
                         anchor: "Privacy_LocalNetwork"
                     )
                 }
@@ -468,17 +524,14 @@ struct ContentView: View {
             // Status bar
             HStack(spacing: 8) {
                 Circle()
-                    .fill(statusColor)
+                    .fill(controller.running ? .green : .secondary.opacity(0.5))
                     .frame(width: 9, height: 9)
-                Text(controller.status)
+                Text(controller.running
+                     ? "\(controller.sessions.count) device\(controller.sessions.count == 1 ? "" : "s") connected"
+                     : "Idle")
                     .font(.callout)
                     .lineLimit(1)
                 Spacer()
-                if controller.running, controller.mbps > 0 {
-                    Text("\(String(format: "%.1f", controller.mbps)) Mbit/s")
-                        .font(.system(.caption, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                }
                 Button("Quit") { NSApp.terminate(nil) }
                     .controlSize(.small)
             }
@@ -516,6 +569,53 @@ struct ContentView: View {
                 }
                 .controlSize(.small)
             }
+        }
+    }
+}
+
+/// One connected device: live status, throughput, reconnect + disconnect.
+struct SessionRow: View {
+    @ObservedObject var session: DeviceSession
+    let controller: SenderController
+
+    private var statusColor: Color {
+        if session.status.hasPrefix("Extending") || session.status.hasPrefix("Mirroring")
+            || session.status.hasPrefix("Connected") {
+            return .green
+        }
+        if session.status.hasPrefix("Failed") || session.status.contains("stopped") {
+            return .red
+        }
+        return .orange
+    }
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 9, height: 9)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(session.name)
+                Text(session.status)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+            Spacer()
+            if session.mbps > 0 {
+                Text("\(String(format: "%.1f", session.mbps)) Mbit/s")
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+            Button {
+                session.sender.forceReconnect()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+            }
+            .controlSize(.small)
+            .help("Drop the connection and pair with the device again")
+            Button("Disconnect") { controller.disconnect(session) }
+                .controlSize(.small)
         }
     }
 }

--- a/Mac/TestPatternWindow.swift
+++ b/Mac/TestPatternWindow.swift
@@ -7,10 +7,12 @@ import AppKit
 /// Enable with `defaults write sh.peet.opensidecar.mac testPattern -bool true`.
 @MainActor
 enum TestPattern {
-    private static var window: NSWindow?
+    // One window per virtual display — multi-device sessions each get their
+    // own pattern, so all pipelines stream at once during measurements.
+    private static var windows: [CGDirectDisplayID: NSWindow] = [:]
 
     static func show(on displayID: CGDirectDisplayID) {
-        hide()
+        hide(on: displayID)
         // The screen may register a beat after the virtual display appears.
         Task { @MainActor in
             for _ in 0..<10 {
@@ -22,7 +24,7 @@ enum TestPattern {
                     w.contentView = NSHostingView(rootView: PatternView())
                     w.setFrame(screen.frame, display: true)
                     w.orderFrontRegardless()
-                    window = w
+                    windows[displayID] = w
                     Log.info("test pattern window shown on display \(displayID)")
                     return
                 }
@@ -32,9 +34,8 @@ enum TestPattern {
         }
     }
 
-    static func hide() {
-        window?.orderOut(nil)
-        window = nil
+    static func hide(on displayID: CGDirectDisplayID) {
+        windows.removeValue(forKey: displayID)?.orderOut(nil)
     }
 }
 

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -47,18 +47,29 @@ final class VirtualDisplay {
         }
         Log.info("virtual display created: id=\(display.displayID) \(pointsWide)x\(pointsHigh)pt @2x")
 
-        // macOS defaults the new display to its 1x mode; explicitly select the
-        // HiDPI (@2x) variant so UI renders at Retina sharpness. The mode list
-        // populates asynchronously after applySettings, so retry briefly.
+        // macOS defaults the new display to its 1x mode AND can restore a
+        // stale saved mode for this serial asynchronously, seconds after the
+        // display appears (observed: a display checked as @2x at creation
+        // sitting at 1x later, and a rotated rebuild pillarboxed by the
+        // previous orientation's mode). So mode selection is enforcement,
+        // not a one-shot: keep watching for the lifetime of the display and
+        // re-assert the HiDPI mode whenever something else changes it.
         Task { @MainActor [weak self] in
-            for _ in 0..<10 {
-                if self?.selectHiDPIMode() == true { return }
-                try? await Task.sleep(for: .milliseconds(200))
+            var settled = false
+            while true {
+                // Scoped strong ref: a rotation rebuild relies on release
+                // removing the display — never hold it across the sleep.
+                do {
+                    guard let self else { return }
+                    if self.selectHiDPIMode() { settled = true }
+                }
+                try? await Task.sleep(for: .milliseconds(settled ? 2000 : 200))
             }
-            Log.info("HiDPI mode never appeared — staying at 1x")
         }
     }
 
+    /// Returns true when the display is (now) in its HiDPI mode. Silent when
+    /// nothing needed doing — this runs every 2s as enforcement.
     @discardableResult
     private func selectHiDPIMode() -> Bool {
         let opts = [kCGDisplayShowDuplicateLowResolutionModes: kCFBooleanTrue] as CFDictionary
@@ -70,14 +81,13 @@ final class VirtualDisplay {
         }
         if let current = CGDisplayCopyDisplayMode(display.displayID),
            current.width == hidpi.width, current.pixelWidth == hidpi.pixelWidth {
-            Log.info("HiDPI mode already active")
             return true
         }
         var config: CGDisplayConfigRef?
         CGBeginDisplayConfiguration(&config)
         CGConfigureDisplayWithDisplayMode(config, display.displayID, hidpi, nil)
         let err = CGCompleteDisplayConfiguration(config, .permanently)
-        Log.info("HiDPI mode selected: \(hidpi.width)x\(hidpi.height)@2x (result \(err.rawValue))")
+        Log.info("HiDPI mode (re)selected: \(hidpi.width)x\(hidpi.height)@2x (result \(err.rawValue))")
         return err == .success
     }
 }

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -12,8 +12,12 @@ final class VirtualDisplay {
 
     var displayID: CGDirectDisplayID { display.displayID }
 
-    /// Must be called on the main thread.
-    init?(name: String, pointsWide: Int, pointsHigh: Int, sizeInMillimeters: CGSize) {
+    /// Must be called on the main thread. `serialNum` must be unique per
+    /// concurrent display AND stable per device — macOS keys saved display
+    /// arrangement on vendor/product/serial, so a stable serial means each
+    /// device keeps its position in System Settings across sessions.
+    init?(name: String, pointsWide: Int, pointsHigh: Int, sizeInMillimeters: CGSize,
+          serialNum: UInt32 = 0x0001) {
         self.pointsWide = pointsWide
         self.pointsHigh = pointsHigh
 
@@ -25,7 +29,7 @@ final class VirtualDisplay {
         descriptor.sizeInMillimeters = sizeInMillimeters
         descriptor.productID = 0x4F53   // "OS"
         descriptor.vendorID = 0x5043    // "PC"
-        descriptor.serialNum = 0x0001
+        descriptor.serialNum = serialNum
         descriptor.terminationHandler = { _, _ in
             Log.info("virtual display terminated by the system")
         }

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -7,6 +7,7 @@ import CoreGraphics
 final class VirtualDisplay {
 
     private let display: CGVirtualDisplay
+    private let settings: CGVirtualDisplaySettings
     let pointsWide: Int
     let pointsHigh: Int
 
@@ -36,7 +37,7 @@ final class VirtualDisplay {
 
         display = CGVirtualDisplay(descriptor: descriptor)
 
-        let settings = CGVirtualDisplaySettings()
+        settings = CGVirtualDisplaySettings()
         settings.hiDPI = 1
         settings.modes = [
             CGVirtualDisplayMode(width: UInt(pointsWide), height: UInt(pointsHigh), refreshRate: 60)
@@ -61,7 +62,7 @@ final class VirtualDisplay {
                 // removing the display — never hold it across the sleep.
                 do {
                     guard let self else { return }
-                    if self.selectHiDPIMode() { settled = true }
+                    if self.selectHiDPIMode(recover: settled) { settled = true }
                 }
                 try? await Task.sleep(for: .milliseconds(settled ? 2000 : 200))
             }
@@ -69,14 +70,21 @@ final class VirtualDisplay {
     }
 
     /// Returns true when the display is (now) in its HiDPI mode. Silent when
-    /// nothing needed doing — this runs every 2s as enforcement.
+    /// nothing needed doing — this runs every 2s as enforcement. With
+    /// `recover`, a missing @2x mode (macOS can replace the whole mode list
+    /// when it restores saved display state) re-applies our settings to
+    /// publish it again instead of failing silently forever.
     @discardableResult
-    private func selectHiDPIMode() -> Bool {
+    private func selectHiDPIMode(recover: Bool = false) -> Bool {
         let opts = [kCGDisplayShowDuplicateLowResolutionModes: kCFBooleanTrue] as CFDictionary
         guard let modes = CGDisplayCopyAllDisplayModes(display.displayID, opts) as? [CGDisplayMode],
               let hidpi = modes.first(where: {
                   $0.width == pointsWide && $0.pixelWidth == pointsWide * 2
               }) else {
+            if recover {
+                Log.info("@2x mode vanished from display \(display.displayID) — re-applying settings")
+                _ = display.apply(settings)
+            }
             return false
         }
         if let current = CGDisplayCopyDisplayMode(display.displayID),

--- a/README.md
+++ b/README.md
@@ -234,7 +234,6 @@ Tracked as [roadmap issues](https://github.com/peetzweg/opensidecar/issues?q=is%
 - [#7](https://github.com/peetzweg/opensidecar/issues/7) On-screen modifier key sidebar
 
 **Display & media**
-- [#8](https://github.com/peetzweg/opensidecar/issues/8) Multiple devices / multiple virtual displays
 - [#9](https://github.com/peetzweg/opensidecar/issues/9) Resolution & quality settings
 - [#10](https://github.com/peetzweg/opensidecar/issues/10) HEVC encoding
 - [#12](https://github.com/peetzweg/opensidecar/issues/12) Audio forwarding
@@ -248,7 +247,7 @@ Tracked as [roadmap issues](https://github.com/peetzweg/opensidecar/issues?q=is%
 - [#14](https://github.com/peetzweg/opensidecar/issues/14) Remote access beyond the local network
 - [#15](https://github.com/peetzweg/opensidecar/issues/15) Additional client platforms
 
-Done: prebuilt releases, built-in USB connectivity (no helper tools), WiFi via Bonjour, portrait mode, touch + two-finger scroll, performance overlay, iPad support.
+Done: prebuilt releases, built-in USB connectivity (no helper tools), WiFi via Bonjour, portrait mode, touch + two-finger scroll, performance overlay, iPad support, multiple devices at once ([#8](https://github.com/peetzweg/opensidecar/issues/8) — every connected device becomes its own extended display).
 
 ## Contributing
 

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -540,6 +540,8 @@ struct VideoLayerView: UIViewRepresentable {
         private var cursorNorm = CGPoint(x: 0.5, y: 0.5)
         private var cursorVisible = false
 
+        private var lastLoggedLayout = ""
+
         override func layoutSubviews() {
             super.layoutSubviews()
             CATransaction.begin()
@@ -555,6 +557,15 @@ struct VideoLayerView: UIViewRepresentable {
             if cursorLayer.superlayer == nil { layer.addSublayer(cursorLayer) }
             updateCursorLayout()
             CATransaction.commit()
+            // Rotation diagnostics — one line per layout change.
+            let video = receiver?.videoSize ?? .zero
+            let line = "layout: bounds=\(Int(bounds.width))x\(Int(bounds.height))"
+                + " video=\(Int(video.width))x\(Int(video.height))"
+                + " layer=\(Int(layer.sublayers?.first?.frame.width ?? -1))x\(Int(layer.sublayers?.first?.frame.height ?? -1))"
+            if line != lastLoggedLayout {
+                lastLoggedLayout = line
+                Log.info(line)
+            }
         }
 
         /// Aspect-fit rect of the video inside the view (inverse of normalized()).

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -144,6 +144,27 @@ final class PhoneReceiver: ObservableObject {
     // the real name host-side via lockdownd regardless.
     var serviceName = "OpenSidecar"
 
+    // Stable per-install identity, advertised in the Bonjour TXT record and
+    // sent in every hello. The Mac uses it to recognize "same device, other
+    // transport" — the service name can't serve that role since it's
+    // user-editable, and iOS offers no public API for the hardware UDID
+    // that usbmuxd reports.
+    static let installID: String = {
+        if let existing = UserDefaults.standard.string(forKey: "installID") {
+            return existing
+        }
+        let fresh = UUID().uuidString
+        UserDefaults.standard.set(fresh, forKey: "installID")
+        return fresh
+    }()
+
+    private var advertisedService: NWListener.Service {
+        var txt = NWTXTRecord()
+        txt["id"] = Self.installID
+        return NWListener.Service(name: serviceName, type: "_opensidecar._tcp",
+                                  domain: nil, txtRecord: txt)
+    }
+
     /// Update the advertised name and re-publish if already listening.
     func setServiceName(_ name: String) {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -152,8 +173,7 @@ final class PhoneReceiver: ObservableObject {
             guard resolved != self.serviceName else { return }
             self.serviceName = resolved
             if self.listener != nil {
-                self.listener?.service = NWListener.Service(
-                    name: resolved, type: "_opensidecar._tcp")
+                self.listener?.service = self.advertisedService
                 Log.info("re-advertising as \"\(resolved)\"")
             }
         }
@@ -228,7 +248,7 @@ final class PhoneReceiver: ObservableObject {
         }
         // Advertise on the local network so the Mac can discover us for WiFi
         // mode (USB/usbmux connects straight to the port and ignores this).
-        listener?.service = NWListener.Service(name: serviceName, type: "_opensidecar._tcp")
+        listener?.service = advertisedService
         listener?.newConnectionHandler = { [weak self] conn in
             guard let self else { return }
             Log.info("new connection from \(String(describing: conn.endpoint))")
@@ -368,6 +388,7 @@ final class PhoneReceiver: ObservableObject {
             "pixelsHigh": devicePixelsHigh,
             "scale": deviceScale,
             "device": UIDevice.current.userInterfaceIdiom == .pad ? "iPad" : "iPhone",
+            "id": Self.installID,
         ], on: conn)
         Log.info("hello sent")
     }

--- a/tools/fake-receiver.swift
+++ b/tools/fake-receiver.swift
@@ -15,6 +15,11 @@ func frame(_ json: String) -> Data {
     return d
 }
 
+// Pass "rotate" as arg 1 to announce a portrait re-hello 20s after connect
+// (and back to landscape at 45s) — simulates device rotation for testing
+// the Mac's rebuild path without physical hardware.
+let simulateRotation = CommandLine.arguments.dropFirst().first == "rotate"
+
 listener.newConnectionHandler = { conn in
     print("connection from \(conn.endpoint)")
     var frames = 0, bytes = 0
@@ -23,6 +28,18 @@ listener.newConnectionHandler = { conn in
     // iPad Pro 12.9" panel: 2732x2048 @2x
     conn.send(content: frame("{\"type\":\"hello\",\"pixelsWide\":2732,\"pixelsHigh\":2048,\"scale\":2,\"device\":\"iPad\",\"id\":\"FAKE-3\"}"),
               completion: .contentProcessed { _ in })
+    if simulateRotation {
+        DispatchQueue.global().asyncAfter(deadline: .now() + 20) {
+            print("simulating rotation -> portrait")
+            conn.send(content: frame("{\"type\":\"hello\",\"pixelsWide\":2048,\"pixelsHigh\":2732,\"scale\":2,\"device\":\"iPad\",\"id\":\"FAKE-3\"}"),
+                      completion: .contentProcessed { _ in })
+        }
+        DispatchQueue.global().asyncAfter(deadline: .now() + 45) {
+            print("simulating rotation -> landscape")
+            conn.send(content: frame("{\"type\":\"hello\",\"pixelsWide\":2732,\"pixelsHigh\":2048,\"scale\":2,\"device\":\"iPad\",\"id\":\"FAKE-3\"}"),
+                      completion: .contentProcessed { _ in })
+        }
+    }
     let timer = DispatchSource.makeTimerSource(queue: .global())
     timer.schedule(deadline: .now() + 1, repeating: 2)
     timer.setEventHandler {

--- a/tools/fake-receiver.swift
+++ b/tools/fake-receiver.swift
@@ -1,0 +1,57 @@
+// Fake OpenSidecar receiver — speaks just enough of the wire protocol to
+// stand in for a third device: sends hello + pings, consumes video frames,
+// reports receive rate. For Mac-side scale testing only.
+import Foundation
+import Network
+
+let port: UInt16 = 9000
+let listener = try! NWListener(using: .tcp, on: NWEndpoint.Port(rawValue: port)!)
+
+func frame(_ json: String) -> Data {
+    let payload = Data(json.utf8)
+    var header = UInt32(payload.count).bigEndian
+    var d = Data(bytes: &header, count: 4)
+    d.append(payload)
+    return d
+}
+
+listener.newConnectionHandler = { conn in
+    print("connection from \(conn.endpoint)")
+    var frames = 0, bytes = 0
+    var windowStart = Date()
+    conn.start(queue: .global())
+    // iPad Pro 12.9" panel: 2732x2048 @2x
+    conn.send(content: frame("{\"type\":\"hello\",\"pixelsWide\":2732,\"pixelsHigh\":2048,\"scale\":2,\"device\":\"iPad\",\"id\":\"FAKE-3\"}"),
+              completion: .contentProcessed { _ in })
+    let timer = DispatchSource.makeTimerSource(queue: .global())
+    timer.schedule(deadline: .now() + 1, repeating: 2)
+    timer.setEventHandler {
+        let t = Date().timeIntervalSince1970 * 1000
+        conn.send(content: frame("{\"type\":\"ping\",\"t\":\(t)}"),
+                  completion: .contentProcessed { _ in })
+    }
+    timer.resume()
+    func readLoop() {
+        conn.receive(minimumIncompleteLength: 4, maximumLength: 4) { data, _, _, err in
+            guard let data, data.count == 4, err == nil else { print("closed"); timer.cancel(); return }
+            let len = Int(UInt32(bigEndian: data.withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }))
+            guard len > 0, len < 1 << 24 else { print("bad length \(len)"); timer.cancel(); return }
+            conn.receive(minimumIncompleteLength: len, maximumLength: len) { payload, _, _, err in
+                guard let payload, payload.count == len, err == nil else { print("closed"); timer.cancel(); return }
+                frames += 1
+                bytes += len
+                let el = Date().timeIntervalSince(windowStart)
+                if el >= 5 {
+                    print(String(format: "recv %.0f frames/s  %.1f Mbit/s",
+                                 Double(frames) / el, Double(bytes) * 8 / el / 1_000_000))
+                    frames = 0; bytes = 0; windowStart = Date()
+                }
+                readLoop()
+            }
+        }
+    }
+    readLoop()
+}
+listener.start(queue: .global())
+print("fake receiver listening on \(port)")
+RunLoop.main.run()


### PR DESCRIPTION
Implements #8 — every connected iPhone/iPad becomes its own extended display, over USB and WiFi simultaneously. Closes #8.

## What's in here

**Multi-device core**
- One `DeviceSession` per device: full independent pipeline (CGVirtualDisplay + ScreenCaptureKit + encoder + socket + input injector). Devices connect/disconnect without affecting each other.
- Device-list UI replaces the single connection picker: one row per physical device with live name, transport (USB · WiFi), status, and throughput.
- USB devices auto-connect on attach (plug in and go); WiFi devices the user connected before reconnect in a short launch window. `-autostart NO` disables both.
- Stable per-device (and per-orientation) display serials, so macOS persists each device's arrangement.

**Same device on two transports**
- Receivers advertise a persistent install id (Bonjour TXT + hello). The Mac keeps ONE session per physical device — without this, USB and WiFi steal the receiver's single connection from each other in a loop. Old receivers fall back to lockdown-name matching.
- No automatic transport handover (deliberate): unplugging ends the session. An explicit Connect click takes over from a session stuck in its reconnect grace.

**Bugs found by testing on real hardware** (each was observed live, see commits)
- macOS asynchronously restores saved display modes — onto the wrong orientation (desktop pillarboxed into the framebuffer → bars on the device after rotation) and to 1x (blurry). Mode selection is now lifetime enforcement, with recovery when the saved-state restore wipes our @2x mode from the list.
- Injected clicks carried no event source / clickState, which breaks macOS menu tracking: menus opened by touch left zombie menu windows composited over every stream. Clicks now post like real ones.
- Cursor sprite was normalized against the display size snapshotted at capture start — half-size cursor when the snapshot landed during a 1x moment. Now read live and re-sent on mode flips.

## Measured (M5 Pro, iPhone 15 Pro + iPad over USB and WiFi)
- 2 devices: 9–15 ms median end-to-end at 58–59 fps, zero drops — same as single-device.
- 3 displays (third simulated with `tools/fake-receiver.swift`, all animating 60 fps): hardware H.264 encoder is the only ceiling; 'Fast' quality runs it at 5 ms e2e. Full findings + levers for 3× iPad Pro in #25.

## Notes
- Wire protocol is backward compatible — old receivers work, minus install-id dedup and the device-kind naming.
- `tools/fake-receiver.swift` speaks the protocol (hello/ping/frames, optional rotation simulation) for Mac-side testing without hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)