### PR TITLE
Add Plausible analytics + iOS Smart App Banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,13 @@
   <meta name="keywords" content="iPhone second monitor, iPad external display, Sidecar alternative, Duet Display alternative, free second screen Mac, open source, virtual display macOS, USB second display, use iPhone as monitor" />
   <link rel="icon" type="image/png" href="./icon-256.png" />
   <link rel="canonical" href="https://opendisplay.app/" />
+  <!-- Smart App Banner: offers the iOS receiver to visitors on iPhone/iPad Safari. -->
+  <meta name="apple-itunes-app" content="app-id=6780264891" />
 
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="OpenDisplay" />
+  <meta property="og:locale" content="en_US" />
   <meta property="og:title" content="OpenDisplay — free, open-source Sidecar/Duet alternative" />
   <meta property="og:description" content="Use your iPhone or iPad as a second monitor for your Mac. A true extended display over USB or WiFi — Retina-sharp, low latency, with touch and scroll. No subscription, no dongle, no account." />
   <meta property="og:url" content="https://opendisplay.app/" />
@@ -61,6 +64,10 @@
   </script>
 
   <meta name="theme-color" content="#ffffff" />
+
+  <!-- Privacy-friendly, cookieless analytics (self-hosted Plausible). -->
+  <link rel="preconnect" href="https://analytics.drdrip.xyz" crossorigin />
+  <script defer data-domain="opendisplay.app" src="https://analytics.drdrip.xyz/js/script.hash.outbound-links.js"></script>
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
Wire up analytics for opendisplay.app and a couple of SEO touch-ups.

**Why:** The site had no analytics, and there was no metadata pointing iOS visitors at the freshly-launched App Store listing.

**How:** Add the self-hosted Plausible snippet (cookieless `script.hash.outbound-links.js`) in `<head>`, with a `preconnect` to the analytics host so the deferred script resolves faster. Surface the iOS receiver via an `apple-itunes-app` Smart App Banner meta tag — this is where the App Store link earns its keep (iOS Safari shows an install banner). Also filled in the missing `og:locale`.

Desktop distribution is deliberately **unchanged**: the JSON-LD `downloadUrl` still points at the GitHub releases DMG — there is no Mac App Store build.

**Further SEO I'd suggest as follow-ups (not in this PR):** add `FAQPage` structured data for the on-page FAQ (rich-result eligible), and a dedicated 1200×630 OG/Twitter image instead of the square app icon. Happy to do either if you want them.