### PR TITLE
chore(deps): pnpm safe batch — bump motion 12.41.0 → 12.42.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "motion": "^12.41.0",
+    "motion": "^12.42.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       motion:
-        specifier: ^12.41.0
-        version: 12.41.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^12.42.0
+        version: 12.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -192,8 +192,8 @@ packages:
       picomatch:
         optional: true
 
-  framer-motion@12.41.0:
-    resolution: {integrity: sha512-OHAMNiCEON1RDBlRGuulsN5AD8ptMjvk5QWfFmYmBLPZ3zFGIJe60kQucQQf4cez1OzQmjYBWDY+dYfISkUdqg==}
+  framer-motion@12.42.0:
+    resolution: {integrity: sha512-wp7EJnfWaaEScVygKv3e20udoRz+LbtxScsuTkakAxfXmt+ReC6WyPW2nINRAGvd+hG9odwcjBLyOTPjH5pBRA==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -285,14 +285,14 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  motion-dom@12.41.0:
-    resolution: {integrity: sha512-Lk3J39fOGg6xNr1KRZsN6usDyBf8aP7MEbUPez1VCughHt79OrP7VGqNrPyFL0riaT7WS8t9DRw1M3BHtM/xKw==}
+  motion-dom@12.42.0:
+    resolution: {integrity: sha512-M63h4n8R+quJdNhBwuLlgxM+OLYa9+I/T2pzDRboB9fLXRdbou+Gw7Zury+SkpaCyACP1JHSjHgZ1EgTkBr30w==}
 
   motion-utils@12.39.0:
     resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
 
-  motion@12.41.0:
-    resolution: {integrity: sha512-avEDKE22rFPJqDr3Ttk7gMQpeaOmNik60NoJ5T0tj+RBCNvz21D3ArY3l4uitoeQ7eIpDqueWaO3pPYFv8JOVA==}
+  motion@12.42.0:
+    resolution: {integrity: sha512-Qhwvu9sVl5/URSq5CNzwMCpSKK8Uhnrwb6VO977kZyj/wOCS7mWebJUnBoHx5cZU1Zv8a9BD5CSICWKAlrLJgA==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -501,9 +501,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  framer-motion@12.41.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  framer-motion@12.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      motion-dom: 12.41.0
+      motion-dom: 12.42.0
       motion-utils: 12.39.0
       tslib: 2.8.1
     optionalDependencies:
@@ -562,15 +562,15 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  motion-dom@12.41.0:
+  motion-dom@12.42.0:
     dependencies:
       motion-utils: 12.39.0
 
   motion-utils@12.39.0: {}
 
-  motion@12.41.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  motion@12.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      framer-motion: 12.41.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      framer-motion: 12.42.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tslib: 2.8.1
     optionalDependencies:
       react: 19.2.7


### PR DESCRIPTION
## Dependency freshness — pnpm safe batch

Automated dependency freshness pass over the **pnpm/JavaScript** side of the repo (Vite + React landing site). Swift/SPM and the Ruby `Gemfile` are out of scope.

### Bumped (safe batch — patch + minor only, no majors)

| Package | Type | Old | New | Changelog |
|---|---|---|---|---|
| `motion` | minor | 12.41.0 | 12.42.0 | https://github.com/motiondivision/motion/releases/tag/v12.42.0 |

`motion` was the **only** outdated dependency in the tree.

### Full outdated list (digest)

| Package | Current | Latest | Category |
|---|---|---|---|
| motion | 12.41.0 | 12.42.0 | minor |

- **Patch:** none
- **Minor:** motion (bumped)
- **Major held back for human action:** none

### Security (`pnpm audit`)

`No known vulnerabilities found` — 0 info / low / moderate / high / critical across 59 dependencies. No advisories, nothing to prioritize.

### Dropped bumps

None. The single bump passed validation.

### Local validation

Ran the same set the web CI (`.github/workflows/pages.yml`) runs:

- `pnpm install` — clean baseline ✅
- `pnpm build` (vite client build + `vite build --ssr` + `node tools/prerender.mjs`) ✅

Build output is byte-identical to the pre-bump baseline (same asset hashes), confirming the bump is non-breaking for this site.

### Notes
- No `.changeset/` in this repo (release is driven by `release-please`), so no changeset added.
- The Pages workflow triggers on push-to-main, not on PRs, so there are no PR-triggered checks to watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
