### PR TITLE
feat(site): improve landing-page SEO (robots, sitemap, meta)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,32 +6,57 @@
   <title>OpenSidecar — Turn your spare Apple devices into second monitors for your Mac (free &amp; open source)</title>
   <meta name="description" content="OpenSidecar is a free, open-source alternative to Apple Sidecar and Duet Display. Turn your spare Apple devices — iPhone and iPad today, Macs on the roadmap — into true extended displays for your Mac over USB or WiFi. Retina-sharp, low latency, with touch and scroll input. No subscription, no dongle, no account." />
   <meta name="keywords" content="iPhone second monitor, iPad external display, Sidecar alternative, Duet Display alternative, free second screen Mac, open source, virtual display macOS, USB second display, use iPhone as monitor" />
-  <link rel="icon" type="image/png" href="/icon-256.png" />
+  <link rel="icon" type="image/png" href="./icon-256.png" />
   <link rel="canonical" href="https://peetzweg.github.io/opensidecar/" />
 
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="OpenSidecar — your spare Apple devices as second monitors for your Mac" />
-  <meta property="og:description" content="Free, open-source Sidecar/Duet alternative. True display extension over USB or WiFi, Retina-sharp, with touch input. No subscription." />
+  <meta property="og:site_name" content="OpenSidecar" />
+  <meta property="og:title" content="OpenSidecar — free, open-source Sidecar/Duet alternative" />
+  <meta property="og:description" content="Use your iPhone or iPad as a second monitor for your Mac. A true extended display over USB or WiFi — Retina-sharp, low latency, with touch and scroll. No subscription, no dongle, no account." />
   <meta property="og:url" content="https://peetzweg.github.io/opensidecar/" />
   <meta property="og:image" content="https://peetzweg.github.io/opensidecar/icon.png" />
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:title" content="OpenSidecar — your spare Apple devices as second monitors for your Mac" />
-  <meta name="twitter:description" content="Free, open-source Sidecar/Duet alternative. True display extension over USB or WiFi." />
+  <meta property="og:image:type" content="image/png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="2048" />
+  <meta property="og:image:alt" content="OpenSidecar app icon" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="OpenSidecar — free, open-source Sidecar/Duet alternative" />
+  <meta name="twitter:description" content="Use your iPhone or iPad as a second monitor for your Mac. True extended display over USB or WiFi — Retina-sharp, low latency, with touch. No subscription, no dongle, no account." />
   <meta name="twitter:image" content="https://peetzweg.github.io/opensidecar/icon.png" />
+  <meta name="twitter:image:alt" content="OpenSidecar app icon" />
 
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "OpenSidecar",
-    "operatingSystem": "macOS, iOS",
+    "alternateName": "Open Sidecar",
+    "operatingSystem": "macOS 14+, iOS 17+",
     "applicationCategory": "UtilitiesApplication",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-    "description": "Free, open-source alternative to Apple Sidecar and Duet Display: use spare Apple devices (iPhone, iPad) as true extended displays for a Mac over USB or WiFi.",
+    "description": "Free, open-source alternative to Apple Sidecar, Duet Display and Luna Display: use your iPhone or iPad as a true second monitor (extended display, not a mirror) for your Mac over USB or WiFi — Retina-sharp, low latency, with touch and scroll input. No subscription, no dongle, no account.",
+    "featureList": [
+      "True extended display via a virtual monitor (not just mirroring)",
+      "Wired USB streaming over the charging cable for lowest latency",
+      "Zero-config WiFi discovery via Bonjour",
+      "Retina / HiDPI (@2x) display matching the device panel",
+      "Touch input: tap to click, drag, two-finger scroll",
+      "Portrait or landscape virtual display",
+      "Hardware H.264 (VideoToolbox) low-latency pipeline",
+      "Self-hosted and private — no servers, accounts or telemetry"
+    ],
     "url": "https://peetzweg.github.io/opensidecar/",
+    "image": "https://peetzweg.github.io/opensidecar/icon.png",
     "downloadUrl": "https://github.com/peetzweg/opensidecar/releases/latest",
-    "license": "https://www.gnu.org/licenses/gpl-3.0.html"
+    "softwareHelp": "https://github.com/peetzweg/opensidecar#quick-start",
+    "isAccessibleForFree": true,
+    "license": "https://www.gnu.org/licenses/gpl-3.0.html",
+    "author": {
+      "@type": "Person",
+      "name": "peetzweg",
+      "url": "https://github.com/peetzweg"
+    }
   }
   </script>
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,6 @@
+# OpenSidecar — free, open-source Sidecar/Duet alternative
+# Allow all crawlers full access.
+User-agent: *
+Allow: /
+
+Sitemap: https://peetzweg.github.io/opensidecar/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://peetzweg.github.io/opensidecar/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://peetzweg.github.io/opensidecar/privacy.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Closes #59

