### PR TITLE
feat(web): add Ko-fi support nudge banner under downloads

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -238,6 +238,15 @@ export default function App() {
               </p>
             </div>
           </div>
+          <a className="kofi-banner" href="#support">
+            <span className="kofi-banner-left">
+              <img className="kofi-mark" src="kofi-mark.webp" alt="" width="24" height="24" />
+              <span className="kofi-banner-text">Free, and built by one person.</span>
+            </span>
+            <span className="kofi-banner-cta">
+              Support me<span className="kofi-banner-arrow">↓</span>
+            </span>
+          </a>
         </div>
       </section>
 

--- a/src/index.css
+++ b/src/index.css
@@ -226,6 +226,23 @@ details p { color: var(--muted); padding: 0 0 24px; max-width: 78ch; }
 .btn.kofi { background: #fff; color: var(--fg); }
 .btn.kofi:hover { background: #fafafa; }
 .btn.kofi .kofi-mark { height: 22px; width: auto; display: block; }
+/* Ko-fi nudge under the downloads → scrolls down to #support. Internal jump, so
+   generic wording ("Support me") + a down arrow. Desktop: content-width, centered.
+   Mobile: full width, stacked into two centered lines. Coffee mark is the eye-catch. */
+.kofi-banner { display: flex; width: fit-content; margin: 16px auto 0;
+  align-items: center; gap: 14px; padding: 10px 18px;
+  border: 1px solid var(--line); border-radius: 3px; text-decoration: none; color: var(--fg); }
+.kofi-banner:hover { background: #fafafa; }
+.kofi-banner-left { display: inline-flex; align-items: center; gap: 10px; }
+.kofi-banner .kofi-mark { height: 24px; width: auto; display: block; flex: none; }
+.kofi-banner-text { font-size: 0.9rem; color: var(--muted); }
+.kofi-banner-cta { font-size: 0.92rem; font-weight: 600; white-space: nowrap; }
+.kofi-banner-arrow { display: inline-block; margin-left: 6px; color: var(--faint);
+  transition: transform 0.15s ease; }
+.kofi-banner:hover .kofi-banner-arrow { transform: translateY(3px); }
+@media (max-width: 560px) {
+  .kofi-banner { width: auto; flex-direction: column; gap: 6px; text-align: center; }
+}
 
 /* ---- footer ---- */
 footer { border-top: 1px solid var(--line); padding: 48px 0 64px;


### PR DESCRIPTION
Adds a Ko-fi support nudge banner directly under the download buttons that scrolls to the `#support` section.

**Why:** The support section lives far down the page; downloaders rarely reach it. A lightweight nudge at the point of download surfaces that the app is free and one-person-built.

**How:** In-page anchor jump (not an external Ko-fi link), so the copy stays generic ("Support me") with a down arrow that animates on hover. Content-width and centered on desktop; full-width, stacked into two centered lines under 560px.
