### PR TITLE
feat: ship notarized .dmg + wire TestFlight link (#48)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,15 +104,9 @@ jobs:
           export APP_MARKETING_VERSION="${TAG_NAME#v}"
           bundle exec fastlane mac build_release
 
-      - name: Zip notarized macOS app
-        run: |
-          ditto -c -k --keepParent \
-            build/export/OpenSidecar.app \
-            OpenSidecar-macOS.zip
-
       - name: Upload macOS artifact to release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload "${{ needs.release-please.outputs.tag_name }}" \
-            OpenSidecar-macOS.zip
+            build/export/OpenSidecar.dmg

--- a/README.md
+++ b/README.md
@@ -86,29 +86,18 @@ You need **two apps**: a Mac app (captures and sends) and an iOS app
 
 ### Prebuilt downloads (Mac)
 
-Grab `OpenSidecar-macOS.zip` from the
+Grab `OpenSidecar.dmg` from the
 [latest release](https://github.com/peetzweg/opensidecar/releases/latest).
-The app is ad-hoc signed (no paid developer certificate), so on first launch
-macOS will warn about an unidentified developer — **right-click → Open**, or:
-
-```sh
-xattr -d com.apple.quarantine OpenSidecar.app
-```
+The app is signed with a Developer ID certificate and notarized by Apple, so it
+opens with a plain double-click on macOS 14+ — no Gatekeeper warning. Open the
+`.dmg` and drag the app to Applications.
 
 ### iPhone app
 
-Apple doesn't allow distributing installable iOS builds without a paid
-developer program, so pick one:
-
-- **Build from source** (recommended): open the project in Xcode, select your
-  free Apple ID under Signing, hit Run. Takes ~2 minutes.
-- **Sideload the release `.ipa`**: each release includes
-  `OpenSidecar-iOS-unsigned.ipa`, which tools like
-  [AltStore](https://altstore.io) or Sideloadly can sign with your own
-  Apple ID and install.
-
-Free-account sideloads expire after 7 days and need a re-deploy; a paid
-account ($99/yr) removes that limit.
+- **TestFlight** (recommended): join the public beta at
+  [testflight.apple.com/join/3NYaY11c](https://testflight.apple.com/join/3NYaY11c).
+- **Build from source**: open the project in Xcode, select your free Apple ID
+  under Signing, hit Run. Takes ~2 minutes.
 
 ## Quick start (from source)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -251,7 +251,7 @@
         <div class="dl-head"><span class="step">Step 1</span> On your Mac <span class="ver" id="mac-ver"></span></div>
         <p class="dl-sub">The sender — captures a virtual display and streams it.</p>
         <a class="btn primary" id="mac-dl"
-           href="https://github.com/peetzweg/opensidecar/releases/latest/download/OpenSidecar-macOS.zip">
+           href="https://github.com/peetzweg/opensidecar/releases/latest/download/OpenSidecar.dmg">
           Download for Mac
         </a>
         <p class="note">
@@ -270,10 +270,8 @@
             <span class="cap">Coming soon</span>
           </span>
         </div>
-        <!-- TODO: replace the #testflight href with the public TestFlight invite link
-             (e.g. https://testflight.apple.com/join/XXXXXXXX), then drop the onclick and "(soon)". -->
         <p class="sub">
-          <a id="testflight" href="#" onclick="return false;" title="TestFlight invite link coming soon">Join the TestFlight beta (soon)</a>,<br>
+          <a id="testflight" href="https://testflight.apple.com/join/3NYaY11c">Join the TestFlight beta</a>,<br>
           or get started now by
           <a href="https://github.com/peetzweg/opensidecar#quick-start">compiling it from source ↗</a>.
         </p>
@@ -396,9 +394,9 @@
       <details>
         <summary>Why isn't this on the App Store yet?</summary>
         <p><code>CGVirtualDisplay</code> is a private API. That's the deal: every
-        virtual-display product either uses it or ships a dongle. A TestFlight beta is coming;
-        in the meantime you can build from source with your own (free) Apple developer account in
-        a few minutes.</p>
+        virtual-display product either uses it or ships a dongle. A
+        <a href="https://testflight.apple.com/join/3NYaY11c">TestFlight beta is available now</a>;
+        or build from source with your own (free) Apple developer account in a few minutes.</p>
       </details>
       <details>
         <summary>Why do I see the purple screen-recording indicator on my Mac?</summary>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,6 +52,27 @@ platform :mac do
       bundle_id: "com.peetzweg.opensidecar.mac",
       api_key:   key
     )
+
+    # Wrap the notarized app in a DMG for a friendlier download. Use hdiutil
+    # (built-in) rather than create-dmg to avoid the AppleScript window-styling
+    # step that is flaky in headless CI. Sign the DMG with the Developer ID
+    # identity match installed, then notarize + staple it too — so the
+    # downloaded disk image itself passes Gatekeeper without a prompt.
+    dmg = "build/export/OpenSidecar.dmg"
+    sh(<<~BASH)
+      set -euo pipefail
+      rm -rf build/dmg-src
+      mkdir -p build/dmg-src
+      cp -R build/export/OpenSidecar.app build/dmg-src/
+      ln -s /Applications build/dmg-src/Applications
+      hdiutil create -volname OpenSidecar -srcfolder build/dmg-src -ov -format UDZO #{dmg}
+      codesign --force --sign "Developer ID Application" --timestamp #{dmg}
+    BASH
+    notarize(
+      package:   dmg,
+      bundle_id: "com.peetzweg.opensidecar.mac",
+      api_key:   key
+    )
   end
 end
 


### PR DESCRIPTION
Closes #48 (the codeable parts).

## What & why
Issue #48 wants hassle-free desktop distribution — download, double-click, no Gatekeeper "unidentified developer" prompt. Developer ID signing + notarization + stapling already handled that for the `.app`; this finishes the polish from the issue.

## Changes
- **Notarized `.dmg`** (`fastlane/Fastfile`): after notarizing the `.app`, wrap it in an `hdiutil` DMG (with an `/Applications` drop link), sign the DMG with the match-installed Developer ID identity, then notarize + staple the DMG so the downloaded disk image itself passes Gatekeeper. Used `hdiutil` over `create-dmg` to avoid the flaky AppleScript window-styling step in headless CI.
- **Release workflow** (`.github/workflows/release.yml`): drop the `ditto` zip step; upload `build/export/OpenSidecar.dmg` instead of `OpenSidecar-macOS.zip`. (`.dmg` **replaces** the `.zip` — confirmed with maintainer.)
- **Landing page** (`docs/index.html`): Mac download → `OpenSidecar.dmg`; enable the public TestFlight invite link (was a placeholder); refresh the App Store FAQ. App Store badge stays disabled (no public listing yet).
- **README**: replace stale ad-hoc-signing / right-click▸Open / unsigned-`.ipa` copy with the notarized `.dmg` + TestFlight instructions.

## Verification
- `ruby -c fastlane/Fastfile` → Syntax OK. (`fastlane lanes` not runnable locally — gems not installed.)
- The DMG/sign/notarize path needs Apple signing secrets and **only runs in CI**, on the next release-please release. After it runs: confirm the Release has `OpenSidecar.dmg` (no `.zip`), then on a Mac download → double-click → drag to Applications → launch with **no** Gatekeeper prompt. Offline check: `xcrun stapler validate OpenSidecar.dmg`.

## Out of scope
App Store listing/review (manual Apple work); badge stays disabled until a public listing URL exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)