### PR TITLE
Rename app to OpenDisplay

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,4 +109,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload "${{ needs.release-please.outputs.tag_name }}" \
-            build/export/OpenSidecar.dmg
+            build/export/OpenDisplay.dmg

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -109,7 +109,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private let mode: CaptureMode
     private let quality: StreamQuality
     // Stable per-device serial for the virtual display, so macOS can tell
-    // multiple OpenSidecar monitors apart and persist their arrangement.
+    // multiple OpenDisplay monitors apart and persist their arrangement.
     private let displaySerial: UInt32
 
     // Backpressure: outstanding sends. If the socket can't keep up we drop
@@ -259,8 +259,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // USB sessions can start before lockdown resolves the device name —
         // fall back to the kind from the hello rather than the generic label.
         let displayName = endpointName.hasPrefix("iPhone / iPad")
-            ? "OpenSidecar — \(info.kind)"
-            : "OpenSidecar — \(endpointName)"
+            ? "OpenDisplay — \(info.kind)"
+            : "OpenDisplay — \(endpointName)"
         // Orientation-specific serial: macOS persists the chosen mode per
         // serial, and a portrait mode restored onto a landscape display
         // pillarboxes the desktop INTO the framebuffer (streamed as-is).
@@ -535,7 +535,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 case .noDevice:
                     hint = "Waiting for a USB device — plug in the iPhone or iPad…"
                 case .refused:
-                    hint = "Device found — open the OpenSidecar app on it…"
+                    hint = "Device found — open the OpenDisplay app on it…"
                 default:
                     Log.info("usb dial failed: \(error)")
                     hint = "USB connection failed: \(error.localizedDescription)"

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -63,7 +63,7 @@ enum MainWindow {
                 contentRect: NSRect(x: 0, y: 0, width: 440, height: 540),
                 styleMask: [.titled, .closable, .miniaturizable],
                 backing: .buffered, defer: false)
-            w.title = "OpenSidecar"
+            w.title = "OpenDisplay"
             w.contentView = NSHostingView(
                 rootView: ContentView(controller: SenderController.shared))
             w.isReleasedWhenClosed = false
