### PR TITLE
fix(mac): virtual display hidden from ScreenCaptureKit by the TV mirror default

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -251,10 +251,15 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // = native pixels / 2 (rounded down to even for the encoder).
         let pointsWide = (info.pixelsWide / 2) & ~1
         let pointsHigh = (info.pixelsHigh / 2) & ~1
-        // Rough physical size so macOS picks a sane default UI scale.
-        let mm = info.pixelsWide >= info.pixelsHigh
-            ? CGSize(width: 147, height: 68)
-            : CGSize(width: 68, height: 147)
+        // Physical size from a per-kind PPI estimate (iPads ≈264, iPhones
+        // ≈460) so macOS picks a sane default UI scale. The old 147×68mm
+        // constant described a phone even for iPads — a wildly wrong size
+        // feeds the display-class heuristic bad data (#111), and TV-classed
+        // displays default to "Mirror Entire Screen" (#100). Orientation is
+        // inherent: pixelsWide/High arrive swapped on rotation.
+        let ppi = info.kind == "iPad" ? 264.0 : 460.0
+        let mm = CGSize(width: Double(info.pixelsWide) / ppi * 25.4,
+                        height: Double(info.pixelsHigh) / ppi * 25.4)
 
         // USB sessions can start before lockdown resolves the device name —
         // fall back to the kind from the hello rather than the generic label.

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -329,17 +329,42 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         }
     }
 
