### PR TITLE
Serve site from opendisplay.app custom domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,15 +7,15 @@
   <meta name="description" content="OpenDisplay is a free, open-source alternative to Apple Sidecar and Duet Display. Turn your spare Apple devices — iPhone and iPad today, Macs on the roadmap — into true extended displays for your Mac over USB or WiFi. Retina-sharp, low latency, with touch and scroll input. No subscription, no dongle, no account." />
   <meta name="keywords" content="iPhone second monitor, iPad external display, Sidecar alternative, Duet Display alternative, free second screen Mac, open source, virtual display macOS, USB second display, use iPhone as monitor" />
   <link rel="icon" type="image/png" href="./icon-256.png" />
-  <link rel="canonical" href="https://peetzweg.github.io/opendisplay/" />
+  <link rel="canonical" href="https://opendisplay.app/" />
 
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="OpenDisplay" />
   <meta property="og:title" content="OpenDisplay — free, open-source Sidecar/Duet alternative" />
   <meta property="og:description" content="Use your iPhone or iPad as a second monitor for your Mac. A true extended display over USB or WiFi — Retina-sharp, low latency, with touch and scroll. No subscription, no dongle, no account." />
-  <meta property="og:url" content="https://peetzweg.github.io/opendisplay/" />
-  <meta property="og:image" content="https://peetzweg.github.io/opendisplay/icon.png" />
+  <meta property="og:url" content="https://opendisplay.app/" />
+  <meta property="og:image" content="https://opendisplay.app/icon.png" />
   <meta property="og:image:type" content="image/png" />
   <meta property="og:image:width" content="2048" />
   <meta property="og:image:height" content="2048" />
@@ -23,7 +23,7 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="OpenDisplay — free, open-source Sidecar/Duet alternative" />
   <meta name="twitter:description" content="Use your iPhone or iPad as a second monitor for your Mac. True extended display over USB or WiFi — Retina-sharp, low latency, with touch. No subscription, no dongle, no account." />
-  <meta name="twitter:image" content="https://peetzweg.github.io/opendisplay/icon.png" />
+  <meta name="twitter:image" content="https://opendisplay.app/icon.png" />
   <meta name="twitter:image:alt" content="OpenDisplay app icon" />
 
   <script type="application/ld+json">
@@ -46,8 +46,8 @@
       "Hardware H.264 (VideoToolbox) low-latency pipeline",
       "Self-hosted and private — no servers, accounts or telemetry"
     ],
-    "url": "https://peetzweg.github.io/opendisplay/",
-    "image": "https://peetzweg.github.io/opendisplay/icon.png",
+    "url": "https://opendisplay.app/",
+    "image": "https://opendisplay.app/icon.png",
     "downloadUrl": "https://github.com/peetzweg/opendisplay/releases/latest",
     "softwareHelp": "https://github.com/peetzweg/opendisplay#quick-start",
     "isAccessibleForFree": true,

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+opendisplay.app

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -6,7 +6,7 @@
   <title>Privacy — OpenDisplay</title>
   <meta name="description" content="OpenDisplay's privacy policy: no data collection, no analytics, no accounts, no servers. Your screen content travels directly between your Mac and your device, over your cable or your local network." />
   <link rel="icon" type="image/png" href="icon-256.png" />
-  <link rel="canonical" href="https://peetzweg.github.io/opendisplay/privacy.html" />
+  <link rel="canonical" href="https://opendisplay.app/privacy.html" />
   <meta name="theme-color" content="#ffffff" />
   <style>
     :root {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,4 +3,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://peetzweg.github.io/opendisplay/sitemap.xml
+Sitemap: https://opendisplay.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://peetzweg.github.io/opendisplay/</loc>
+    <loc>https://opendisplay.app/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://peetzweg.github.io/opendisplay/privacy.html</loc>
+    <loc>https://opendisplay.app/privacy.html</loc>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>


### PR DESCRIPTION
Point GitHub Pages at the newly-registered **opendisplay.app** and update the site's canonical/OG/sitemap URLs to match.

**Why:** The app was approved and we now own `opendisplay.app` — the landing page should live there and show that TLD in the address bar, rather than the `peetzweg.github.io/opendisplay/` subpath.

**How:** Add a `public/CNAME` (vite copies it verbatim into `docs/`, so the deployed Pages artifact carries the domain) and swap the hardcoded `peetzweg.github.io/opendisplay` URLs for the apex `opendisplay.app`. Vite's relative `base: "./"` means the subpath→apex move needs nothing else. The old github.io URL keeps working via GitHub's automatic 301 to the custom domain.

⚠️ **Merge order:** configure DNS at the registrar *first*, then merge — merging flips Pages to the custom domain, and until DNS resolves the github.io URL would 301 to a domain that isn't answering yet.