### PR TITLE
fix(mac): remember virtual display arrangement across reconnects

### DIFF
--- a/Mac/DisplayArrangement.swift
+++ b/Mac/DisplayArrangement.swift
@@ -1,0 +1,48 @@
+import CoreGraphics
+import Foundation
+
+/// Remembers where the user placed each device's virtual display (#116).
+///
+/// macOS does persist display arrangement, but keys it on the monitor
+/// identity (vendor/product/serial) — and ours legitimately changes: each
+/// orientation uses a distinct serial (saved-mode separation, see
+/// setupExtend), and the serial also derives from the session id, so USB
+/// and WiFi produce different identities for the same iPad. Every such
+/// change makes macOS treat the display as a brand-new monitor and park it
+/// at the default position. Keying saved origins on the device's install id
+/// makes the arrangement follow the physical device instead.
+enum DisplayArrangement {
+
+    /// Record the origin (global desktop points) the display settled at.
+    static func save(origin: CGPoint, size: CGSize, device: String) {
+        UserDefaults.standard.set([Int(origin.x), Int(origin.y), Int(size.width), Int(size.height)],
+                                  forKey: key(device, size))
+    }
+
+    /// Where a new display of `size` points should go: the exact spot this
+    /// orientation was last at, else the other orientation's spot mapped to
+    /// keep the display's center (WindowServer then snaps that to the
+    /// nearest valid adjacent arrangement, so the display stays on the same
+    /// side of the desktop). Nil on first contact — let macOS choose.
+    static func origin(for size: CGSize, device: String) -> CGPoint? {
+        if let v = load(key(device, size)) {
+            return CGPoint(x: v[0], y: v[1])
+        }
+        let flipped = CGSize(width: size.height, height: size.width)
+        if let v = load(key(device, flipped)) {
+            let saved = CGRect(x: CGFloat(v[0]), y: CGFloat(v[1]),
+                               width: CGFloat(v[2]), height: CGFloat(v[3]))
+            return CGPoint(x: saved.midX - size.width / 2, y: saved.midY - size.height / 2)
+        }
+        return nil
+    }
+
+    private static func key(_ device: String, _ size: CGSize) -> String {
+        "displayOrigin.\(device).\(size.width >= size.height ? "landscape" : "portrait")"
+    }
+
+    private static func load(_ key: String) -> [Int]? {
+        guard let v = UserDefaults.standard.array(forKey: key) as? [Int], v.count == 4 else { return nil }
+        return v
+    }
+}

--- a/Mac/DisplayArrangement.swift
+++ b/Mac/DisplayArrangement.swift
@@ -14,35 +14,29 @@ import Foundation
 enum DisplayArrangement {
 
     /// Record the origin (global desktop points) the display settled at.
+    /// One record per device — the latest arrangement wins regardless of
+    /// orientation, so the display follows wherever the user last put it
+    /// (tested per-orientation spots and flipping back to an orientation's
+    /// old position reads as broken; deliberate split positions are a
+    /// possible opt-in, see #128).
     static func save(origin: CGPoint, size: CGSize, device: String) {
         UserDefaults.standard.set([Int(origin.x), Int(origin.y), Int(size.width), Int(size.height)],
-                                  forKey: key(device, size))
+                                  forKey: key(device))
     }
 