-    /// The virtual display takes a moment to show up in shareable content.
+    /// The virtual display takes a moment to show up in shareable content —
+    /// and on machines that misclassify it as a TV (#100), macOS restores the
+    /// saved "Mirror Entire Screen" arrangement asynchronously, seconds after
+    /// creation. A mirror-set secondary is not an active display and is
+    /// omitted from SCShareableContent entirely, so the display *vanishes*
+    /// until the un-mirror guard (`VirtualDisplay.ensureNotMirrored`, ≤2s
+    /// cadence) detaches it, plus ~2s more to re-register with SCK. That
+    /// round trip regularly overran the old 5s window (also reported
+    /// independently in PR #106) — allow 15s, and log the CG-level state
+    /// while waiting so a failure pinpoints why SCK isn't listing it.
     private func findSCDisplay(id: CGDirectDisplayID) async throws -> SCDisplay {
-        for _ in 0..<20 {
+        for attempt in 0..<60 {
             let content = try await SCShareableContent.current
             if let display = content.displays.first(where: { $0.displayID == id }) {
                 return display
             }
+            if attempt % 4 == 3 {
+                Log.info("display \(id) not in SCShareableContent yet: \(Self.displayState(id))")
+            }
             try await Task.sleep(for: .milliseconds(250))
         }
         throw NSError(domain: "MacSender", code: 3,
-                      userInfo: [NSLocalizedDescriptionKey: "virtual display never appeared in SCShareableContent"])
+                      userInfo: [NSLocalizedDescriptionKey:
+                          "virtual display never appeared in SCShareableContent (\(Self.displayState(id)))"])
+    }
+
+    /// One-line CG-level view of a display for diagnosing why SCK omits it
+    /// (mirror-set members that aren't the set's primary are inactive and
+    /// hidden from SCShareableContent — the #100 failure mode).
+    private static func displayState(_ id: CGDirectDisplayID) -> String {
+        let mirrors = CGDisplayMirrorsDisplay(id)
+        return "inMirrorSet=\(CGDisplayIsInMirrorSet(id) != 0)"
+            + (mirrors == kCGNullDirectDisplay ? "" : " mirroring=\(mirrors)")
+            + " active=\(CGDisplayIsActive(id) != 0)"
+            + " online=\(CGDisplayIsOnline(id) != 0)"
+            + " main=\(CGDisplayIsMain(id) != 0)"
     }
 
     private func startCapture(display: SCDisplay, pixelsWide: Int, pixelsHigh: Int) async throws {

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -120,10 +120,14 @@ final class VirtualDisplay {
         CGConfigureDisplayMirrorOfDisplay(config, id, kCGNullDirectDisplay)
         // ...and any display currently mirroring the VD (covers the reporter's
         // arrangement: the device set as Main, with the built-in mirroring it).
+        // Online list, NOT active list: a display that mirrors another is not
+        // drawable, so it never appears among the actives — scanning those can
+        // never find the display we're looking for (measured: a built-in
+        // mirroring the VD reports active=false).
         var n: UInt32 = 0
-        CGGetActiveDisplayList(0, nil, &n)
+        CGGetOnlineDisplayList(0, nil, &n)
         var list = [CGDirectDisplayID](repeating: 0, count: Int(n))
-        CGGetActiveDisplayList(n, &list, &n)
+        CGGetOnlineDisplayList(n, &list, &n)
         for other in list where other != id && CGDisplayMirrorsDisplay(other) == id {
             CGConfigureDisplayMirrorOfDisplay(config, other, kCGNullDirectDisplay)
         }

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -28,7 +28,13 @@ final class VirtualDisplay {
         descriptor.maxPixelsWide = UInt32(pointsWide * 2)
         descriptor.maxPixelsHigh = UInt32(pointsHigh * 2)
         descriptor.sizeInMillimeters = sizeInMillimeters
-        descriptor.productID = 0x4F53   // "OS"
+        // "OD" — bumped from 0x4F53 "OS" (pre-rebrand) deliberately: macOS keys
+        // saved display state on vendor/product/serial, and machines hit by the
+        // TV misclassification (#100) have a poisoned saved arrangement (the
+        // display pinned into a mirror set) stored against the old identity.
+        // A new product ID starts every install from a clean slate, at the
+        // one-time cost of macOS forgetting the display's saved position.
+        descriptor.productID = 0x4F44
         descriptor.vendorID = 0x5043    // "PC"
         descriptor.serialNum = serialNum
         descriptor.terminationHandler = { _, _ in
@@ -39,9 +45,23 @@ final class VirtualDisplay {
 
         settings = CGVirtualDisplaySettings()
         settings.hiDPI = 1
-        settings.modes = [
+        // Advertise a few standard monitor timings alongside the device-native
+        // mode. A display whose EDID offers exactly one non-standard resolution
+        // is a suspected trigger for macOS classifying it as a TV — whose
+        // arrangement default is "Mirror Entire Screen" (#100/#111); DeskPad,
+        // built on the same private API and never TV-classified, ships such a
+        // ladder. The HiDPI enforcement loop below pins the native mode
+        // regardless, so the extras are EDID advertisement, not behavior.
+        var modes = [
             CGVirtualDisplayMode(width: UInt(pointsWide), height: UInt(pointsHigh), refreshRate: 60)
         ]
+        for (w, h) in [(1024, 768), (800, 600), (640, 480)] {
+            let (mw, mh) = pointsWide >= pointsHigh ? (w, h) : (h, w)
+            if mw < pointsWide && mh < pointsHigh {
+                modes.append(CGVirtualDisplayMode(width: UInt(mw), height: UInt(mh), refreshRate: 60))
+            }
+        }
+        settings.modes = modes
         guard display.apply(settings) else {
             Log.info("CGVirtualDisplay applySettings FAILED")
             return nil


### PR DESCRIPTION
Second report on #100; also touches #111. **Parked as draft: the two commits have very different risk profiles and we haven't decided yet how much of this to ship — see "Ship decision" below.**

**Why:** After 0.11.0 the reporter's failure changed from "stuck mirroring" to `WiFi • Failed: virtual display never appeared in SCShareableContent`. Reproduced the mechanism locally with a harness that force-mirrors the virtual display at creation (what the TV default does on the reporter's Mac):

1. A **mirror-set secondary is not an active display and is omitted from `SCShareableContent` entirely** — the display doesn't show up wrong, it vanishes from ScreenCaptureKit's world.
2. macOS restores the saved TV "Mirror Entire Screen" arrangement **asynchronously, seconds after creation**. The #109 guard detaches it on its next tick (≤2s cadence), SCK takes ~2s more to re-list the display.
3. That round trip regularly overruns `findSCDisplay`'s hard 5s window → the exact error in the report.

## Commit 1 — robustness + diagnostics (safe, inert for healthy machines)

- `findSCDisplay` waits 15s instead of 5s (same direction PR #106 proposed). Healthy machines still exit on the first successful poll (~0.3–3s measured) — nobody waits longer unless they're already failing.
- While waiting, log the CG-level display state, and embed it in the timeout error (`inMirrorSet/mirroring/active/online/main`). If this still fails for the reporter, **the next screenshot diagnoses itself** — worth more than knowing their macOS version.
- Bug fix in `ensureNotMirrored`: it scanned the **active** display list to find displays mirroring the VD, but a mirroring display is never active (measured) — switched to the **online** list. This code path only executes when a VD is already in a mirror set, i.e. never on unaffected Macs.

Based on the measured timings there's a decent chance this half alone fixes the reporter.

## Commit 2 — root-cause experiment (#111): monitor-like identity (speculative, affects everyone)

Mirrors what DeskPad (same private API, never TV-classified) does differently: a ladder of standard modes (1024×768/800×600/640×480 when they fit under native), PPI-derived physical size instead of the phone-sized 147×68mm constant, and a product-id bump (`"OS"`→`"OD"`) so installs with a poisoned saved mirror arrangement start from a clean slate.

Costs, honestly: **every existing user's Mac forgets the display's saved position once** (identity change); System Settings lists three extra selectable resolutions the enforcement loop will fight; and the classification benefit is **unvalidated** — the maintainer's machine classifies the display correctly, so this cannot be tested without the reporter's setup.

## Ship decision (open)

Options, in rough order of preference:
1. **Merge commit 1 only**; park commit 2 on this branch, linked from #111, until the reporter's data (macOS version + the new self-diagnosing error text from a commit-1 build) proves classification is still the blocker.
2. Commit 1 + commit 2 gated behind a hidden `defaults` knob; hand the reporter a Terminal one-liner to opt in, promote once proven.
3. Ship both as-is.

## Verification

Fake receiver + mirror-attacker harness: session heals to "Extending" in ~1.3s under attack; both rotation rebuilds clean; baseline extend unaffected. Verified on macOS 26.5.1 (M5 Pro) — which does *not* reproduce the TV classification, hence the caution above.
