### PR TITLE
fix(mac): stop CPU leak that creeps up across sleep/wake (#75)

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -146,6 +146,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private let localCursor = UserDefaults.standard.object(forKey: "localCursor") == nil
         || UserDefaults.standard.bool(forKey: "localCursor")
     private var cursorTimer: DispatchSourceTimer?
+    private var cursorImageTimer: DispatchSourceTimer?
     private var lastCursorSent: (x: Double, y: Double, visible: Bool) = (-1, -1, false)
     private var lastCursorPNGHash = 0
     private var captureDisplayID: CGDirectDisplayID = 0
@@ -372,6 +373,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         stopped = true
         cursorTimer?.cancel()
         cursorTimer = nil
+        cursorImageTimer?.cancel()
+        cursorImageTimer = nil
         stream?.stopCapture { _ in }
         stream = nil
         connection?.cancel()
@@ -615,6 +618,27 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         scheduleCursorImagePoll()
     }
 
+    /// Sprite changes (arrow ↔ I-beam ↔ resize…) must land fast or the wrong
+    /// cursor shows over hot areas — poll at 30Hz on the main thread (NSCursor
+    /// is AppKit), hash the raw bitmap, and only PNG-encode + send on change.
+    ///
+    /// A dedicated timer (cancelled+replaced here, like cursorTimer above) — not
+    /// a self-rescheduling asyncAfter chain. Every rebuild re-enters
+    /// startCursorEcho, and sleep/wake rebuilds happen often; a recursive chain
+    /// guarded only by `stopped` would stack one extra 30Hz main-thread
+    /// TIFF-encode loop per rebuild, creeping CPU to ~50% until a restart (#75).
+    private func scheduleCursorImagePoll() {
+        cursorImageTimer?.cancel()
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + 0.033, repeating: .milliseconds(33))
+        timer.setEventHandler { [weak self] in
+            guard let self, !self.stopped, self.localCursor else { return }
+            self.pollCursorImage()
+        }
+        timer.resume()
+        cursorImageTimer = timer
+    }
+
     private func pollCursorPosition() {
         guard connectionReady, captureDisplayID != 0,
               let loc = CGEvent(source: nil)?.location else { return }
@@ -631,17 +655,6 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         } else if lastCursorSent.visible {
             lastCursorSent.visible = false
             sendJSONFrame("{\"type\":\"cursor\",\"v\":0}")
-        }
-    }
-
-    /// Sprite changes (arrow ↔ I-beam ↔ resize…) must land fast or the wrong
-    /// cursor shows over hot areas — poll at 30Hz on the main thread (NSCursor
-    /// is AppKit), hash the raw bitmap, and only PNG-encode + send on change.
-    private func scheduleCursorImagePoll() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.033) { [weak self] in
-            guard let self, !self.stopped, self.localCursor else { return }
-            self.pollCursorImage()
-            self.scheduleCursorImagePoll()
         }
     }
 

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -121,6 +121,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private var needsKeyframe = true
     private var connectionReady = false
     private var stopped = false
+    // The liveness monitors are self-rescheduling chains guarded only by
+    // `stopped`; arm them at most once per instance so a double start() can't
+    // stack parallel loops (the failure mode behind #75). Mirrors the
+    // `monitorsStarted` guard the iOS PhoneReceiver already uses.
+    private var monitorsStarted = false
 
     // Disconnect detection: before the first connection we dial patiently
     // (the user may start the Mac side first); once connected, a device that
@@ -184,8 +189,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     func start() async throws {
         stopped = false
         queue.async { self.connect() }   // dial state lives on `queue`
-        schedulePing()
-        scheduleWatchdog()
+        if !monitorsStarted {
+            monitorsStarted = true
+            schedulePing()
+            scheduleWatchdog()
+        }
 
         // Screen Recording permission: poll until granted. No auto-prompt at
         // launch — the permission panel's Grant button triggers the system


### PR DESCRIPTION
Closes #75.

The local cursor-sprite poll ran as a self-rescheduling `asyncAfter` chain on the main thread, doing `tiffRepresentation` 30×/sec. Its only exit was the `stopped` flag (full app teardown) — but it's kicked off by `startCursorEcho()` inside `startCapture()`, which runs on **every** rebuild. Sleep/wake tears the virtual display out from under the stream and rebuilds, so each wake stacked another parallel 30Hz loop. CPU crept toward ~50% of a core over a day of sleep/wake cycles; a restart reset it. This matches the `sample` in the issue (all cost on main-thread `TIFFRepresentation`).

**Why:** an idle Sidecar session shouldn't sustain 50% CPU — it drains battery and spins fans for nothing, and the only fix users had was `killall`.

**How:** replace the recursive chain with a dedicated `cursorImageTimer` (`DispatchSourceTimer`) that `startCursorEcho` cancels-and-replaces and `stop()` tears down — exactly like the sibling position-poll `cursorTimer` already did. The loop count is now invariant: one, regardless of rebuilds. A second commit adds a `monitorsStarted` guard to `start()` so the ping/watchdog chains (same pattern, currently safe only by being started once) can't regress the same way — mirroring the guard the iOS `PhoneReceiver` already has.

Verified: Mac app builds and runs; the leak's signature was a per-wake step in baseline CPU, which the singleton loop removes.