### PR TITLE
fix(mac): stop forcing a keyframe on backpressure drops

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -113,8 +113,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private let displaySerial: UInt32
 
     // Backpressure: outstanding sends. If the socket can't keep up we drop
-    // frames instead of queueing latency, then force a keyframe to resync.
-    // Kept tight: at 60fps each queued send is ~17ms of added latency.
+    // frames instead of queueing latency. Kept tight: at 60fps each queued
+    // send is ~17ms of added latency.
     private var pendingSends = 0
     private let maxPendingSends = 3
     private var dropsThisWindow = 0
@@ -856,7 +856,13 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // No receiver, or the socket is backed up: skip this frame entirely.
         guard connectionReady else { return }
         if pendingSends > maxPendingSends {
-            needsKeyframe = true   // dropped frames break the P-frame chain
+            // Pre-encode skip: the P-frame chain stays valid — the encoder
+            // references its own last output, and TCP delivers every encoded
+            // frame in order. Forcing an IDR here (as this path once did)
+            // turned each drop into a multi-hundred-KB keyframe, which backed
+            // the socket up further — a drop→IDR→drop spiral under sustained
+            // pressure (measured on a 120Hz fork of this pipeline: delivered
+            // fps collapsing to 0 while capture held 80+).
             dropsThisWindow += 1
             dropsTotal += 1
             return


### PR DESCRIPTION
## What

Removes `needsKeyframe = true` from the backpressure drop path in `MacSender`.

## Why

A frame skipped **before** the encoder never breaks the P-frame chain: the encoder only references frames it was actually fed, and TCP delivers every encoded frame in order — the receiver stays in sync without any resync IDR.

The forced keyframe was actively harmful: the drop fires exactly when the socket is already backed up, and an IDR is a multi-hundred-KB bitrate spike. Each drop made the congestion worse, feeding a drop → IDR → drop spiral under sustained pressure. Measured on a private 120Hz experiment on top of this pipeline: delivered fps collapsed to ~0 while capture held 80+; removing the forced IDR restored delivery to what the wire sustains. At upstream's 60fps the spiral is milder but the mechanism is identical — every backpressure drop today costs an unnecessary keyframe right when bandwidth is scarcest.

Keyframes are still forced where they are actually needed: reconnect, display rebuild, and explicit receiver `keyframe` requests.

## Testing

- `xcodebuild -scheme OpenSidecarMac -configuration Debug` builds clean (only pre-existing Swift 6 concurrency warnings).
- Behavior verified on the experimental build where this was found: under deliberate socket pressure the stream now degrades to the wire's sustainable fps instead of spiraling.

Two sibling PRs touch adjacent lines (silent-encode-failure logging, encoder in-flight gate) — trivial conflicts if merged together, happy to rebase whichever lands last.