-    /// Where a new display of `size` points should go: the exact spot this
-    /// orientation was last at, else the other orientation's spot mapped to
-    /// keep the display's center (WindowServer then snaps that to the
-    /// nearest valid adjacent arrangement, so the display stays on the same
-    /// side of the desktop). Nil on first contact — let macOS choose.
+    /// Where a new display of `size` points should go: the saved spot —
+    /// verbatim when the size matches, else mapped to keep the display's
+    /// center (WindowServer then snaps that to the nearest valid adjacent
+    /// arrangement, so a rotated display stays on the same side of the
+    /// desktop). Nil on first contact — let macOS choose.
     static func origin(for size: CGSize, device: String) -> CGPoint? {
-        if let v = load(key(device, size)) {
-            return CGPoint(x: v[0], y: v[1])
-        }
-        let flipped = CGSize(width: size.height, height: size.width)
-        if let v = load(key(device, flipped)) {
-            let saved = CGRect(x: CGFloat(v[0]), y: CGFloat(v[1]),
-                               width: CGFloat(v[2]), height: CGFloat(v[3]))
-            return CGPoint(x: saved.midX - size.width / 2, y: saved.midY - size.height / 2)
-        }
-        return nil
+        guard let v = UserDefaults.standard.array(forKey: key(device)) as? [Int],
+              v.count == 4 else { return nil }
+        let saved = CGRect(x: CGFloat(v[0]), y: CGFloat(v[1]),
+                           width: CGFloat(v[2]), height: CGFloat(v[3]))
+        if saved.size == size { return saved.origin }
+        return CGPoint(x: saved.midX - size.width / 2, y: saved.midY - size.height / 2)
     }
 
-    private static func key(_ device: String, _ size: CGSize) -> String {
-        "displayOrigin.\(device).\(size.width >= size.height ? "landscape" : "portrait")"
-    }
-
-    private static func load(_ key: String) -> [Int]? {
-        guard let v = UserDefaults.standard.array(forKey: key) as? [Int], v.count == 4 else { return nil }
-        return v
-    }
+    private static func key(_ device: String) -> String { "displayOrigin.\(device)" }
 }

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -268,10 +268,23 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         let serial = info.pixelsWide >= info.pixelsHigh
             ? displaySerial
             : displaySerial ^ 0x8000_0000
