### PR TITLE
feat(mac): scaffold Sparkle auto-update with Pages-hosted appcast

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Lets the build-mac job dispatch the Pages deploy after committing the
+  # Sparkle appcast (a GITHUB_TOKEN push won't auto-trigger pages.yml).
+  actions: write
 
 # Serialize release runs on the same ref so two quick merges can't race two
 # uploads. Never cancel an in-flight run — it may be mid-upload to TestFlight.
@@ -110,3 +113,67 @@ jobs:
         run: |
           gh release upload "${{ needs.release-please.outputs.tag_name }}" \
             build/export/OpenSidecar.dmg
+
+      # --- Sparkle auto-update: generate + publish the appcast (issue #52) ---
+      # Builds appcast.xml from the just-released, notarized DMG and commits it
+      # to public/appcast.xml on main. The Pages workflow (pages.yml) triggers
+      # on public/** changes, copies public/ into docs/ via the Vite build, and
+      # deploys it — so https://peetzweg.github.io/opensidecar/appcast.xml (the
+      # SUFeedURL in project.yml) resolves.
+      #
+      # No-ops gracefully until the maintainer adds the SPARKLE_PRIVATE_KEY
+      # secret (the EdDSA private key from Sparkle's `generate_keys`), so this
+      # never hard-fails a release before auto-update is switched on.
+      - name: Publish Sparkle appcast to GitHub Pages
+        if: ${{ secrets.SPARKLE_PRIVATE_KEY != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          # Sparkle release that ships the generate_appcast / sign_update tools.
+          SPARKLE_TOOLS_VERSION: "2.6.4"
+        run: |
+          set -euo pipefail
+
+          # Sparkle's CLI tools (generate_appcast, sign_update) ship in the
+          # official release tarball — download the matching version.
+          curl -fsSL -o /tmp/sparkle.tar.xz \
+            "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_TOOLS_VERSION}/Sparkle-${SPARKLE_TOOLS_VERSION}.tar.xz"
+          mkdir -p /tmp/sparkle && tar -xf /tmp/sparkle.tar.xz -C /tmp/sparkle
+          GEN_APPCAST="$(find /tmp/sparkle -name generate_appcast -type f | head -1)"
+          echo "Using $GEN_APPCAST"
+
+          # The EdDSA private key (CI secret) → file for --ed-key-file.
+          printf '%s' "$SPARKLE_PRIVATE_KEY" > /tmp/sparkle_ed_priv
+
+          # generate_appcast wants a directory of update archives. Point the
+          # download links at the GitHub Release assets where the DMG lives.
+          mkdir -p /tmp/appcast-updates
+          cp build/export/OpenSidecar.dmg /tmp/appcast-updates/
+
+          "$GEN_APPCAST" \
+            --ed-key-file /tmp/sparkle_ed_priv \
+            --download-url-prefix "https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG_NAME}/" \
+            -o /tmp/appcast-updates/appcast.xml \
+            /tmp/appcast-updates
+
+          # Commit the feed into public/ on main; Pages picks it up from there.
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git checkout main
+          mkdir -p public
+          cp /tmp/appcast-updates/appcast.xml public/appcast.xml
+          rm -f /tmp/sparkle_ed_priv
+          if ! git diff --quiet -- public/appcast.xml; then
+            git add public/appcast.xml
+            git commit -m "chore(release): publish Sparkle appcast for ${TAG_NAME} [skip ci]"
+            git push origin main
+            # Pushes made with GITHUB_TOKEN do NOT trigger other workflows
+            # (GitHub blocks recursive runs), so kick the Pages deploy
+            # explicitly via its workflow_dispatch entry point.
+            gh workflow run pages.yml --ref main || \
+              echo "could not dispatch pages.yml — deploy it manually"
+          else
+            echo "appcast.xml unchanged — nothing to publish"
+          fi

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import Network
+import Combine
+import Sparkle
 
 /// How the app presents itself. One bundle, switched at runtime via the
 /// activation policy — like Raycast/Hammerspoon style background agents.
@@ -25,7 +27,7 @@ struct OpenSidecarMacApp: App {
             get: { controller.presentation == .menuBar },
             set: { _ in }
         )) {
-            ContentView(controller: controller)
+            ContentView(controller: controller, updater: appDelegate.updater)
         } label: {
             Image(systemName: controller.running
                   ? "rectangle.on.rectangle.fill" : "rectangle.on.rectangle")
@@ -35,7 +37,18 @@ struct OpenSidecarMacApp: App {
 }
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    // Sparkle's standard updater. `startingUpdater: true` boots the updater
+    // immediately so scheduled background checks (SUEnableAutomaticChecks)
+    // run; the menu item drives manual "Check for Updates…". Held for the
+    // app's lifetime here so every window (menu bar + control window) shares
+    // one updater instance.
+    let updater = SPUStandardUpdaterController(
+        startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Hand the updater to the control window, which is built outside the
+        // SwiftUI App scene (NSHostingView), so it can offer the same button.
+        MainWindow.updater = updater
         let presentation = SenderController.shared.presentation
         NSApp.setActivationPolicy(presentation == .dock ? .regular : .accessory)
         if presentation != .menuBar {
@@ -56,6 +69,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 @MainActor
 enum MainWindow {
     private static var window: NSWindow?
+    // Set once at launch by AppDelegate so the control window can share the
+    // app's single Sparkle updater.
+    static var updater: SPUStandardUpdaterController?
 
     static func show() {
         if window == nil {
@@ -65,7 +81,8 @@ enum MainWindow {
                 backing: .buffered, defer: false)
             w.title = "OpenSidecar"
             w.contentView = NSHostingView(
-                rootView: ContentView(controller: SenderController.shared))
+                rootView: ContentView(controller: SenderController.shared,
+                                      updater: updater))
             w.isReleasedWhenClosed = false
             w.center()
             window = w
@@ -587,6 +604,9 @@ final class PermissionMonitor: ObservableObject {
 struct ContentView: View {
     @ObservedObject var controller: SenderController
     @StateObject private var permissions = PermissionMonitor()
+    // Optional so the view still compiles/previews without an updater (e.g.
+    // if Sparkle ever fails to start); the button just disables itself then.
+    let updater: SPUStandardUpdaterController?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -736,6 +756,9 @@ struct ContentView: View {
                     .font(.callout)
                     .lineLimit(1)
                 Spacer()
+                if let updater {
+                    CheckForUpdatesView(updater: updater)
+                }
                 Button("Quit") { NSApp.terminate(nil) }
                     .controlSize(.small)
             }
@@ -774,6 +797,36 @@ struct ContentView: View {
                 .controlSize(.small)
             }
         }
+    }
+}
+
+/// "Check for Updates…" button wired to Sparkle. Follows Sparkle 2's
+/// documented SwiftUI pattern: a small view model publishes the updater's
+/// `canCheckForUpdates` so the button disables itself while a check is
+/// already running (or the updater isn't ready).
+@MainActor
+final class CheckForUpdatesViewModel: ObservableObject {
+    @Published var canCheckForUpdates = false
+
+    init(updater: SPUUpdater) {
+        updater.publisher(for: \.canCheckForUpdates)
+            .assign(to: &$canCheckForUpdates)
+    }
+}
+
+struct CheckForUpdatesView: View {
+    @ObservedObject private var viewModel: CheckForUpdatesViewModel
+    private let updater: SPUUpdater
+
+    init(updater: SPUStandardUpdaterController) {
+        self.updater = updater.updater
+        self.viewModel = CheckForUpdatesViewModel(updater: updater.updater)
+    }
+
+    var body: some View {
+        Button("Check for Updates…") { updater.checkForUpdates() }
+            .controlSize(.small)
+            .disabled(!viewModel.canCheckForUpdates)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -247,13 +247,56 @@ Tracked as [roadmap issues](https://github.com/peetzweg/opensidecar/issues?q=is%
 
 Done: prebuilt releases, built-in USB connectivity (no helper tools), WiFi via Bonjour, portrait mode, touch + two-finger scroll, performance overlay, iPad support, multiple devices at once ([#8](https://github.com/peetzweg/opensidecar/issues/8) — every connected device becomes its own extended display).
 
+## Auto-update (macOS app)
+
+The macOS app updates itself with [Sparkle](https://sparkle-project.org) —
+an open-source framework, **not** a hosted service. Update checks hit only
+our own infrastructure:
+
+- The app reads an **appcast** feed hosted on this GitHub Pages site:
+  `https://peetzweg.github.io/opensidecar/appcast.xml` (`SUFeedURL` in
+  `project.yml`).
+- The release workflow (`.github/workflows/release.yml`, `build-mac` job)
+  runs Sparkle's `generate_appcast` against the notarized
+  `OpenSidecar.dmg`, signs it with the EdDSA key, commits the result to
+  `public/appcast.xml`, and dispatches the Pages deploy — so the published
+  feed points download links at the GitHub Release assets.
+- Sparkle verifies both the EdDSA signature and Apple's notarization before
+  installing. The app checks automatically in the background
+  (`SUEnableAutomaticChecks`) and offers a manual **"Check for Updates…"**
+  button next to **Quit** in the menu-bar window.
+
+### Maintainer prerequisites (before auto-update goes live)
+
+Auto-update is **scaffolded but inert** until the signing keys are in place.
+The private signing key is **never** committed — it lives only as a CI
+secret. To switch it on:
+
+1. **Generate the key pair.** Run Sparkle's `generate_keys` once (it ships
+   in the Sparkle SPM artifact bundle and in the release tarball at
+   `bin/generate_keys`). It prints a **public** key and stores the
+   **private** key in your login keychain.
+2. **Public key →** paste it into `SUPublicEDKey` in `project.yml` (replace
+   the `REPLACE_WITH_SUPUBLICEDKEY_FROM_generate_keys` placeholder), then
+   re-run `xcodegen generate` and commit.
+3. **Private key →** add it as the `SPARKLE_PRIVATE_KEY` GitHub Actions
+   secret (export it with `generate_keys -x private_key.pem` if needed). The
+   appcast step in `release.yml` no-ops gracefully while this secret is
+   absent, so releases keep working until you're ready.
+4. The **first appcast publishes on the next release** after both keys are
+   set. Confirm `https://peetzweg.github.io/opensidecar/appcast.xml`
+   resolves, then **test the full update flow on a real signed/notarized
+   build** (check → download → verify → relaunch) — this can't be validated
+   in CI.
+
 ## Contributing
 
 Issues and PRs are very welcome — especially for the roadmap items above.
-The codebase is intentionally small: ~4 Swift files per platform, no
-dependencies. The [How it works](#how-it-works) section above is the
-architecture doc; see `Mac/CGVirtualDisplayPrivate.h` for the private API
-surface.
+The codebase is intentionally small: ~4 Swift files per platform, with
+[Sparkle](https://sparkle-project.org) (SPM) as the macOS app's only
+runtime dependency, for auto-update. The [How it works](#how-it-works)
+section above is the architecture doc; see `Mac/CGVirtualDisplayPrivate.h`
+for the private API surface.
 
 Releases are automated with
 [release-please](https://github.com/googleapis/release-please): use

--- a/project.yml
+++ b/project.yml
@@ -1,6 +1,16 @@
 name: OpenSidecar
 options:
   createIntermediateGroups: true
+# Swift Package Manager dependencies. Sparkle powers the macOS app's
+# out-of-store auto-update (issue #52); it's an embedded open-source
+# framework + CLI tooling, not a hosted service — the appcast feed and the
+# DMG are served from infrastructure we already own (GitHub Pages + Releases).
+packages:
+  Sparkle:
+    url: https://github.com/sparkle-project/Sparkle
+    # 2.x is the current major (latest 2.9.x as of 2026-06) and the first
+    # Sparkle line to support SPM. `from:` allows compatible 2.x updates.
+    from: "2.6.0"
 schemes:
   OpenSidecarMac:
     build:
@@ -29,6 +39,8 @@ targets:
     deploymentTarget: "14.0"
     sources:
       - Mac
+    dependencies:
+      - package: Sparkle
     info:
       path: Mac/Info.plist
       properties:
@@ -40,6 +52,20 @@ targets:
         NSLocalNetworkUsageDescription: OpenSidecar connects to your iPad or iPhone over the local network in WiFi mode.
         NSBonjourServices: ["_opensidecar._tcp"]
         LSApplicationCategoryType: public.app-category.utilities
+        # --- Sparkle auto-update (issue #52) ---
+        # The appcast feed is hosted on the existing GitHub Pages site
+        # (per maintainer decision). The release workflow publishes
+        # appcast.xml so this URL resolves — see .github/workflows/release.yml.
+        SUFeedURL: https://peetzweg.github.io/opensidecar/appcast.xml
+        # PLACEHOLDER — auto-update will NOT verify/install until this is set.
+        # The MAINTAINER must run Sparkle's `generate_keys` (ships with the
+        # Sparkle SPM artifact / release tarball), then paste the printed
+        # PUBLIC EdDSA key here, and add the matching PRIVATE key as the
+        # `SPARKLE_PRIVATE_KEY` GitHub Actions secret (used to sign the
+        # appcast in CI). The private key must NEVER be committed.
+        SUPublicEDKey: REPLACE_WITH_SUPUBLICEDKEY_FROM_generate_keys
+        # Check for updates automatically in the background on a schedule.
+        SUEnableAutomaticChecks: true
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.peetzweg.opensidecar.mac


### PR DESCRIPTION
## What this does

Scaffolds **out-of-store auto-update** for the macOS app using **[Sparkle](https://sparkle-project.org)** (open-source framework + CLI tooling — not a hosted service), with the appcast feed served from the **existing GitHub Pages site**, per @peetzweg's decision in #52 ("Sparkle it is. Let's put the xml on the github pages deployed page").

This is a **DRAFT** — the feature is scaffolded but **inert** until the maintainer adds the signing keys and tests on-device (see checklist below).

### Changes

**`project.yml`**
- Adds Sparkle to `packages:` (`https://github.com/sparkle-project/Sparkle`, `from: "2.6.0"` — 2.x is the current major; SPM resolves the latest 2.9.x) and to the `OpenSidecarMac` target's `dependencies:`.
- Adds Info.plist keys to the Mac target's `info.properties`:
  - `SUFeedURL` = `https://peetzweg.github.io/opensidecar/appcast.xml`
  - `SUPublicEDKey` = `REPLACE_WITH_SUPUBLICEDKEY_FROM_generate_keys` (**PLACEHOLDER**, commented — maintainer pastes the real public key from `generate_keys`)
  - `SUEnableAutomaticChecks` = `true` (background checks on a schedule)

**`Mac/OpenSidecarMacApp.swift`**
- `SPUStandardUpdaterController(startingUpdater: true, …)` owned by `AppDelegate`, shared with the menu-bar window and the control window.
- A **"Check for Updates…"** button placed next to the existing **Quit** button in the `MenuBarExtra` window; uses the standard Sparkle 2 SwiftUI pattern (a small view model publishing `canCheckForUpdates`, `.disabled(!canCheckForUpdates)`, `updater.checkForUpdates()`).

**`.github/workflows/release.yml`** (`build-mac` job, after the DMG is notarized + uploaded)
- New step **"Publish Sparkle appcast to GitHub Pages"**:
  - Downloads Sparkle's release tarball to get `generate_appcast` (`SPARKLE_TOOLS_VERSION: 2.6.4`).
  - Runs `generate_appcast --ed-key-file <private key from secret> --download-url-prefix <Release assets URL>` against the notarized `OpenSidecar.dmg`.
  - Commits the result to **`public/appcast.xml`** on `main`, then dispatches the Pages deploy.
  - **Secret-guarded**: `if: ${{ secrets.SPARKLE_PRIVATE_KEY != '' }}` — no-ops gracefully until the maintainer adds the key, so releases never hard-fail.
  - **No private key is invented or committed** — only the `${{ secrets.SPARKLE_PRIVATE_KEY }}` reference is wired.

**`README.md`** — Auto-update section + maintainer prerequisites.

### How the appcast reaches GitHub Pages

`pages.yml` builds the Vite site into `docs/` and copies `public/**` into it (`docs/` is git-ignored and built fresh; `vite.config.ts` → `outDir: docs`, `base: "./"`). So the release job writes **`public/appcast.xml`** → the Vite build copies it to `docs/appcast.xml` → Pages deploys it → **`https://peetzweg.github.io/opensidecar/appcast.xml`** resolves (matching `SUFeedURL`). Because a `GITHUB_TOKEN` push doesn't auto-trigger other workflows, the release job explicitly `gh workflow run pages.yml` after committing (needs the added `actions: write` permission).

### Build verification

`xcodegen generate` then a host build (`CODE_SIGNING_ALLOWED=NO`), Sparkle 2.9.3 resolved + linked:

```
** BUILD SUCCEEDED **
```

The actual update/download/verify/relaunch flow **cannot** be validated headlessly — it needs the real signing key + a notarized release + an on-device run.

---

## ⚠️ Before this can go live (maintainer)

- [ ] **Generate the key pair**: run Sparkle's `generate_keys` (ships in the SPM artifact bundle / release tarball `bin/`).
- [ ] **Public key → `SUPublicEDKey`** in `project.yml` (replace the `REPLACE_WITH_…` placeholder), re-run `xcodegen generate`, commit.
- [ ] **Private key → `SPARKLE_PRIVATE_KEY`** GitHub Actions secret (the appcast step no-ops until this exists). **Never commit it.**
- [ ] **Confirm the Pages appcast URL** resolves after the first release: `https://peetzweg.github.io/opensidecar/appcast.xml`.
- [ ] **On-device test** the full **check → download → verify → relaunch** flow on a real signed/notarized build.

The first appcast publishes on the **next release** after both keys are in place. Feed hosting = **GitHub Pages** per the maintainer's decision in #52.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)
