### PR TITLE
fix(ci): release workflow fails at startup (secrets in if:)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,11 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: macos-26
+    # The `secrets` context can't be referenced in a step-level `if:` (it's a
+    # workflow-validation error). Map the Sparkle key to a job env var so the
+    # appcast step can guard on its presence via the allowed `env` context.
+    env:
+      SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v6
 
@@ -125,10 +130,9 @@ jobs:
       # secret (the EdDSA private key from Sparkle's `generate_keys`), so this
       # never hard-fails a release before auto-update is switched on.
       - name: Publish Sparkle appcast to GitHub Pages
-        if: ${{ secrets.SPARKLE_PRIVATE_KEY != '' }}
+        if: ${{ env.SPARKLE_PRIVATE_KEY != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
           # Sparkle release that ships the generate_appcast / sign_update tools.
           SPARKLE_TOOLS_VERSION: "2.6.4"


### PR DESCRIPTION
**Urgent** — the Release workflow currently fails at startup on `main`, so no releases can run.

**Why:** The Sparkle appcast step (from #93) guarded with `if: ${{ secrets.SPARKLE_PRIVATE_KEY != '' }}`. The `secrets` context is not permitted in an `if:` expression — GitHub rejects the whole workflow at validation time ("a workflow file issue"), so every job is skipped. My miss in the #93 rebase; it was never exercised on a real push until merge.

**How:** Map the secret to a job-level `env` var (secrets *are* allowed there) and guard the step on `env.SPARKLE_PRIVATE_KEY != ''` (env *is* allowed in a step `if:`). Validated with actionlint — clean.