@@ -596,7 +596,7 @@ struct ContentView: View {
                     .resizable()
                     .frame(width: 44, height: 44)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("OpenSidecar")
+                    Text("OpenDisplay")
                         .font(.title3.bold())
                     Text("Your iPads and iPhones as extra displays")
                         .font(.caption)
@@ -616,7 +616,7 @@ struct ContentView: View {
             Form {
                 Section("Devices") {
                     if controller.deviceEntries.isEmpty {
-                        Text("No devices found — plug one in via USB, or open the OpenSidecar app on a device on this WiFi network.")
+                        Text("No devices found — plug one in via USB, or open the OpenDisplay app on a device on this WiFi network.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -676,7 +676,7 @@ struct ContentView: View {
                         }
                     }
                     if controller.presentation == .background {
-                        Text("No menu bar or Dock icon — streaming keeps running. Open the OpenSidecar app again (Spotlight/Finder) to show this window.")
+                        Text("No menu bar or Dock icon — streaming keeps running. Open the OpenDisplay app again (Spotlight/Finder) to show this window.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -713,7 +713,7 @@ struct ContentView: View {
                         "Local Network",
                         granted: !controller.discovered.isEmpty,
                         uncertain: controller.discovered.isEmpty,
-                        help: "Required for WiFi mode. If no device appears in the Devices list, allow OpenSidecar under Privacy & Security → Local Network on this Mac AND on the device — and keep the OpenSidecar app open there.",
+                        help: "Required for WiFi mode. If no device appears in the Devices list, allow OpenDisplay under Privacy & Security → Local Network on this Mac AND on the device — and keep the OpenDisplay app open there.",
                         anchor: "Privacy_LocalNetwork"
                     )
                 }

--- a/Mac/Usbmux.swift
+++ b/Mac/Usbmux.swift
@@ -105,7 +105,7 @@ enum Usbmux {
         let conn = try await connect(deviceID: deviceID, port: lockdownPort, queue: queue)
         defer { conn.cancel() }
         let request = try PropertyListSerialization.data(fromPropertyList: [
-            "Request": "GetValue", "Key": "DeviceName", "Label": "OpenSidecar",
+            "Request": "GetValue", "Key": "DeviceName", "Label": "OpenDisplay",
         ] as [String: Any], format: .xml, options: 0)
         var packet = withUnsafeBytes(of: UInt32(request.count).bigEndian) { Data($0) }
         packet.append(request)
@@ -163,8 +163,8 @@ enum Usbmux {
 
     static func send(_ message: [String: Any], on conn: NWConnection) async throws {
         var message = message
-        message["ProgName"] = "OpenSidecar"
-        message["ClientVersionString"] = "OpenSidecar"
+        message["ProgName"] = "OpenDisplay"
+        message["ClientVersionString"] = "OpenDisplay"
         let body = try PropertyListSerialization.data(
             fromPropertyList: message, format: .xml, options: 0)
         var packet = Data(capacity: 16 + body.count)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-<img src="public/icon.png" width="128" alt="OpenSidecar app icon" />
+<img src="public/icon.png" width="128" alt="OpenDisplay app icon" />
 
-# OpenSidecar
+# OpenDisplay
 
 **Turn your spare Apple devices into second monitors for your Mac — free, open source, no subscription.**
 
@@ -11,13 +11,13 @@ alternative to Apple Sidecar, Duet Display, and Luna Display: true extended
 display (not just mirroring), Retina-sharp, over USB or WiFi, with touch and
 scroll input.
 
-[Website](https://peetzweg.github.io/opensidecar/) · [Quick start](#quick-start) · [How it works](#how-it-works) · [FAQ](#faq) · [Contributing](#contributing)
+[Website](https://peetzweg.github.io/opendisplay/) · [Quick start](#quick-start) · [How it works](#how-it-works) · [FAQ](#faq) · [Contributing](#contributing)
 
 </div>
 
 ---
 
-## Why OpenSidecar exists
+## Why OpenDisplay exists
 
 Turning an iPhone or iPad into an external display for a Mac is a solved
 problem — but every existing option has a catch:
@@ -27,7 +27,7 @@ problem — but every existing option has a catch:
 - **Duet Display** moved to a subscription.
 - **Luna Display** requires a hardware dongle.
 
-OpenSidecar is the missing option: a **free, open-source, no-account,
+OpenDisplay is the missing option: a **free, open-source, no-account,
 no-dongle** way to use the iOS device you already own as a true second
 display. If you were about to write your own — don't! Contribute here
 instead; the hard parts (virtual display creation, low-latency H.264
@@ -86,8 +86,8 @@ You need **two apps**: a Mac app (captures and sends) and an iOS app
 
 ### Prebuilt downloads (Mac)
 
-Grab `OpenSidecar.dmg` from the
-[latest release](https://github.com/peetzweg/opensidecar/releases/latest).
+Grab `OpenDisplay.dmg` from the
+[latest release](https://github.com/peetzweg/opendisplay/releases/latest).
 The app is signed with a Developer ID certificate and notarized by Apple, so it
 opens with a plain double-click on macOS 14+ — no Gatekeeper warning. Open the
 `.dmg` and drag the app to Applications.
@@ -113,8 +113,8 @@ app onto your device).
 ### Build
 
 ```sh
-git clone https://github.com/peetzweg/opensidecar.git
-cd opensidecar
+git clone https://github.com/peetzweg/opendisplay.git
+cd opendisplay
 echo "DEVELOPMENT_TEAM=YOURTEAMID" > .env   # your Apple team ID, for signing
 ./generate.sh                               # runs xcodegen with your .env
 xcodebuild -project OpenSidecar.xcodeproj -scheme OpenSidecarMac \
@@ -130,7 +130,7 @@ under Membership, or just pick your team in Xcode's Signing pane.)
 
 ### Run (USB — recommended)
 
-1. Install + open **OpenSidecar** on the iPhone (it listens on port 9000).
+1. Install + open **OpenDisplay** on the iPhone (it listens on port 9000).
 2. On the Mac, run `./run.sh` (or just open the app) — it talks to macOS's
    built-in `usbmuxd` directly and auto-connects over the cable. No tunnel
    tools needed.
@@ -190,7 +190,7 @@ quality-per-bit.
 between your Mac and your device, over your cable or your LAN. No servers,
 no accounts, no analytics. Full details — including what the apps store
 locally and the current WiFi-encryption caveat — on the
-[privacy page](https://peetzweg.github.io/opensidecar/privacy.html).
+[privacy page](https://peetzweg.github.io/opendisplay/privacy.html).
 
 **What's the license? Can I fork it or use it commercially?**
 [GPL-3.0](LICENSE). Use, study, and adapt it freely — commercially too. If
@@ -207,7 +207,7 @@ The capture/streaming pipeline itself uses only public APIs.
 
 ## Comparison
 
-| | OpenSidecar | Apple Sidecar | Duet Display | Luna Display |
+| | OpenDisplay | Apple Sidecar | Duet Display | Luna Display |
 |---|---|---|---|---|
 | Price | **Free, open source** | Free | Subscription | $$$ + dongle |
 | iPhone as display | ✅ | ❌ (iPad only) | ✅ | ✅ |
@@ -219,33 +219,33 @@ The capture/streaming pipeline itself uses only public APIs.
 
 ## Roadmap
 
-Tracked as [roadmap issues](https://github.com/peetzweg/opensidecar/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap) — pick one up if you'd like to contribute!
+Tracked as [roadmap issues](https://github.com/peetzweg/opendisplay/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap) — pick one up if you'd like to contribute!
 
 **Connectivity & distribution**
-- [#16](https://github.com/peetzweg/opensidecar/issues/16) Encrypted WiFi transport with pairing code
+- [#16](https://github.com/peetzweg/opendisplay/issues/16) Encrypted WiFi transport with pairing code
 - [ ] App Store release of the iOS app + notarized Mac downloads
 
 **Input**
-- [#4](https://github.com/peetzweg/opensidecar/issues/4) Apple Pencil with pressure and tilt
-- [#5](https://github.com/peetzweg/opensidecar/issues/5) Right-click and multi-touch gestures
-- [#6](https://github.com/peetzweg/opensidecar/issues/6) Hardware keyboard passthrough
-- [#7](https://github.com/peetzweg/opensidecar/issues/7) On-screen modifier key sidebar
+- [#4](https://github.com/peetzweg/opendisplay/issues/4) Apple Pencil with pressure and tilt
+- [#5](https://github.com/peetzweg/opendisplay/issues/5) Right-click and multi-touch gestures
+- [#6](https://github.com/peetzweg/opendisplay/issues/6) Hardware keyboard passthrough
+- [#7](https://github.com/peetzweg/opendisplay/issues/7) On-screen modifier key sidebar
 
 **Display & media**
-- [#9](https://github.com/peetzweg/opensidecar/issues/9) Resolution & quality settings
-- [#10](https://github.com/peetzweg/opensidecar/issues/10) HEVC encoding
-- [#12](https://github.com/peetzweg/opensidecar/issues/12) Audio forwarding
-- [#17](https://github.com/peetzweg/opensidecar/issues/17) macOS receiver — use another Mac as a display
+- [#9](https://github.com/peetzweg/opendisplay/issues/9) Resolution & quality settings
+- [#10](https://github.com/peetzweg/opendisplay/issues/10) HEVC encoding
+- [#12](https://github.com/peetzweg/opendisplay/issues/12) Audio forwarding
+- [#17](https://github.com/peetzweg/opendisplay/issues/17) macOS receiver — use another Mac as a display
 
 **Experience**
-- [#11](https://github.com/peetzweg/opensidecar/issues/11) Menu bar app mode with auto-connect
-- [#13](https://github.com/peetzweg/opensidecar/issues/13) Battery & lifecycle awareness
+- [#11](https://github.com/peetzweg/opendisplay/issues/11) Menu bar app mode with auto-connect
+- [#13](https://github.com/peetzweg/opendisplay/issues/13) Battery & lifecycle awareness
 
 **Exploratory**
-- [#14](https://github.com/peetzweg/opensidecar/issues/14) Remote access beyond the local network
-- [#15](https://github.com/peetzweg/opensidecar/issues/15) Additional client platforms
+- [#14](https://github.com/peetzweg/opendisplay/issues/14) Remote access beyond the local network
+- [#15](https://github.com/peetzweg/opendisplay/issues/15) Additional client platforms
 
-Done: prebuilt releases, built-in USB connectivity (no helper tools), WiFi via Bonjour, portrait mode, touch + two-finger scroll, performance overlay, iPad support, multiple devices at once ([#8](https://github.com/peetzweg/opensidecar/issues/8) — every connected device becomes its own extended display).
+Done: prebuilt releases, built-in USB connectivity (no helper tools), WiFi via Bonjour, portrait mode, touch + two-finger scroll, performance overlay, iPad support, multiple devices at once ([#8](https://github.com/peetzweg/opendisplay/issues/8) — every connected device becomes its own extended display).
 
 ## Contributing
 

--- a/fastlane/APP_STORE_LISTING.md
+++ b/fastlane/APP_STORE_LISTING.md
@@ -1,7 +1,7 @@
 # App Store Connect listing — reference
 
-Canonical copy for the OpenSidecar iOS app's App Store Connect / TestFlight text
-fields, kept in version control so we know what's live and can edit deliberately.
+Canonical copy for the iOS app's App Store Connect / TestFlight text fields, kept in
+version control so we know what's live and can edit deliberately.
 
 > **Privacy:** the **Feedback email** and any contact addresses are intentionally
 > **not** stored here. Set/maintain those directly in App Store Connect.
@@ -14,7 +14,7 @@ When you change a field in App Store Connect, update it here too.
 
 **Name**
 ```
-OpenSidecar
+OpenDisplay
 ```
 
 **Subtitle** _(max 30 chars)_
@@ -39,14 +39,14 @@ Second monitor for your Mac
 
 **Promotional Text** _(max 170 chars; editable without a new build)_
 ```
-Turn the iPhone or iPad you already own into a real second display for your Mac — free, open source, and private. Works over USB or Wi-Fi.
+Turn the iPhone or iPad you already own into a real second display for your Mac — open source and private. Works over USB or Wi-Fi.
 ```
 
 **Description**
 ```
-OpenSidecar turns your iPhone or iPad into a second display for your Mac.
+OpenDisplay turns your iPhone or iPad into a second display for your Mac.
 
-It's the free, open-source way to put your spare Apple device to work as a real extended monitor — drag windows onto it, keep chat, notes, or logs in view, and gain screen space anywhere you go. It's not a mirror: it's a genuine additional display your Mac treats like any other monitor.
+It's the open-source way to put your spare Apple device to work as a real extended monitor — drag windows onto it, keep chat, notes, or logs in view, and gain screen space anywhere you go. It's not a mirror: it's a genuine additional display your Mac treats like any other monitor.
 
 • Real extended display — arrange it in your Mac's Display settings and drag windows across
 • Connect over USB for the lowest latency, or over Wi-Fi with zero setup
@@ -55,9 +55,9 @@ It's the free, open-source way to put your spare Apple device to work as a real 
 • Works in portrait or landscape
 • Private by design — a direct connection between your own devices, with no accounts, no servers, and no tracking
 
-IMPORTANT: OpenSidecar requires the free companion OpenSidecar app for Mac, running on your computer on the same cable or Wi-Fi network. Get it at https://peetzweg.github.io/opensidecar — without it, this app has nothing to connect to.
+IMPORTANT: OpenDisplay requires the companion OpenDisplay app for Mac, running on your computer on the same cable or Wi-Fi network. Get it at https://peetzweg.github.io/opendisplay — without it, this app has nothing to connect to.
 
-OpenSidecar is open source under the GPL-3.0 license. Read the code, report issues, or contribute at https://github.com/peetzweg/opensidecar
+OpenDisplay is open source under the GPL-3.0 license. Read the code, report issues, or contribute at https://github.com/peetzweg/opendisplay
 ```
 
 **Keywords** _(max 100 chars; comma-separated, no spaces after commas)_
@@ -67,17 +67,17 @@ second monitor,external display,extend screen,monitor,display,screen,ipad as dis
 
 **Support URL**
 ```
-https://peetzweg.github.io/opensidecar
+https://peetzweg.github.io/opendisplay
 ```
 
 **Marketing URL** _(optional)_
 ```
-https://peetzweg.github.io/opensidecar
+https://peetzweg.github.io/opendisplay
 ```
 
 **Privacy Policy URL**
 ```
-https://peetzweg.github.io/opensidecar/privacy.html
+https://peetzweg.github.io/opendisplay/privacy.html
 ```
 
 ---
@@ -86,10 +86,10 @@ https://peetzweg.github.io/opensidecar/privacy.html
 
 **Beta App Description**
 ```
-OpenSidecar turns your iPhone or iPad into a second display for your Mac.
+OpenDisplay turns your iPhone or iPad into a second display for your Mac.
 
-To use this beta you also need the free OpenSidecar app for Mac running on your computer, on the same USB cable or Wi-Fi network. Get it here:
-https://peetzweg.github.io/opensidecar
+To use this beta you also need the companion OpenDisplay app for Mac running on your computer, on the same USB cable or Wi-Fi network. Get it here:
+https://peetzweg.github.io/opendisplay
 
 Once both are running: connect over USB for the lowest latency or over Wi-Fi with no setup, drag windows onto the device, try touch and two-finger scroll, and rotate between portrait and landscape.
 
@@ -102,10 +102,20 @@ Please report anything that looks off — connection drops, latency, image sharp
 
 ## Notes for future edits
 
+- **App name change (2026-06-30):** Apple rejected the previous name "OpenSidecar"
+  under Guideline 5.2.5 — "Sidecar" is confusingly similar to Apple's Sidecar feature.
+  Renamed to **OpenDisplay**. The on-device name lives in `project.yml` (iOS
+  `CFBundleDisplayName`, Mac `PRODUCT_NAME` / `BUNDLE_DISPLAY_NAME`) and **needs a new
+  build** to take effect; the store **Name** field is set in App Store Connect. The repo,
+  Pages site, and bundle IDs (`com.peetzweg.opensidecar.*`) intentionally keep the old
+  slug — bundle IDs are permanent and renaming them would spawn a new ASC app.
 - **Trademark caution:** keep Apple's feature name "Sidecar" and competitor brands
-  ("Duet", "Luna") **out of the Description and Keywords** — Apple review often rejects
-  metadata that uses them. Comparing to those products is fine on the website, not in
-  store metadata. (The app *name* contains "Sidecar" — a separate, already-made call.)
+  ("Duet", "Luna") **out of every field** — name, subtitle, promo text, description,
+  keywords. Comparing to those products is fine on the website, not in store metadata.
+- **No price references (Guideline 2.3.7):** keep "free" / "no cost" / "discounted" out
+  of the subtitle, promotional text, keywords, and especially the **screenshots** — the
+  screenshots are what got flagged. Apple permits price claims only in the Description,
+  but we lead with "open source" (a licensing fact) instead, which reads fine anywhere.
 - The Description states the **Mac-app requirement** on purpose; App Review needs to
   know the app is non-functional without the companion. Keep that line.
 - Field limits: Subtitle ≤ 30, Promotional Text ≤ 170, Keywords ≤ 100 (whole string,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -44,7 +44,7 @@ platform :mac do
       configuration:    "Release",
       export_method:    "developer-id",
       output_directory: "build/export",
-      output_name:      "OpenSidecar",
+      output_name:      "OpenDisplay",
       xcargs:           version_xcargs
     )
     # gym/notarize resolve relative paths against the repo root, but during a
@@ -53,7 +53,7 @@ platform :mac do
     # Keep the fastlane actions on repo-root-relative paths, and cd the shell
     # block to the repo root so every path agrees.
     notarize(
-      package:   "build/export/OpenSidecar.app",
+      package:   "build/export/OpenDisplay.app",
       bundle_id: "com.peetzweg.opensidecar.mac",
       api_key:   key
     )
@@ -63,15 +63,15 @@ platform :mac do
     # step that is flaky in headless CI. Sign the DMG with the Developer ID
     # identity match installed, then notarize + staple it too — so the
     # downloaded disk image itself passes Gatekeeper without a prompt.
-    dmg = "build/export/OpenSidecar.dmg"
+    dmg = "build/export/OpenDisplay.dmg"
     sh(<<~BASH)
       set -euo pipefail
       cd "$(git rev-parse --show-toplevel)"
       rm -rf build/dmg-src
       mkdir -p build/dmg-src
-      cp -R build/export/OpenSidecar.app build/dmg-src/
+      cp -R build/export/OpenDisplay.app build/dmg-src/
       ln -s /Applications build/dmg-src/Applications
-      hdiutil create -volname OpenSidecar -srcfolder build/dmg-src -ov -format UDZO #{dmg}
+      hdiutil create -volname OpenDisplay -srcfolder build/dmg-src -ov -format UDZO #{dmg}
       codesign --force --sign "Developer ID Application" --timestamp #{dmg}
     BASH
     notarize(

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -7,7 +7,7 @@ import Combine
 let deviceKind = UIDevice.current.userInterfaceIdiom == .pad ? "iPad" : "iPhone"
 
 /// Landing page — hosts the Mac app download and explains the two-app setup.
-let macAppURL = URL(string: "https://peetzweg.github.io/opensidecar/")!
+let macAppURL = URL(string: "https://peetzweg.github.io/opendisplay/")!
 
 @main
 struct OpenSidecarPhoneApp: App {
@@ -131,7 +131,7 @@ struct IdleView: View {
                 .frame(width: 132)
 
             VStack(spacing: 6) {
-                Text("OpenSidecar")
+                Text("OpenDisplay")
                     .font(.largeTitle.bold())
                 HStack(spacing: 8) {
                     Circle()
@@ -179,7 +179,7 @@ struct IdleView: View {
 
 // MARK: - First-run onboarding (the Mac app is required to connect)
 
-/// Shown on first launch / while the device has never connected: OpenSidecar
+/// Shown on first launch / while the device has never connected: OpenDisplay
 /// is two apps, and the iOS side is useless without the Mac app running.
 struct OnboardingView: View {
     @Environment(\.dismiss) private var dismiss
@@ -198,7 +198,7 @@ struct OnboardingView: View {
                         Text("One more app to go")
                             .font(.title2.bold())
                             .multilineTextAlignment(.center)
-                        Text("OpenSidecar turns this \(deviceKind) into a second screen for your Mac — but it needs the **OpenSidecar Mac app** running on a Mac connected by the same USB cable or on the same WiFi network.")
+                        Text("OpenDisplay turns this \(deviceKind) into a second screen for your Mac — but it needs the **OpenDisplay Mac app** running on a Mac connected by the same USB cable or on the same WiFi network.")
                             .font(.body)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)
@@ -206,7 +206,7 @@ struct OnboardingView: View {
                     }
 
                     VStack(alignment: .leading, spacing: 14) {
-                        Label("Install the OpenSidecar Mac app on your Mac", systemImage: "1.circle.fill")
+                        Label("Install the OpenDisplay Mac app on your Mac", systemImage: "1.circle.fill")
                         Label("Connect the \(deviceKind) by USB, or join the same WiFi", systemImage: "2.circle.fill")
                         Label("Keep this app open — streaming starts on its own", systemImage: "3.circle.fill")
                     }
@@ -470,7 +470,7 @@ struct SettingsView: View {
                 }
 
                 Section {
-                    Button("Open iOS Settings for OpenSidecar") {
+                    Button("Open iOS Settings for OpenDisplay") {
                         if let url = URL(string: UIApplication.openSettingsURLString) {
                             UIApplication.shared.open(url)
                         }
@@ -478,7 +478,7 @@ struct SettingsView: View {
                 } header: {
                     Text("Permissions")
                 } footer: {
-                    Text("WiFi mode needs Local Network access. If your Mac can't find this \(deviceKind), enable it under Settings → Privacy & Security → Local Network → OpenSidecar. USB mode works without it.")
+                    Text("WiFi mode needs Local Network access. If your Mac can't find this \(deviceKind), enable it under Settings → Privacy & Security → Local Network → OpenDisplay. USB mode works without it.")
                 }
 
                 Section {
@@ -499,20 +499,20 @@ struct SettingsView: View {
                         Label("Get the Mac app", systemImage: "arrow.down.circle")
                     }
                 } footer: {
-                    Text("OpenSidecar needs the Mac app running on a Mac on the same cable or WiFi network. Download it here if you haven't yet.")
+                    Text("OpenDisplay needs the Mac app running on a Mac on the same cable or WiFi network. Download it here if you haven't yet.")
                 }
 
                 Section("About") {
                     LabeledContent("Version", value: version)
-                    Link(destination: URL(string: "https://github.com/peetzweg/opensidecar")!) {
-                        Label("GitHub — peetzweg/opensidecar", systemImage: "link")
+                    Link(destination: URL(string: "https://github.com/peetzweg/opendisplay")!) {
+                        Label("GitHub — peetzweg/opendisplay", systemImage: "link")
                     }
                     Link(destination: macAppURL) {
                         Label("Website", systemImage: "globe")
                     }
                 }
             }
-            .navigationTitle("OpenSidecar")
+            .navigationTitle("OpenDisplay")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -142,7 +142,7 @@ final class PhoneReceiver: ObservableObject {
     // needs an entitlement Apple gates behind approval and personal teams
     // can't get), so this is user-editable in Settings. The USB picker gets
     // the real name host-side via lockdownd regardless.
-    var serviceName = "OpenSidecar"
+    var serviceName = "OpenDisplay"
 
     // Stable per-install identity, advertised in the Bonjour TXT record and
     // sent in every hello. The Mac uses it to recognize "same device, other

--- a/index.html
+++ b/index.html
@@ -3,35 +3,35 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>OpenSidecar — Turn your spare Apple devices into second monitors for your Mac (free &amp; open source)</title>
-  <meta name="description" content="OpenSidecar is a free, open-source alternative to Apple Sidecar and Duet Display. Turn your spare Apple devices — iPhone and iPad today, Macs on the roadmap — into true extended displays for your Mac over USB or WiFi. Retina-sharp, low latency, with touch and scroll input. No subscription, no dongle, no account." />
+  <title>OpenDisplay — Turn your spare Apple devices into second monitors for your Mac (free &amp; open source)</title>
+  <meta name="description" content="OpenDisplay is a free, open-source alternative to Apple Sidecar and Duet Display. Turn your spare Apple devices — iPhone and iPad today, Macs on the roadmap — into true extended displays for your Mac over USB or WiFi. Retina-sharp, low latency, with touch and scroll input. No subscription, no dongle, no account." />
   <meta name="keywords" content="iPhone second monitor, iPad external display, Sidecar alternative, Duet Display alternative, free second screen Mac, open source, virtual display macOS, USB second display, use iPhone as monitor" />
   <link rel="icon" type="image/png" href="./icon-256.png" />
-  <link rel="canonical" href="https://peetzweg.github.io/opensidecar/" />
+  <link rel="canonical" href="https://peetzweg.github.io/opendisplay/" />
 
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
-  <meta property="og:site_name" content="OpenSidecar" />
-  <meta property="og:title" content="OpenSidecar — free, open-source Sidecar/Duet alternative" />
+  <meta property="og:site_name" content="OpenDisplay" />
+  <meta property="og:title" content="OpenDisplay — free, open-source Sidecar/Duet alternative" />
   <meta property="og:description" content="Use your iPhone or iPad as a second monitor for your Mac. A true extended display over USB or WiFi — Retina-sharp, low latency, with touch and scroll. No subscription, no dongle, no account." />
-  <meta property="og:url" content="https://peetzweg.github.io/opensidecar/" />
-  <meta property="og:image" content="https://peetzweg.github.io/opensidecar/icon.png" />
+  <meta property="og:url" content="https://peetzweg.github.io/opendisplay/" />
+  <meta property="og:image" content="https://peetzweg.github.io/opendisplay/icon.png" />
   <meta property="og:image:type" content="image/png" />
   <meta property="og:image:width" content="2048" />
   <meta property="og:image:height" content="2048" />
-  <meta property="og:image:alt" content="OpenSidecar app icon" />
+  <meta property="og:image:alt" content="OpenDisplay app icon" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="OpenSidecar — free, open-source Sidecar/Duet alternative" />
+  <meta name="twitter:title" content="OpenDisplay — free, open-source Sidecar/Duet alternative" />
   <meta name="twitter:description" content="Use your iPhone or iPad as a second monitor for your Mac. True extended display over USB or WiFi — Retina-sharp, low latency, with touch. No subscription, no dongle, no account." />
-  <meta name="twitter:image" content="https://peetzweg.github.io/opensidecar/icon.png" />
-  <meta name="twitter:image:alt" content="OpenSidecar app icon" />
+  <meta name="twitter:image" content="https://peetzweg.github.io/opendisplay/icon.png" />
+  <meta name="twitter:image:alt" content="OpenDisplay app icon" />
 
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
-    "name": "OpenSidecar",
-    "alternateName": "Open Sidecar",
+    "name": "OpenDisplay",
+    "alternateName": "Open Display",
     "operatingSystem": "macOS 14+, iOS 17+",
     "applicationCategory": "UtilitiesApplication",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
@@ -46,10 +46,10 @@
       "Hardware H.264 (VideoToolbox) low-latency pipeline",
       "Self-hosted and private — no servers, accounts or telemetry"
     ],
-    "url": "https://peetzweg.github.io/opensidecar/",
-    "image": "https://peetzweg.github.io/opensidecar/icon.png",
-    "downloadUrl": "https://github.com/peetzweg/opensidecar/releases/latest",
-    "softwareHelp": "https://github.com/peetzweg/opensidecar#quick-start",
+    "url": "https://peetzweg.github.io/opendisplay/",
+    "image": "https://peetzweg.github.io/opendisplay/icon.png",
+    "downloadUrl": "https://github.com/peetzweg/opendisplay/releases/latest",
+    "softwareHelp": "https://github.com/peetzweg/opendisplay#quick-start",
     "isAccessibleForFree": true,
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
     "author": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "opensidecar-site",
+  "name": "opendisplay-site",
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "description": "OpenSidecar landing page (Vite + React + motion). Builds into docs/ for GitHub Pages.",
+  "description": "OpenDisplay landing page (Vite + React + motion). Builds into docs/ for GitHub Pages.",
   "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "vite",

--- a/project.yml
+++ b/project.yml
@@ -37,14 +37,14 @@ targets:
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         LSUIElement: true
-        NSLocalNetworkUsageDescription: OpenSidecar connects to your iPad or iPhone over the local network in WiFi mode.
+        NSLocalNetworkUsageDescription: OpenDisplay connects to your iPad or iPhone over the local network in WiFi mode.
         NSBonjourServices: ["_opensidecar._tcp"]
         LSApplicationCategoryType: public.app-category.utilities
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.peetzweg.opensidecar.mac
-        PRODUCT_NAME: OpenSidecar
-        BUNDLE_DISPLAY_NAME: OpenSidecar
+        PRODUCT_NAME: OpenDisplay
+        BUNDLE_DISPLAY_NAME: OpenDisplay
         SWIFT_OBJC_BRIDGING_HEADER: Mac/OpenSidecarMac-Bridging-Header.h
         ENABLE_HARDENED_RUNTIME: YES
         CODE_SIGN_ENTITLEMENTS: Mac/OpenSidecarMac.entitlements
@@ -58,7 +58,7 @@ targets:
         # System Settings permission lists.
         Debug:
           PRODUCT_BUNDLE_IDENTIFIER: com.peetzweg.opensidecar.mac.debug
-          BUNDLE_DISPLAY_NAME: OpenSidecar Dev
+          BUNDLE_DISPLAY_NAME: OpenDisplay Dev
   OpenSidecariOS:
     type: application
     platform: iOS
@@ -68,13 +68,13 @@ targets:
     info:
       path: iOS/Info.plist
       properties:
-        CFBundleDisplayName: OpenSidecar
+        CFBundleDisplayName: OpenDisplay
         CFBundleIconName: AppIcon
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         UILaunchScreen: {}
         UIRequiresFullScreen: true
-        NSLocalNetworkUsageDescription: OpenSidecar advertises itself on the local network so your Mac can connect over WiFi.
+        NSLocalNetworkUsageDescription: OpenDisplay advertises itself on the local network so your Mac can connect over WiFi.
         NSBonjourServices: ["_opensidecar._tcp"]
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Privacy — OpenSidecar</title>
-  <meta name="description" content="OpenSidecar's privacy policy: no data collection, no analytics, no accounts, no servers. Your screen content travels directly between your Mac and your device, over your cable or your local network." />
+  <title>Privacy — OpenDisplay</title>
+  <meta name="description" content="OpenDisplay's privacy policy: no data collection, no analytics, no accounts, no servers. Your screen content travels directly between your Mac and your device, over your cable or your local network." />
   <link rel="icon" type="image/png" href="icon-256.png" />
-  <link rel="canonical" href="https://peetzweg.github.io/opensidecar/privacy.html" />
+  <link rel="canonical" href="https://peetzweg.github.io/opendisplay/privacy.html" />
   <meta name="theme-color" content="#ffffff" />
   <style>
     :root {
@@ -73,7 +73,7 @@
 <nav>
   <div class="wrap">
     <a class="brand" href="index.html">
-      <img src="icon-256.png" alt="" /> OpenSidecar
+      <img src="icon-256.png" alt="" /> OpenDisplay
     </a>
   </div>
 </nav>
@@ -82,7 +82,7 @@
   <div class="wrap">
     <p class="eyebrow">Privacy policy</p>
     <h1>No accounts. No analytics. No servers.</h1>
-    <p class="updated">Effective June 11, 2026 · applies to the OpenSidecar Mac and iOS apps and this website</p>
+    <p class="updated">Effective June 11, 2026 · applies to the OpenDisplay Mac and iOS apps and this website</p>
   </div>
 </header>
 
@@ -90,17 +90,17 @@
   <div class="wrap">
 
     <div class="tldr">
-      <p>OpenSidecar collects <strong>no data</strong>. There are no accounts, no analytics,
+      <p>OpenDisplay collects <strong>no data</strong>. There are no accounts, no analytics,
       no telemetry, no crash reporting, no ads, and no servers — ours or anyone else's.
       Your screen content travels directly from your Mac to your device over your USB
       cable or your local network, and nowhere else. Because the source code is public,
       every claim on this page is verifiable.</p>
     </div>
 
-    <h2>What OpenSidecar does with your screen</h2>
-    <p>OpenSidecar turns an iPhone or iPad into an extra display for your Mac. To do
+    <h2>What OpenDisplay does with your screen</h2>
+    <p>OpenDisplay turns an iPhone or iPad into an extra display for your Mac. To do
     that, the Mac app captures the contents of a virtual display, encodes it as video,
-    and sends it over a <strong>single direct connection</strong> to the OpenSidecar
+    and sends it over a <strong>single direct connection</strong> to the OpenDisplay
     app on your device:</p>
     <ul>
       <li><strong>Over USB</strong>, the video travels through your cable via the
@@ -135,7 +135,7 @@
 
     <h2>Permissions, and why they're needed</h2>
     <table>
-      <tr><th>Permission</th><th>Why OpenSidecar asks</th></tr>
+      <tr><th>Permission</th><th>Why OpenDisplay asks</th></tr>
       <tr><td>Screen Recording (Mac)</td>
           <td>To capture the virtual display it streams to your device. macOS shows
           the purple capture indicator whenever this is active — by design, you
@@ -157,7 +157,7 @@
       stream. On a trusted home or office network this is rarely a concern, but on
       shared or public WiFi we recommend USB mode. Encrypted WiFi transport with
       device pairing is on the roadmap
-      (<a href="https://github.com/peetzweg/opensidecar/issues/16">issue&nbsp;#16</a>).
+      (<a href="https://github.com/peetzweg/opendisplay/issues/16">issue&nbsp;#16</a>).
       A privacy page that didn't tell you this wouldn't be worth linking to.</p>
     </div>
 
@@ -169,20 +169,20 @@
     Privacy Statement</a>.</p>
 
     <h2>Verifiability</h2>
-    <p>OpenSidecar is open source under the
-    <a href="https://github.com/peetzweg/opensidecar/blob/main/LICENSE">GPL-3.0 license</a>.
+    <p>OpenDisplay is open source under the
+    <a href="https://github.com/peetzweg/opendisplay/blob/main/LICENSE">GPL-3.0 license</a>.
     The complete source code of both apps — including everything this page
     describes — is public at
-    <a href="https://github.com/peetzweg/opensidecar">github.com/peetzweg/opensidecar</a>.
+    <a href="https://github.com/peetzweg/opendisplay">github.com/peetzweg/opendisplay</a>.
     You don't have to take our word for any of this; you can read the code, build
     the apps yourself, or watch the network with the tools of your choice.</p>
 
     <h2>Changes and contact</h2>
     <p>If the app's behavior ever changes in a way that affects this page, the page
     will be updated in the same repository — its
-    <a href="https://github.com/peetzweg/opensidecar/commits/main/docs/privacy.html">edit
+    <a href="https://github.com/peetzweg/opendisplay/commits/main/docs/privacy.html">edit
     history</a> is public. Questions or concerns are welcome on the
-    <a href="https://github.com/peetzweg/opensidecar/issues">issue tracker</a>.</p>
+    <a href="https://github.com/peetzweg/opendisplay/issues">issue tracker</a>.</p>
 
   </div>
 </main>
@@ -191,11 +191,11 @@
   <div class="wrap">
     <div class="links">
       <a href="index.html">Home</a>
-      <a href="https://github.com/peetzweg/opensidecar">GitHub</a>
-      <a href="https://github.com/peetzweg/opensidecar/issues">Issues</a>
-      <a href="https://github.com/peetzweg/opensidecar/blob/main/LICENSE">GPL-3.0 License</a>
+      <a href="https://github.com/peetzweg/opendisplay">GitHub</a>
+      <a href="https://github.com/peetzweg/opendisplay/issues">Issues</a>
+      <a href="https://github.com/peetzweg/opendisplay/blob/main/LICENSE">GPL-3.0 License</a>
     </div>
-    <p class="fine">OpenSidecar — use your iPhone or iPad as a second monitor for your Mac. Free forever, private by design.</p>
+    <p class="fine">OpenDisplay — use your iPhone or iPad as a second monitor for your Mac. Free forever, private by design.</p>
   </div>
 </footer>
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,6 @@
-# OpenSidecar — free, open-source Sidecar/Duet alternative
+# OpenDisplay — free, open-source Sidecar/Duet alternative
 # Allow all crawlers full access.
 User-agent: *
 Allow: /
 
-Sitemap: https://peetzweg.github.io/opensidecar/sitemap.xml
+Sitemap: https://peetzweg.github.io/opendisplay/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://peetzweg.github.io/opensidecar/</loc>
+    <loc>https://peetzweg.github.io/opendisplay/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://peetzweg.github.io/opensidecar/privacy.html</loc>
+    <loc>https://peetzweg.github.io/opendisplay/privacy.html</loc>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/run.sh
+++ b/run.sh
@@ -5,11 +5,11 @@
 set -e
 cd "$(dirname "$0")"
 
-APP=build/Build/Products/Debug/OpenSidecar.app
+APP=build/Build/Products/Debug/OpenDisplay.app
 if [[ ! -d $APP ]]; then
   echo "Mac app not built — run: xcodegen generate && xcodebuild -project OpenSidecar.xcodeproj -scheme OpenSidecarMac -configuration Debug -derivedDataPath build build"
   exit 1
 fi
 
 open "$APP"
-echo "OpenSidecar running — logs at /tmp/opensidecar-mac.log."
+echo "OpenDisplay running — logs at /tmp/opensidecar-mac.log."

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ export default function App() {
   // Progressive enhancement: current release version + live star count.
   // Fails silent (offline / rate-limited) — the page works without it.
   useEffect(() => {
-    fetch("https://api.github.com/repos/peetzweg/opensidecar/releases/latest", {
+    fetch("https://api.github.com/repos/peetzweg/opendisplay/releases/latest", {
       headers: { Accept: "application/vnd.github+json" },
     })
       .then((r) => (r.ok ? r.json() : null))
@@ -27,7 +27,7 @@ export default function App() {
       })
       .catch(() => {})
 
-    fetch("https://api.github.com/repos/peetzweg/opensidecar", {
+    fetch("https://api.github.com/repos/peetzweg/opendisplay", {
       headers: { Accept: "application/vnd.github+json" },
     })
       .then((r) => (r.ok ? r.json() : null))
@@ -44,7 +44,7 @@ export default function App() {
       <nav>
         <div className="wrap">
           <a className="brand" href="./">
-            <img src="icon-256.png" alt="" /> OpenSidecar
+            <img src="icon-256.png" alt="" /> OpenDisplay
           </a>
           <div className="links">
             <a href="#features">Features</a>
@@ -54,8 +54,8 @@ export default function App() {
             <a href="#support">Support</a>
             <a
               className="gh"
-              href="https://github.com/peetzweg/opensidecar"
-              title="Star OpenSidecar on GitHub"
+              href="https://github.com/peetzweg/opendisplay"
+              title="Star OpenDisplay on GitHub"
             >
               <svg className="gh-logo" viewBox="0 0 16 16" aria-hidden="true">
                 <path
@@ -107,7 +107,7 @@ export default function App() {
           </p>
 
           <p className="needs-both">
-            OpenSidecar is <strong>two apps that work together</strong> — install both to get going.
+            OpenDisplay is <strong>two apps that work together</strong> — install both to get going.
           </p>
           <div className="downloads">
             <div>
@@ -118,13 +118,13 @@ export default function App() {
               <p className="dl-sub">The sender — captures a virtual display and streams it.</p>
               <a
                 className="btn primary"
-                href="https://github.com/peetzweg/opensidecar/releases/latest/download/OpenSidecar.dmg"
+                href="https://github.com/peetzweg/opendisplay/releases/latest/download/OpenDisplay.dmg"
               >
                 Download for Mac
               </a>
               <p className="note">
                 Signed &amp; notarized — opens normally on macOS&nbsp;14+. Prefer to compile it yourself?{" "}
-                <a href="https://github.com/peetzweg/opensidecar#quick-start">Build from source ↗</a>
+                <a href="https://github.com/peetzweg/opendisplay#quick-start">Build from source ↗</a>
               </p>
             </div>
             <div>
@@ -152,7 +152,7 @@ export default function App() {
                 </a>
                 ,<br />
                 or get started now by{" "}
-                <a href="https://github.com/peetzweg/opensidecar#quick-start">
+                <a href="https://github.com/peetzweg/opendisplay#quick-start">
                   compiling it from source ↗
                 </a>
                 .
@@ -165,7 +165,7 @@ export default function App() {
       <section id="support">
         <div className="wrap sec support">
           <p className="eyebrow">Support the project</p>
-          <h2>If OpenSidecar saved you a monitor, consider buying me a coffee.</h2>
+          <h2>If OpenDisplay saved you a monitor, consider buying me a coffee.</h2>
           <p>
             Free, open source, and funded out of my own pocket — including the Apple Developer
             membership behind signed, one-click installs. If it helps you, a tip keeps it going.
@@ -197,27 +197,27 @@ export default function App() {
           <p className="eyebrow">Contribute</p>
           <h2>Open source, and built in the open.</h2>
           <p style={{ color: "var(--muted)", maxWidth: "72ch", marginTop: "8px" }}>
-            OpenSidecar is GPL-3.0 and developed entirely on GitHub — the whole stack, from Mac
+            OpenDisplay is GPL-3.0 and developed entirely on GitHub — the whole stack, from Mac
             capture and H.264 encoding to the iOS receiver, is yours to read, build, and improve.
             Bug reports, feature ideas, and pull requests are all welcome. Build-and-run instructions
             live in the README.
           </p>
           <div className="btn-row">
-            <a className="btn primary" href="https://github.com/peetzweg/opensidecar">View on GitHub ↗</a>
-            <a className="btn ghost" href="https://github.com/peetzweg/opensidecar/issues">Open an issue ↗</a>
+            <a className="btn primary" href="https://github.com/peetzweg/opendisplay">View on GitHub ↗</a>
+            <a className="btn ghost" href="https://github.com/peetzweg/opendisplay/issues">Open an issue ↗</a>
           </div>
           <p className="sub">
             New here? Start with the{" "}
-            <a href="https://github.com/peetzweg/opensidecar#quick-start">README quick-start</a>{" "}
+            <a href="https://github.com/peetzweg/opendisplay#quick-start">README quick-start</a>{" "}
             to build both apps, or browse the{" "}
-            <a href="https://github.com/peetzweg/opensidecar/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">good first issues</a>.
+            <a href="https://github.com/peetzweg/opendisplay/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">good first issues</a>.
           </p>
         </div>
       </section>
 
       <section id="why">
         <div className="wrap sec">
-          <p className="eyebrow">Why OpenSidecar</p>
+          <p className="eyebrow">Why OpenDisplay</p>
           <h2>The device you already own becomes a real additional display.</h2>
           <div className="compare">
             <div className="row">
@@ -234,7 +234,7 @@ export default function App() {
               <p>Great latency, but you're buying a hardware dongle.</p>
             </div>
             <div className="row highlight">
-              <div className="name">OpenSidecar</div>
+              <div className="name">OpenDisplay</div>
               <p>Free, open source, auditable. The device you already own becomes a real additional
               display. If you were about to build your own — contribute here instead.</p>
             </div>
@@ -244,7 +244,7 @@ export default function App() {
           <div className="tbl-scroll">
             <table>
               <thead>
-                <tr><th></th><th className="os">OpenSidecar</th><th>Apple Sidecar</th><th>Duet</th><th>Luna</th></tr>
+                <tr><th></th><th className="os">OpenDisplay</th><th>Apple Sidecar</th><th>Duet</th><th>Luna</th></tr>
               </thead>
               <tbody>
                 <tr><td>Price</td><td className="mark-yes os">Free &amp; open source</td><td>Free</td><td className="mark-no">Subscription</td><td className="mark-no">$$$ + dongle</td></tr>
@@ -310,8 +310,8 @@ export default function App() {
             </details>
             <details>
               <summary>What's the license? Can I fork it or use it commercially?</summary>
-              <p>OpenSidecar is licensed under{" "}
-              <a href="https://github.com/peetzweg/opensidecar/blob/main/LICENSE">GPL-3.0</a>. You can
+              <p>OpenDisplay is licensed under{" "}
+              <a href="https://github.com/peetzweg/opendisplay/blob/main/LICENSE">GPL-3.0</a>. You can
               use, study, and adapt it freely — including commercially. If you distribute a modified
               version, it must remain open source under the same license with the original attribution
               intact, so improvements flow back to everyone instead of into closed forks. (Releases up
@@ -324,14 +324,14 @@ export default function App() {
       <footer>
         <div className="wrap">
           <div className="links">
-            <a href="https://github.com/peetzweg/opensidecar">GitHub</a>
-            <a href="https://github.com/peetzweg/opensidecar/releases/latest">Releases</a>
-            <a href="https://github.com/peetzweg/opensidecar/issues">Issues</a>
+            <a href="https://github.com/peetzweg/opendisplay">GitHub</a>
+            <a href="https://github.com/peetzweg/opendisplay/releases/latest">Releases</a>
+            <a href="https://github.com/peetzweg/opendisplay/issues">Issues</a>
             <a href="https://ko-fi.com/peetzweg">Support / Ko-fi</a>
             <a href="privacy.html">Privacy</a>
-            <a href="https://github.com/peetzweg/opensidecar/blob/main/LICENSE">GPL-3.0 License</a>
+            <a href="https://github.com/peetzweg/opendisplay/blob/main/LICENSE">GPL-3.0 License</a>
           </div>
-          <p className="fine">OpenSidecar — use your iPhone or iPad as a second monitor for your Mac. Free forever.</p>
+          <p className="fine">OpenDisplay — use your iPhone or iPad as a second monitor for your Mac. Free forever.</p>
         </div>
       </footer>
     </>

--- a/src/index.css
+++ b/src/index.css
@@ -150,7 +150,7 @@ h2 { font-size: clamp(1.5rem, 3vw, 2rem); line-height: 1.1; letter-spacing: -0.0
 
 /* ---- "why" comparison rows ---- */
 .compare { border-top: 1px solid var(--line); margin-top: 28px; }
-/* 24px horizontal padding = the boxed OpenSidecar row's 2px border + 22px padding,
+/* 24px horizontal padding = the boxed OpenDisplay row's 2px border + 22px padding,
    so every product name and description lines up with the highlighted one */
 .compare .row { display: grid; grid-template-columns: 150px 1fr; gap: 24px;
   padding: 22px 24px; border-bottom: 1px solid var(--line); align-items: start; }
@@ -169,7 +169,7 @@ code { font-family: var(--mono); }
 p code { font-size: 0.88em; background: #f2f2f2; padding: 1px 5px; border-radius: 3px; }
 
 /* ---- comparison table ---- */
-/* no outer frame — keep only the inner row lines (and the boxed OpenSidecar column) */
+/* no outer frame — keep only the inner row lines (and the boxed OpenDisplay column) */
 .tbl-scroll { overflow-x: auto; }
 table { width: 100%; border-collapse: collapse; font-size: 0.92rem; min-width: 660px; }
 th, td { padding: 13px 16px; text-align: left; border-bottom: 1px solid var(--line);
@@ -181,7 +181,7 @@ thead th { text-align: center; font-size: 1rem; color: var(--fg); font-weight: 6
 tbody td:first-child { color: var(--muted); }
 .mark-yes { color: var(--fg); font-weight: 600; }
 .mark-no { color: var(--faint); }
-/* highlight the OpenSidecar column — framed in brand blue */
+/* highlight the OpenDisplay column — framed in brand blue */
 th.os, td.os { border-left: 2px solid var(--accent); border-right: 2px solid var(--accent);
   background: #fafafa; }
 thead th.os { border-top: 2px solid var(--accent); color: var(--fg); }

--- a/tools/fake-receiver.swift
+++ b/tools/fake-receiver.swift
@@ -1,4 +1,4 @@
-// Fake OpenSidecar receiver — speaks just enough of the wire protocol to
+// Fake OpenDisplay receiver — speaks just enough of the wire protocol to
 // stand in for a third device: sends hello + pings, consumes video frames,
 // reports receive rate. For Mac-side scale testing only.
 import Foundation

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from "vite"
 import react from "@vitejs/plugin-react"
 
-// The site is served from https://peetzweg.github.io/opensidecar/ via GitHub Pages
+// The site is served from https://peetzweg.github.io/opendisplay/ via GitHub Pages
 // (Pages "deploy from branch" → /docs). Relative base keeps asset URLs working
-// under the /opensidecar/ subpath without hardcoding it, and the build emits
+// under the /opendisplay/ subpath without hardcoding it, and the build emits
 // straight into docs/ so the published folder stays the same.
 export default defineConfig({
   base: "./",


### PR DESCRIPTION
Resolves the App Store rejection (Review June 30, 2026 — Guideline 5.2.5): Apple flagged "Sidecar" in the app name as confusingly similar to their own Sidecar feature. This renames the user-facing app to **OpenDisplay**.

**Why:** "OpenSidecar" can't ship — the name is the rejection. After researching App Store name availability, trademarks, and domains across ~30 candidates, OpenDisplay was the only option clean on every axis.

**How:** Changes only user-facing surfaces — `CFBundleDisplayName`/`PRODUCT_NAME`, in-app strings, website, README, and the App Store listing copy. Everything permanent or pipeline-coupled is deliberately left as `opensidecar`: the bundle IDs (`com.peetzweg.opensidecar.*`, permanent in ASC), the Xcode project/scheme/target names (referenced by fastlane + CI), the Bonjour service type, and log/defaults domains. The Mac build artifact is renamed to `OpenDisplay.app`/`.dmg` consistently across Fastfile, the release workflow, and `run.sh`. Also drops "free" from the App Store metadata text per Guideline 2.3.7, and repoints repo/Pages URLs at the renamed `opendisplay` repo.

Verified locally: `xcodegen generate` + a Mac Debug build succeed and produce `OpenDisplay.app` (CFBundleName/CFBundleDisplayName = OpenDisplay, bundle ID unchanged). Since the on-device name changed, a **new build** is needed to take effect — merging triggers a release.