### PR TITLE
feat(ios): StoreKit 2 voluntary support / tip purchases

### DIFF
--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -502,6 +502,16 @@ struct SettingsView: View {
                     Text("OpenSidecar needs the Mac app running on a Mac on the same cable or WiFi network. Download it here if you haven't yet.")
                 }
 
+                Section {
+                    NavigationLink {
+                        SupportView()
+                    } label: {
+                        Label("Support OpenSidecar ♥", systemImage: "heart")
+                    }
+                } footer: {
+                    Text("OpenSidecar is free and open source. An optional in-app tip helps fund development — it unlocks nothing, every feature stays free.")
+                }
+
                 Section("About") {
                     LabeledContent("Version", value: version)
                     Link(destination: URL(string: "https://github.com/peetzweg/opensidecar")!) {

--- a/iOS/Support/Support.storekit
+++ b/iOS/Support/Support.storekit
@@ -1,0 +1,143 @@
+{
+  "appPolicies" : {
+    "eula" : "",
+    "policies" : [
+      {
+        "locale" : "en_US",
+        "policyText" : "",
+        "policyURL" : ""
+      }
+    ]
+  },
+  "identifier" : "5B2C3F90",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+    {
+      "displayPrice" : "1.99",
+      "familyShareable" : false,
+      "internalID" : "A1000001",
+      "localizations" : [
+        {
+          "description" : "A small thank-you to support OpenSidecar. Unlocks nothing — every feature stays free.",
+          "displayName" : "Small Tip",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "com.peetzweg.opensidecar.ios.support.tip.2",
+      "referenceName" : "Support Tip (Small)",
+      "type" : "Consumable"
+    },
+    {
+      "displayPrice" : "9.99",
+      "familyShareable" : false,
+      "internalID" : "A1000002",
+      "localizations" : [
+        {
+          "description" : "A generous thank-you to support OpenSidecar. Unlocks nothing — every feature stays free.",
+          "displayName" : "Generous Tip",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "com.peetzweg.opensidecar.ios.support.tip.10",
+      "referenceName" : "Support Tip (Generous)",
+      "type" : "Consumable"
+    }
+  ],
+  "settings" : {
+    "_applicationInternalID" : "0000000000",
+    "_developerTeamID" : "0000000000",
+    "_failTransactionsEnabled" : false,
+    "_lastSynchronizedDate" : 0,
+    "_locale" : "en_US",
+    "_storefront" : "USA",
+    "_storeKitErrors" : [
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Load Products"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Purchase"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Verification"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Store Sync"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Subscription Status"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Transaction"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Manage Subscriptions Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Refund Request Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Offer Code Redeem Sheet"
+      }
+    ]
+  },
+  "subscriptionGroups" : [
+    {
+      "id" : "21000001",
+      "localizations" : [
+
+      ],
+      "name" : "OpenSidecar Support",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "1.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "B1000001",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Support OpenSidecar with a recurring monthly tip. Unlocks nothing — every feature stays free.",
+              "displayName" : "Monthly Support",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.peetzweg.opensidecar.ios.support.monthly",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Monthly Support",
+          "subscriptionGroupID" : "21000001",
+          "type" : "RecurringSubscription"
+        }
+      ]
+    }
+  ],
+  "version" : {
+    "major" : 4,
+    "minor" : 0
+  }
+}

--- a/iOS/Support/SupportStore.swift
+++ b/iOS/Support/SupportStore.swift
@@ -1,0 +1,167 @@
+import Foundation
+import StoreKit
+
+/// StoreKit 2 manager for the voluntary "support / tip" in-app purchases.
+///
+/// These purchases **unlock nothing functionally** — they are purely a way for
+/// users who enjoy OpenSidecar to support its development through Apple's
+/// In-App Purchase system. On a successful purchase we show a transient
+/// thank-you; there is no feature gating anywhere in the app.
+///
+/// ## App Store Connect prerequisite
+/// The product identifiers below must exist in App Store Connect before real
+/// purchases work (until then `Product.products(for:)` returns an empty list,
+/// which `SupportView` surfaces as a friendly "not available yet" message).
+/// Create:
+///   - `com.peetzweg.opensidecar.ios.support.tip.2`   — Consumable (~$2)
+///   - `com.peetzweg.opensidecar.ios.support.tip.10`  — Consumable (~$10)
+///   - `com.peetzweg.opensidecar.ios.support.monthly` — Auto-renewable subscription (~$2 / month)
+///
+/// If you name them differently in App Store Connect, update `SupportProduct`
+/// below to match. The bundle-id prefix (`com.peetzweg.opensidecar.ios`)
+/// mirrors `PRODUCT_BUNDLE_IDENTIFIER` for the iOS target in `project.yml`.
+///
+/// For local testing without App Store Connect, run the app from the
+/// `OpenSidecariOS` scheme with the bundled `Support.storekit` configuration
+/// selected (Edit Scheme → Run → Options → StoreKit Configuration).
+enum SupportProduct: String, CaseIterable {
+    case tipSmall = "com.peetzweg.opensidecar.ios.support.tip.2"
+    case tipLarge = "com.peetzweg.opensidecar.ios.support.tip.10"
+    case monthly  = "com.peetzweg.opensidecar.ios.support.monthly"
+
+    /// All product IDs to request from StoreKit, in display order.
+    static var allIDs: [String] { allCases.map(\.rawValue) }
+
+    /// Short fallback label used only if a product can't be loaded.
+    var fallbackTitle: String {
+        switch self {
+        case .tipSmall: return "Small tip"
+        case .tipLarge: return "Generous tip"
+        case .monthly:  return "Monthly support"
+        }
+    }
+}
+
+/// Error thrown when a StoreKit transaction fails verification.
+enum SupportStoreError: Error {
+    case failedVerification
+}
+
+@MainActor
+final class SupportStore: ObservableObject {
+    /// Loaded products, ordered: small tip, large tip, then subscription.
+    @Published private(set) var products: [Product] = []
+    /// True while the initial product load is in flight.
+    @Published private(set) var isLoadingProducts = false
+    /// The product ID currently being purchased (drives per-row spinners).
+    @Published private(set) var purchasingProductID: String?
+    /// Set after a successful purchase so the UI can show a thank-you.
+    @Published var thankYouShown = false
+    /// User-facing message when products can't be loaded (expected until
+    /// App Store Connect is configured).
+    @Published private(set) var loadError: String?
+    /// Whether the user currently holds the support subscription. Surfaced for
+    /// information only — nothing in the app is gated on it.
+    @Published private(set) var hasActiveSubscription = false
+
+    /// Convenience: the products that are consumable tips.
+    var tipProducts: [Product] {
+        products.filter { $0.type == .consumable }
+    }
+
+    /// Convenience: the auto-renewable subscription product, if loaded.
+    var subscriptionProduct: Product? {
+        products.first { $0.type == .autoRenewable }
+    }
+
+    /// Load the support products from the App Store (or local .storekit file).
+    func loadProducts() async {
+        isLoadingProducts = true
+        loadError = nil
+        defer { isLoadingProducts = false }
+        do {
+            let loaded = try await Product.products(for: SupportProduct.allIDs)
+            // Keep the order defined in SupportProduct.allIDs.
+            let order = SupportProduct.allIDs
+            products = loaded.sorted {
+                (order.firstIndex(of: $0.id) ?? .max) < (order.firstIndex(of: $1.id) ?? .max)
+            }
+            if products.isEmpty {
+                loadError = "Support options aren't available right now. Please try again later."
+            }
+            await refreshSubscriptionStatus()
+        } catch {
+            loadError = "Couldn't load support options. Please try again later."
+            Log.info("SupportStore: failed to load products: \(error.localizedDescription)")
+        }
+    }
+
+    /// Attempt to purchase a product. Handles success / user-cancel / pending.
+    func purchase(_ product: Product) async {
+        purchasingProductID = product.id
+        defer { purchasingProductID = nil }
+        do {
+            let result = try await product.purchase()
+            switch result {
+            case .success(let verification):
+                let transaction = try checkVerified(verification)
+                // Nothing to unlock — just acknowledge and finish so the
+                // payment completes and StoreKit stops re-delivering it.
+                await transaction.finish()
+                thankYouShown = true
+                await refreshSubscriptionStatus()
+            case .userCancelled:
+                // No-op: the user backed out. Don't show an error.
+                break
+            case .pending:
+                // e.g. Ask to Buy / SCA. The transaction will arrive later via
+                // Transaction.updates; nothing for us to unlock so we simply
+                // don't show a thank-you yet.
+                break
+            @unknown default:
+                break
+            }
+        } catch {
+            Log.info("SupportStore: purchase failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Verify a StoreKit transaction result, unwrapping the signed payload.
+    private func checkVerified<T>(_ result: VerificationResult<T>) throws -> T {
+        switch result {
+        case .unverified:
+            throw SupportStoreError.failedVerification
+        case .verified(let safe):
+            return safe
+        }
+    }
+
+    /// Refresh whether the user holds the support subscription. Informational
+    /// only — no functionality depends on this.
+    func refreshSubscriptionStatus() async {
+        var active = false
+        for await result in Transaction.currentEntitlements {
+            if case .verified(let transaction) = result,
+               transaction.productID == SupportProduct.monthly.rawValue,
+               transaction.revocationDate == nil {
+                active = true
+            }
+        }
+        hasActiveSubscription = active
+    }
+
+    /// Listen for transactions that arrive outside an explicit purchase call
+    /// (e.g. a previously pending "Ask to Buy" being approved, or renewals).
+    /// Call once from the view's `.task`. Returns a Task the caller can cancel.
+    func listenForTransactions() -> Task<Void, Never> {
+        Task.detached { [weak self] in
+            for await result in Transaction.updates {
+                guard let self else { continue }
+                if case .verified(let transaction) = result {
+                    await transaction.finish()
+                    await self.refreshSubscriptionStatus()
+                }
+            }
+        }
+    }
+}

--- a/iOS/Support/SupportView.swift
+++ b/iOS/Support/SupportView.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+import StoreKit
+
+/// Voluntary "support OpenSidecar" screen. Lists the tip / subscription tiers
+/// loaded from StoreKit. Buying any of them **unlocks nothing** — it's purely a
+/// thank-you channel for users who want to chip in. Prices are taken from the
+/// loaded `Product.displayPrice` (localized by App Store / .storekit), never
+/// hardcoded.
+struct SupportView: View {
+    @StateObject private var store = SupportStore()
+    @State private var updatesTask: Task<Void, Never>?
+
+    var body: some View {
+        Form {
+            Section {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Support OpenSidecar")
+                        .font(.title2.bold())
+                    Text("OpenSidecar is free and open source, with no account and no subscription required to use it. If it's saved you the price of a second monitor — or you just want to keep it going — a small voluntary tip helps fund development.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Text("These purchases unlock nothing — every feature stays free for everyone. They're just a thank-you.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+
+            if store.isLoadingProducts {
+                Section {
+                    HStack {
+                        ProgressView()
+                        Text("Loading support options…")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } else if store.products.isEmpty {
+                Section {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label("Support options aren't available right now.", systemImage: "heart.slash")
+                            .font(.subheadline)
+                        Text(store.loadError ?? "Please try again later.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                        Button("Retry") {
+                            Task { await store.loadProducts() }
+                        }
+                        .font(.footnote)
+                    }
+                    .padding(.vertical, 4)
+                }
+            } else {
+                if !store.tipProducts.isEmpty {
+                    Section {
+                        ForEach(store.tipProducts) { product in
+                            SupportTierRow(product: product,
+                                           isPurchasing: store.purchasingProductID == product.id) {
+                                Task { await store.purchase(product) }
+                            }
+                        }
+                    } header: {
+                        Text("One-time tip")
+                    } footer: {
+                        Text("A single thank-you. Tip as many times as you like.")
+                    }
+                }
+
+                if let subscription = store.subscriptionProduct {
+                    Section {
+                        SupportTierRow(product: subscription,
+                                       isPurchasing: store.purchasingProductID == subscription.id) {
+                            Task { await store.purchase(subscription) }
+                        }
+                    } header: {
+                        Text("Monthly support")
+                    } footer: {
+                        Text(store.hasActiveSubscription
+                             ? "You're currently supporting OpenSidecar monthly — thank you! Manage or cancel anytime in the App Store. Auto-renews until cancelled."
+                             : "Recurring monthly support. Auto-renews until cancelled; manage anytime in the App Store.")
+                    }
+                }
+            }
+        }
+        .navigationTitle("Support")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            updatesTask = store.listenForTransactions()
+            await store.loadProducts()
+        }
+        .onDisappear { updatesTask?.cancel() }
+        .alert("Thank you! ♥", isPresented: $store.thankYouShown) {
+            Button("You're welcome", role: .cancel) { }
+        } message: {
+            Text("Your support means a lot and helps keep OpenSidecar free and open source.")
+        }
+    }
+}
+
+/// A single purchasable tier: title, description, price, and a buy button.
+private struct SupportTierRow: View {
+    let product: Product
+    let isPurchasing: Bool
+    let onBuy: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(product.displayName)
+                    .font(.body.weight(.medium))
+                if !product.description.isEmpty {
+                    Text(product.description)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: 12)
+            Button(action: onBuy) {
+                if isPurchasing {
+                    ProgressView()
+                        .frame(minWidth: 64)
+                } else {
+                    Text(product.displayPrice)
+                        .font(.body.weight(.semibold))
+                        .frame(minWidth: 64)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(isPurchasing)
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -10,6 +10,13 @@ schemes:
     build:
       targets:
         OpenSidecariOS: all
+    run:
+      # Use the bundled StoreKit configuration so the support / tip in-app
+      # purchases can be exercised in the simulator WITHOUT App Store Connect.
+      # In production builds StoreKit ignores this and talks to the real App
+      # Store. See iOS/Support/SupportStore.swift for the product IDs to create
+      # in App Store Connect.
+      storeKitConfiguration: iOS/Support/Support.storekit
 # DEVELOPMENT_TEAM comes from the environment (see generate.sh / .env) so no
 # personal team ID lives in the repo. Unset = unsigned, fine for CI.
 settings:


### PR DESCRIPTION
Closes #57

## What this adds (iOS only)

A voluntary **Support OpenSidecar** feature backed by **StoreKit 2**. Purchasing **unlocks nothing** — there is no feature gating anywhere. It is purely an optional way for users to support development; every feature stays free and open source. On success the user sees a thank-you alert.

- **`iOS/Support/SupportStore.swift`** — `@MainActor ObservableObject` that:
  - loads products via `Product.products(for:)`
  - purchases via `product.purchase()`, verifies the `Transaction` (`checkVerified`) and calls `transaction.finish()`
  - handles `userCancelled` and `pending` gracefully (no error shown)
  - listens to `Transaction.updates`, and surfaces the subscription entitlement via `Transaction.currentEntitlements` **for information only** (no gating)
- **`iOS/Support/SupportView.swift`** — SwiftUI screen: intro/thanks copy, the three tiers with prices taken from `Product.displayPrice` (never hardcoded), buy buttons with per-row spinners, a thank-you alert, and graceful "support options aren't available right now" messaging (expected until App Store Connect is set up) with a Retry.
- **`iOS/Support/Support.storekit`** — local StoreKit configuration defining the three products, wired into the `OpenSidecariOS` scheme.
- **Entry point** — a discreet **"Support OpenSidecar ♥"** row added to the existing iOS `SettingsView` (the shake-to-open settings sheet), navigating to `SupportView`. The core full-screen receiver UX is untouched.
- **`project.yml`** — expanded the `OpenSidecariOS` scheme with `run.storeKitConfiguration: iOS/Support/Support.storekit`. New files under `iOS/Support/` are auto-picked up by the existing `iOS` source glob. iOS deployment target is already 17.0 (StoreKit 2 needs 15+).

## App Store Connect prerequisite (human action — @peetzweg)

The maintainer must create these products in App Store Connect before real purchases work. The IDs are defined as constants in `SupportStore.swift` (`SupportProduct`); rename there if you choose different IDs:

| Product ID | Type | Approx. price |
| --- | --- | --- |
| `com.peetzweg.opensidecar.ios.support.tip.2` | Consumable | ~$2 |
| `com.peetzweg.opensidecar.ios.support.tip.10` | Consumable | ~$10 |
| `com.peetzweg.opensidecar.ios.support.monthly` | Auto-renewable subscription | ~$2 / month |

The prefix matches `PRODUCT_BUNDLE_IDENTIFIER` for the iOS target. Until these exist, `Product.products(for:)` returns empty and the UI shows the friendly "not available" state.

## Testing locally (no App Store Connect needed)

`Support.storekit` is referenced by the `OpenSidecariOS` scheme's Run config, so running the app in the simulator exercises the full flow (load products → buy → verify → finish → thank-you) against the bundled test products. If the reference doesn't pick up: Edit Scheme → Run → Options → StoreKit Configuration → `Support.storekit`.

## Scope

- **iOS only.** The Mac app is not on the Mac App Store, so desktop support stays Ko-fi and should be a **separate issue** (the loop can't create issues — see the issue comment).
- No StoreKit framework dependency added (StoreKit 2 ships in the SDK; `import StoreKit`).
- Mac app, web/landing site, and video-pipeline code untouched.

## Compiles

```
xcodebuild -scheme OpenSidecariOS -destination 'generic/platform=iOS Simulator' -configuration Debug build
** BUILD SUCCEEDED **
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)