## What & why

The site ranks behind a dead 6-year-old project, so this targets the **real search intent**: a *free, open-source Sidecar / Duet alternative* for using an **iPhone or iPad as a second monitor for a Mac** (USB or WiFi, low latency). The on-page copy and head were already strong; triage flagged the concrete missing pieces — `robots.txt`, `sitemap.xml`, and a `twitter:card` of `summary`. Scope is landing-site SEO only; no native (`Mac/`, `iOS/`) code touched.

## Changes

- **`public/robots.txt`** (new) — allow all crawlers + `Sitemap:` pointing at the canonical sitemap.
- **`public/sitemap.xml`** (new) — homepage + `/privacy.html` (the only two separately-indexable pages).
- **`twitter:card`** → `summary_large_image`; added `og:image` `type`/`width`/`height`/`alt` + `twitter:image:alt` (the referenced `icon.png` is a real, reachable 2048×2048 image at the site root).
- **`og:site_name`** added; **OG/Twitter title+description** sharpened toward the free/open-source Sidecar/Duet-alternative intent.
- **JSON-LD `SoftwareApplication`** enriched with `featureList`, `operatingSystem` versions, `image`, `author`, `isAccessibleForFree`, `softwareHelp` — every claim grounded in the README.
- **Favicon** `href` made relative (`./icon-256.png`) so it resolves under the `/opensidecar/` Pages subpath (was root-absolute → 404 under subpath).

The `<h1>` and section headings in `src/App.tsx` already contain the target terms ("Use your iPhone/iPad as your Mac's second monitor", "free, open-source alternative to Apple Sidecar, Duet Display and Luna Display") and are unchanged.

## Canonical URL & how it lands in `docs/`

Canonical: **`https://peetzweg.github.io/opensidecar/`** (no CNAME/custom domain in the repo; matches `vite.config.ts` comment and existing `<link rel="canonical">`).

`public/` is copied to the `docs/` site root by Vite (`base: "./"`, `outDir: "docs"`); `tools/prerender.mjs` only injects body markup, leaving the head intact; `.github/workflows/pages.yml` runs `pnpm build` and uploads `docs/` on merge to `main` (`docs/` is gitignored / generated, so not committed here).

Verified locally with `pnpm build` — `docs/` root contains `robots.txt`, `sitemap.xml`, and `docs/index.html` has `twitter:card=summary_large_image`, the new OG tags, the enriched JSON-LD, and the prerendered body includes the intent keywords ("second monitor", "alternative to Apple Sidecar", "true extended display", "free, open-source").

## New head SEO block

```html
<title>OpenSidecar — Turn your spare Apple devices into second monitors for your Mac (free &amp; open source)</title>
<meta name="description" content="OpenSidecar is a free, open-source alternative to Apple Sidecar and Duet Display. Turn your spare Apple devices — iPhone and iPad today, Macs on the roadmap — into true extended displays for your Mac over USB or WiFi. Retina-sharp, low latency, with touch and scroll input. No subscription, no dongle, no account." />
<link rel="canonical" href="https://peetzweg.github.io/opensidecar/" />
<meta property="og:type" content="website" />
<meta property="og:site_name" content="OpenSidecar" />
<meta property="og:title" content="OpenSidecar — free, open-source Sidecar/Duet alternative" />
<meta property="og:description" content="Use your iPhone or iPad as a second monitor for your Mac. A true extended display over USB or WiFi — Retina-sharp, low latency, with touch and scroll. No subscription, no dongle, no account." />
<meta property="og:image" content="https://peetzweg.github.io/opensidecar/icon.png" />
<meta property="og:image:type" content="image/png" />
<meta property="og:image:width" content="2048" />
<meta property="og:image:height" content="2048" />
<meta property="og:image:alt" content="OpenSidecar app icon" />
<meta name="twitter:card" content="summary_large_image" />
<meta name="twitter:image:alt" content="OpenSidecar app icon" />
```

## robots.txt

```
User-agent: *
Allow: /

Sitemap: https://peetzweg.github.io/opensidecar/sitemap.xml
```

## sitemap.xml

```xml
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <url><loc>https://peetzweg.github.io/opensidecar/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
  <url><loc>https://peetzweg.github.io/opensidecar/privacy.html</loc><changefreq>monthly</changefreq><priority>0.3</priority></url>
</urlset>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
