### PR TITLE
fix(ci): appcast never publishes on first release (untracked file)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,8 +169,11 @@ jobs:
           mkdir -p public
           cp /tmp/appcast-updates/appcast.xml public/appcast.xml
           rm -f /tmp/sparkle_ed_priv
-          if ! git diff --quiet -- public/appcast.xml; then
-            git add public/appcast.xml
+          git add public/appcast.xml
+          # Compare the STAGED file: plain `git diff` ignores untracked files,
+          # so the first-ever appcast (a brand-new public/appcast.xml) looked
+          # "unchanged" and was never committed. `--cached` sees the staged add.
+          if ! git diff --cached --quiet -- public/appcast.xml; then
             git commit -m "chore(release): publish Sparkle appcast for ${TAG_NAME} [skip ci]"
             git push origin main
             # Pushes made with GITHUB_TOKEN do NOT trigger other workflows


### PR DESCRIPTION
The 0.10.0 release ran the appcast step to success, but `https://opendisplay.app/appcast.xml` is 404 — the feed was never actually committed.

**Why:** `generate_appcast` wrote and signed `appcast.xml` (log: "Wrote 1 new update"), then the publish guard `git diff --quiet -- public/appcast.xml` decided it was "unchanged" and skipped the commit. Plain `git diff` ignores **untracked** files — and `public/appcast.xml` had never existed, so the first-ever appcast was invisible to it. Result: nothing committed, nothing deployed.

**How:** `git add` the file first, then guard on `git diff --cached --quiet` (staged diff sees the new file). Validated with actionlint.

Confirmed separately that the 0.10.0 DMG embeds Sparkle + correct SUFeedURL/SUPublicEDKey, so once this is merged the **next release publishes the feed and 0.10.0 clients can auto-update.**