### PR TITLE
Add demo video section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ export default function App() {
             <img src="icon-256.png" alt="" /> OpenDisplay
           </a>
           <div className="links">
+            <a href="#demo">Demo</a>
             <a href="#features">Features</a>
             <a href="#contribute">Contribute</a>
             <a href="#why">Compare</a>
@@ -158,6 +159,22 @@ export default function App() {
                 .
               </p>
             </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="demo">
+        <div className="wrap sec">
+          <p className="eyebrow">Demo</p>
+          <h2>See it in action.</h2>
+          <div className="video-embed">
+            <iframe
+              src="https://www.youtube-nocookie.com/embed/wyEUkMgH3zw"
+              title="OpenDisplay demo — use your iPad as a second monitor for your Mac"
+              loading="lazy"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowFullScreen
+            />
           </div>
         </div>
       </section>

--- a/src/index.css
+++ b/src/index.css
@@ -126,6 +126,11 @@ h2 { font-size: clamp(1.5rem, 3vw, 2rem); line-height: 1.1; letter-spacing: -0.0
 .sub { display: block; font-size: 0.84rem; color: var(--muted); margin-top: 12px; }
 .btn-row { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 28px; }
 
+/* Demo video: responsive 16:9 embed matching the bordered, squared aesthetic. */
+.video-embed { position: relative; aspect-ratio: 16 / 9; margin-top: 28px;
+  border: 1px solid var(--line-strong); background: #000; overflow: hidden; }
+.video-embed iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; }
+
 /* App Store / TestFlight cluster */
 .ios-row { display: flex; flex-wrap: wrap; align-items: center; gap: 14px; }
 .badge-wrap { display: inline-flex; flex-direction: column; gap: 4px; }


### PR DESCRIPTION
Add a **Demo** section embedding the YouTube walkthrough, placed right after the hero (with a matching `#demo` nav link).

**Why:** Seeing the app run is the fastest way to convince a visitor; the landing page had no video.

**How:** Responsive 16:9 embed styled to match the existing bordered/squared look. Uses the privacy-enhanced `youtube-nocookie.com` domain (no cookies until play) and `loading="lazy"` so the player only loads when scrolled into view — keeps the initial page light. Verified the video is public/embeddable via YouTube oembed.