+        // Arrangement memory (#116): keyed on the device's install id so the
+        // display returns to its spot across transports and orientations —
+        // the serial-keyed memory macOS keeps starts from scratch whenever
+        // the serial changes. Old receivers without an id fall back to the
+        // session serial, which is at least orientation-stable.
+        let arrangementKey = info.id ?? String(format: "serial-%08x", displaySerial)
+        let sizeInPoints = CGSize(width: pointsWide, height: pointsHigh)
         let vd = await MainActor.run {
             VirtualDisplay(name: displayName,
                            pointsWide: pointsWide, pointsHigh: pointsHigh,
-                           sizeInMillimeters: mm, serialNum: serial)
+                           sizeInMillimeters: mm, serialNum: serial,
+                           restoreOrigin: DisplayArrangement.origin(for: sizeInPoints,
+                                                                    device: arrangementKey),
+                           onOriginChange: { origin in
+                               DisplayArrangement.save(origin: origin, size: sizeInPoints,
+                                                       device: arrangementKey)
+                           })
         }
         guard let vd else {
             throw NSError(domain: "MacSender", code: 2,

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -11,16 +11,28 @@ final class VirtualDisplay {
     let pointsWide: Int
     let pointsHigh: Int
 
+    private var restoreTarget: CGPoint?
+    private let restoreUntil: Date
+    private var lastReportedOrigin: CGPoint?
+    private let onOriginChange: ((CGPoint) -> Void)?
+
     var displayID: CGDirectDisplayID { display.displayID }
 
     /// Must be called on the main thread. `serialNum` must be unique per
     /// concurrent display AND stable per device — macOS keys saved display
     /// arrangement on vendor/product/serial, so a stable serial means each
     /// device keeps its position in System Settings across sessions.
+    /// `restoreOrigin` overrides that saved arrangement (see manageOrigin);
+    /// `onOriginChange` reports where the display sits afterwards, so the
+    /// caller can persist user drags.
     init?(name: String, pointsWide: Int, pointsHigh: Int, sizeInMillimeters: CGSize,
-          serialNum: UInt32 = 0x0001) {
+          serialNum: UInt32 = 0x0001, restoreOrigin: CGPoint? = nil,
+          onOriginChange: ((CGPoint) -> Void)? = nil) {
         self.pointsWide = pointsWide
         self.pointsHigh = pointsHigh
+        self.restoreTarget = restoreOrigin
+        self.restoreUntil = restoreOrigin == nil ? .distantPast : Date().addingTimeInterval(6)
+        self.onOriginChange = onOriginChange
 
         let descriptor = CGVirtualDisplayDescriptor()
         descriptor.setDispatchQueue(DispatchQueue.main)
@@ -64,6 +76,7 @@ final class VirtualDisplay {
                     guard let self else { return }
                     self.ensureNotMirrored()
                     if self.selectHiDPIMode(recover: settled) { settled = true }
+                    self.manageOrigin()
                 }
                 try? await Task.sleep(for: .milliseconds(settled ? 2000 : 200))
             }
@@ -98,6 +111,37 @@ final class VirtualDisplay {
         let err = CGCompleteDisplayConfiguration(config, .permanently)
         Log.info("HiDPI mode (re)selected: \(hidpi.width)x\(hidpi.height)@2x (result \(err.rawValue))")
         return err == .success
+    }
+
+    /// Arrangement restore + observation (#116). For the first few seconds,
+    /// assert `restoreTarget`: macOS restores ITS saved arrangement for this
+    /// display identity asynchronously, seconds after creation, and that
+    /// record is stale or default whenever the identity is fresh (rotation
+    /// swaps the serial, transport switches change it) — the caller's
+    /// device-keyed record must win. Afterwards, origin changes are the user
+    /// rearranging: report them so the caller can persist the new spot.
+    private func manageOrigin() {
+        let id = display.displayID
+        let origin = CGDisplayBounds(id).origin
+        if let target = restoreTarget, Date() < restoreUntil {
+            guard origin != target else { return }
+            var config: CGDisplayConfigRef?
+            guard CGBeginDisplayConfiguration(&config) == .success else { return }
+            CGConfigureDisplayOrigin(config, id, Int32(target.x), Int32(target.y))
+            let err = CGCompleteDisplayConfiguration(config, .permanently)
+            // WindowServer snaps the requested origin to the nearest valid
+            // arrangement — adopt what it settled on, or every remaining
+            // tick of the window would re-apply against the snap.
+            restoreTarget = CGDisplayBounds(id).origin
+            Log.info("display \(id) origin (\(Int(origin.x)),\(Int(origin.y))) → restored "
+                + "(\(Int(target.x)),\(Int(target.y))), settled "
+                + "(\(Int(restoreTarget!.x)),\(Int(restoreTarget!.y))) (result \(err.rawValue))")
+            return
+        }
+        if origin != lastReportedOrigin {
+            lastReportedOrigin = origin
+            onOriginChange?(origin)
+        }
     }
 
     /// An extend-mode virtual display must never sit in a system mirror set.


### PR DESCRIPTION
Fixes #116 — the virtual display now returns to where you placed it after reconnecting, rotating, or switching between USB and WiFi.

**Why:** macOS does remember display arrangement, but keys it on the monitor's vendor/product/serial — and our serial legitimately changes: each orientation uses a distinct serial (saved-mode separation), and it derives from the session id, so USB and WiFi disagree about the same iPad. Every such change makes macOS treat the display as a brand-new monitor and park it at the default spot. Reproduced live: rotating to portrait dropped the display from the user's (-1366,400) to the default (1512,0).

**How:** new [`DisplayArrangement`](../blob/feature-save-arrangement/Mac/DisplayArrangement.swift) persists the origin per device install id; `VirtualDisplay` re-asserts the saved origin during the display's first ~6s — macOS restores its own stale per-serial record asynchronously and must lose — then treats later moves as user drags and saves them. Judgment call: one record per device, latest arrangement wins in either orientation (center-mapped on rotation so the display stays on the same side of the desk) — per-orientation records were tried first and flipping back to an orientation's old spot read as broken on-device; deliberate split positions stay open as an opt-in in #128.

Verified with the fake receiver and on a real iPad: reconnect, both rotation directions (beating deliberately poisoned stale records), move-then-flip-back, drag-then-reconnect, and USB→WiFi all land where expected.
