### PR TITLE
feat(mac): add ADB device support and manual IP:port connection

### DIFF
--- a/Mac/Adb.swift
+++ b/Mac/Adb.swift
@@ -1,0 +1,297 @@
+// ADB-backed Android device discovery and TCP forwarding.
+//
+// The Android receiver listens on the device at TCP :9000. That port cannot
+// be dialed directly over an Android USB connection, so the Mac asks adb to
+// allocate a free loopback port (`adb forward tcp:0 tcp:9000`) for each
+// connected device. The sender can then use its normal TCP transport against
+// 127.0.0.1:<allocated port>; multiple Android devices never contend for the
+// same local port.
+
+import Foundation
+
+struct AdbDevice: Hashable, Identifiable {
+    let serial: String
+    let name: String
+    let state: String
+    let localPort: UInt16?
+
+    var id: String { serial }
+    var ready: Bool { state == "device" && localPort != nil }
+
+    var connectionHint: String {
+        switch state {
+        case "device" where localPort == nil:
+            return "ADB · Unable to forward port \(Adb.receiverPort)"
+        case "unauthorized":
+            return "ADB · Authorize USB debugging on the device"
+        case "offline":
+            return "ADB · Device offline"
+        default:
+            return "ADB"
+        }
+    }
+}
+
+enum Adb {
+    static let receiverPort: UInt16 = 9000
+
+    struct ListedDevice: Equatable {
+        let serial: String
+        let state: String
+        let name: String
+    }
+
+    struct Forward: Equatable {
+        let serial: String
+        let localPort: UInt16
+        let remotePort: UInt16
+    }
+
+    enum Failure: Error, LocalizedError {
+        case unavailable
+        case command(String)
+        case invalidForwardPort(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .unavailable:
+                return "adb is not installed"
+            case .command(let detail):
+                return detail.isEmpty ? "adb command failed" : detail
+            case .invalidForwardPort(let output):
+                return "adb returned an invalid forwarded port: \(output)"
+            }
+        }
+    }
+
+    /// GUI apps do not inherit the interactive shell's PATH. Search Android
+    /// Studio's standard SDK location and the usual Homebrew locations in
+    /// addition to the environment supplied at launch.
+    static func executableURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL? {
+        var candidates: [URL] = []
+        for key in ["ANDROID_SDK_ROOT", "ANDROID_HOME"] {
+            if let root = environment[key], !root.isEmpty {
+                candidates.append(URL(fileURLWithPath: root)
+                    .appendingPathComponent("platform-tools/adb"))
+            }
+        }
+        candidates.append(homeDirectory
+            .appendingPathComponent("Library/Android/sdk/platform-tools/adb"))
+        for directory in (environment["PATH"] ?? "").split(separator: ":") {
+            candidates.append(URL(fileURLWithPath: String(directory))
+                .appendingPathComponent("adb"))
+        }
+        candidates.append(URL(fileURLWithPath: "/opt/homebrew/bin/adb"))
+        candidates.append(URL(fileURLWithPath: "/usr/local/bin/adb"))
+
+        var seen = Set<String>()
+        return candidates.first { candidate in
+            let path = candidate.standardizedFileURL.path
+            guard seen.insert(path).inserted else { return false }
+            return FileManager.default.isExecutableFile(atPath: path)
+        }
+    }
+
+    static func listDevices(using executable: URL) throws -> [ListedDevice] {
+        parseDevices(try run(["devices", "-l"], using: executable))
+    }
+
+    /// Parse `adb devices -l`. Non-ready rows are intentionally retained so
+    /// the UI can tell the user to approve USB debugging instead of looking
+    /// as if no Android device was attached.
+    static func parseDevices(_ output: String) -> [ListedDevice] {
+        output.split(whereSeparator: \Character.isNewline).compactMap { rawLine in
+            let fields = rawLine.split(whereSeparator: \Character.isWhitespace)
+            guard fields.count >= 2,
+                  fields[0] != "List", fields[0] != "*" else { return nil }
+            let serial = String(fields[0])
+            let state = String(fields[1])
+            var attributes: [String: String] = [:]
+            for field in fields.dropFirst(2) {
+                guard let colon = field.firstIndex(of: ":") else { continue }
+                attributes[String(field[..<colon])] =
+                    String(field[field.index(after: colon)...])
+            }
+            let rawName = attributes["model"] ?? attributes["device"] ?? serial
+            let name = rawName.replacingOccurrences(of: "_", with: " ")
+            return ListedDevice(serial: serial, state: state, name: name)
+        }
+    }
+
+    static func listForwards(using executable: URL) throws -> [Forward] {
+        parseForwards(try run(["forward", "--list"], using: executable))
+    }
+
+    static func parseForwards(_ output: String) -> [Forward] {
+        output.split(whereSeparator: \Character.isNewline).compactMap { rawLine in
+            let fields = rawLine.split(whereSeparator: \Character.isWhitespace)
+            guard fields.count == 3,
+                  let local = tcpPort(String(fields[1])),
+                  let remote = tcpPort(String(fields[2])) else { return nil }
+            return Forward(serial: String(fields[0]), localPort: local, remotePort: remote)
+        }
+    }
+
+    /// Prefer the prior local port after a quick detach/reattach so an active
+    /// sender can reconnect to the same endpoint. If it has been claimed in
+    /// the meantime, ask adb for another free port.
+    static func addForward(serial: String, preferredLocalPort: UInt16? = nil,
+                           using executable: URL) throws -> UInt16 {
+        if let preferredLocalPort {
+            do {
+                _ = try run(["-s", serial, "forward", "tcp:\(preferredLocalPort)",
+                             "tcp:\(receiverPort)"], using: executable)
+                return preferredLocalPort
+            } catch {
+                // tcp:0 below is atomic inside adb and avoids a local
+                // check-then-bind race when the old port is no longer free.
+            }
+        }
+        let output = try run(["-s", serial, "forward", "tcp:0",
+                              "tcp:\(receiverPort)"], using: executable)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let port = UInt16(output), port > 0 else {
+            throw Failure.invalidForwardPort(output)
+        }
+        return port
+    }
+
+    static func removeForward(serial: String, localPort: UInt16,
+                              using executable: URL) throws {
+        _ = try run(["-s", serial, "forward", "--remove", "tcp:\(localPort)"],
+                    using: executable)
+    }
+
+    private static func tcpPort(_ endpoint: String) -> UInt16? {
+        guard endpoint.hasPrefix("tcp:") else { return nil }
+        return UInt16(endpoint.dropFirst(4))
+    }
+
+    @discardableResult
+    private static func run(_ arguments: [String], using executable: URL) throws -> String {
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.executableURL = executable
+        process.arguments = arguments
+        process.standardOutput = stdout
+        process.standardError = stderr
+        do {
+            try process.run()
+        } catch {
+            throw Failure.command(error.localizedDescription)
+        }
+        process.waitUntilExit()
+        let output = String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(),
+                            as: UTF8.self)
+        let errorOutput = String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(),
+                                 as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard process.terminationStatus == 0 else {
+            throw Failure.command(errorOutput)
+        }
+        return output
+    }
+}
+
+/// ADB has no attach notification API intended for desktop clients, so poll
+/// its cheap device listing on a private queue. Each ready device receives one
+/// stable, app-owned port forward. The forward is removed when OpenDisplay
+/// exits; adb itself removes it when the device disconnects.
+final class AdbDeviceWatcher {
+    private let queue = DispatchQueue(label: "adb.watcher")
+    private let onChange: ([AdbDevice], Bool) -> Void
+    private var timer: DispatchSourceTimer?
+    private var executable: URL?
+    // Keep ports across a temporary detach so reconnects can preserve the
+    // loopback endpoint used by an existing MacSender.
+    private var ownedPorts: [String: UInt16] = [:]
+    private var stopped = false
+
+    init(onChange: @escaping ([AdbDevice], Bool) -> Void) {
+        self.onChange = onChange
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.refresh()
+            let timer = DispatchSource.makeTimerSource(queue: self.queue)
+            timer.schedule(deadline: .now() + 2, repeating: 2)
+            timer.setEventHandler { [weak self] in self?.refresh() }
+            timer.resume()
+            self.timer = timer
+        }
+    }
+
+    func stop() {
+        queue.sync {
+            guard !stopped else { return }
+            stopped = true
+            timer?.cancel()
+            timer = nil
+            if let executable {
+                for (serial, port) in ownedPorts {
+                    try? Adb.removeForward(serial: serial, localPort: port,
+                                           using: executable)
+                }
+            }
+            ownedPorts.removeAll()
+        }
+    }
+
+    private func refresh() {
+        guard !stopped else { return }
+        guard let executable = Adb.executableURL() else {
+            self.executable = nil
+            publish([], available: false)
+            return
+        }
+        self.executable = executable
+        do {
+            let listed = try Adb.listDevices(using: executable)
+            let forwards = (try? Adb.listForwards(using: executable)) ?? []
+            var devices: [AdbDevice] = []
+            for item in listed {
+                var localPort: UInt16?
+                if item.state == "device" {
+                    let remembered = ownedPorts[item.serial]
+                    let stillForwarded = remembered.map { port in
+                        forwards.contains(Adb.Forward(serial: item.serial,
+                            localPort: port, remotePort: Adb.receiverPort))
+                    } ?? false
+                    if stillForwarded {
+                        localPort = remembered
+                    } else {
+                        do {
+                            // Do not replace an unrelated forward that took
+                            // our remembered port while this device was away.
+                            let reusable = remembered.flatMap { port in
+                                forwards.contains(where: { $0.localPort == port })
+                                    ? nil : port
+                            }
+                            let port = try Adb.addForward(
+                                serial: item.serial, preferredLocalPort: reusable,
+                                using: executable)
+                            ownedPorts[item.serial] = port
+                            localPort = port
+                            Log.info("adb forward: \(item.serial) tcp:\(port) -> tcp:\(Adb.receiverPort)")
+                        } catch {
+                            Log.info("adb forward failed for \(item.serial): \(error)")
+                        }
+                    }
+                }
+                devices.append(AdbDevice(serial: item.serial, name: item.name,
+                                         state: item.state, localPort: localPort))
+            }
+            publish(devices.sorted { $0.serial < $1.serial }, available: true)
+        } catch {
+            Log.info("adb watcher: \(error)")
+            publish([], available: true)
+        }
+    }
+
+    private func publish(_ devices: [AdbDevice], available: Bool) {
+        DispatchQueue.main.async { [onChange] in onChange(devices, available) }
+    }
+}

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -63,6 +63,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         MainWindow.show()
         return false
     }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        SenderController.shared.shutdown()
+    }
 }
 
 /// The control panel as a regular window, for Dock/background presentation.
@@ -94,6 +98,7 @@ enum MainWindow {
 
 enum ConnectionTarget: Hashable {
     case usb(udid: String?)           // wired via built-in usbmuxd; nil = first device
+    case adb(serial: String, localPort: UInt16)  // Android via adb forward to :9000
     case wifi(NWBrowser.Result)       // discovered via Bonjour
     case manual(host: String, port: UInt16)  // user-entered IP:port
 
@@ -102,6 +107,7 @@ enum ConnectionTarget: Hashable {
     var sessionID: String {
         switch self {
         case .usb(let udid): return "usb:\(udid ?? "first")"
+        case .adb(let serial, _): return "adb:\(serial)"
         case .wifi(let result):
             if case .service(let name, _, _, _) = result.endpoint { return "wifi:\(name)" }
             return "wifi:unknown"
@@ -125,7 +131,7 @@ final class DeviceSession: ObservableObject, Identifiable {
     @Published var framesSent = 0
     @Published var mbps = 0.0
     // Receiver's per-install identity (from hello) — the key for recognizing
-    // the same physical device across USB and WiFi.
+    // the same physical device across USB, ADB, and WiFi.
     var deviceID: String?
     // "iPhone" / "iPad" from hello — naming fallback while (or in case)
     // lockdown hasn't resolved the device's real name.
@@ -134,6 +140,7 @@ final class DeviceSession: ObservableObject, Identifiable {
     var transportLabel: String {
         switch target {
         case .usb: return "USB"
+        case .adb: return "ADB"
         case .wifi: return "WiFi"
         case .manual: return "Manual"
         }
@@ -165,6 +172,8 @@ final class SenderController: ObservableObject {
     @Published var sessions: [DeviceSession] = []
     @Published var discovered: [NWBrowser.Result] = []
     @Published var usbDevices: [UsbmuxDevice] = []
+    @Published var adbDevices: [AdbDevice] = []
+    @Published var adbAvailable = Adb.executableURL() != nil
     // `-host x.x.x.x` / `-port n` bypass usbmuxd with a manual TCP endpoint
     // (debugging escape hatch, e.g. an iproxy or SSH tunnel).
     @Published var host = UserDefaults.standard.string(forKey: "host") ?? "127.0.0.1"
@@ -184,6 +193,7 @@ final class SenderController: ObservableObject {
 
     private var browser: NWBrowser?
     private var usbWatcher: UsbmuxDeviceWatcher?
+    private var adbWatcher: AdbDeviceWatcher?
 
     // Connection policy — deliberately simple, no automatic transport
     // switching. One session per physical device; whichever transport
@@ -193,11 +203,13 @@ final class SenderController: ObservableObject {
     // surprised users more than it helped (and every virtual-display
     // create/destroy flashes all screens).
     //
-    //  - USB devices connect on attach ("plug in and go") unless the user
-    //    explicitly disconnected them once (usbDisabled).
+    //  - Wired iOS/Android devices connect on attach ("plug in and go")
+    //    unless the user explicitly disconnected them once (usbDisabled).
     //  - WiFi devices the user connected before (wifiRemembered) reconnect
     //    in a short window at LAUNCH only — never mid-session.
     // `-autostart NO` disables all auto-connecting.
+    // The persisted key predates ADB support; it now stores both `usb:` and
+    // `adb:` session ids so existing iOS preferences migrate without churn.
     private var usbDisabled = Set(UserDefaults.standard.stringArray(forKey: "usbDisabled") ?? []) {
         didSet { UserDefaults.standard.set(Array(usbDisabled), forKey: "usbDisabled") }
     }
@@ -218,11 +230,17 @@ final class SenderController: ObservableObject {
         UserDefaults.standard.dictionary(forKey: "installIDByUDID") as? [String: String] ?? [:] {
         didSet { UserDefaults.standard.set(installIDByUDID, forKey: "installIDByUDID") }
     }
+    @Published private var installIDByADBSerial: [String: String] =
+        UserDefaults.standard.dictionary(forKey: "installIDByADBSerial") as? [String: String] ?? [:] {
+        didSet {
+            UserDefaults.standard.set(installIDByADBSerial, forKey: "installIDByADBSerial")
+        }
+    }
     private let autoConnectEnabled = UserDefaults.standard.object(forKey: "autostart") == nil
         || UserDefaults.standard.bool(forKey: "autostart")
 
-    // Bonjour usually reports devices before usbmuxd does — WiFi reconnects
-    // wait out this window so a cabled device is dialed over USB first. The
+    // Bonjour usually reports devices before usbmuxd/ADB do — WiFi reconnects
+    // wait out this window so a cabled device is dialed first. The
     // deadline closes the window for good: a remembered WiFi device that
     // appears later was brought near the Mac mid-session, which is a user
     // action to confirm, not auto-grab.
@@ -236,11 +254,22 @@ final class SenderController: ObservableObject {
             self.usbDevices = devices
             self.autoConnect()
         }
+        adbWatcher = AdbDeviceWatcher { [weak self] devices, available in
+            guard let self else { return }
+            self.adbDevices = devices
+            self.adbAvailable = available
+            self.autoConnect()
+        }
         Task { @MainActor in
             try? await Task.sleep(for: .seconds(2))
             self.wifiAutoConnectArmed = true
             self.autoConnect()
         }
+    }
+
+    func shutdown() {
+        adbWatcher?.stop()
+        adbWatcher = nil
     }
 
     private func startBrowsing() {
@@ -279,6 +308,11 @@ final class SenderController: ObservableObject {
         return false
     }
 
+    private func sameDevice(_ result: NWBrowser.Result, _ device: AdbDevice) -> Bool {
+        guard let id = txtID(of: result) else { return false }
+        return installIDByADBSerial[device.serial] == id
+    }
+
     /// The session (over either transport) already serving this USB device.
     private func activeSession(coveringUSB device: UsbmuxDevice) -> DeviceSession? {
         if let direct = session(for: "usb:\(device.udid)") { return direct }
@@ -290,17 +324,36 @@ final class SenderController: ObservableObject {
         }
     }
 
+    private func activeSession(coveringADB device: AdbDevice) -> DeviceSession? {
+        if let direct = session(for: "adb:\(device.serial)") { return direct }
+        guard let id = installIDByADBSerial[device.serial] else { return nil }
+        return sessions.first { session in
+            if session.deviceID == id { return true }
+            guard case .wifi(let result) = session.target else { return false }
+            return txtID(of: result) == id
+        }
+    }
+
     /// The session (over either transport) already serving this WiFi service.
     private func activeSession(coveringWiFi result: NWBrowser.Result) -> DeviceSession? {
         if let name = serviceName(of: result), let direct = session(for: "wifi:\(name)") {
             return direct
         }
         return sessions.first { s in
-            guard case .usb(let udid) = s.target else { return false }
-            if let id = txtID(of: result), s.deviceID == id { return true }
-            guard let udid, let device = usbDevices.first(where: { $0.udid == udid })
-            else { return false }
-            return sameDevice(result, device)
+            switch s.target {
+            case .usb(let udid):
+                if let id = txtID(of: result), s.deviceID == id { return true }
+                guard let udid, let device = usbDevices.first(where: { $0.udid == udid })
+                else { return false }
+                return sameDevice(result, device)
+            case .adb(let serial, _):
+                if let id = txtID(of: result), s.deviceID == id { return true }
+                guard let device = adbDevices.first(where: { $0.serial == serial })
+                else { return false }
+                return sameDevice(result, device)
+            default:
+                return false
+            }
         }
     }
 
@@ -320,6 +373,13 @@ final class SenderController: ObservableObject {
             && activeSession(coveringUSB: device) == nil {
             connect(to: .usb(udid: device.udid))
         }
+        for device in adbDevices
+            where device.ready
+            && !usbDisabled.contains("adb:\(device.serial)")
+            && activeSession(coveringADB: device) == nil {
+            guard let localPort = device.localPort else { continue }
+            connect(to: .adb(serial: device.serial, localPort: localPort))
+        }
         guard wifiAutoConnectArmed, Date() < wifiAutoConnectDeadline else { return }
         for result in discovered {
             let target = ConnectionTarget.wifi(result)
@@ -331,30 +391,34 @@ final class SenderController: ObservableObject {
         }
     }
 
-    /// An attached, auto-connectable USB device is (about to be) dialed over
+    /// An attached, auto-connectable wired device is (about to be) dialed over
     /// the cable — its WiFi service must not be grabbed in the launch race.
     private func cabled(_ result: NWBrowser.Result) -> Bool {
         usbDevices.contains {
             sameDevice(result, $0) && !usbDisabled.contains("usb:\($0.udid)")
+        } || adbDevices.contains {
+            sameDevice(result, $0) && !usbDisabled.contains("adb:\($0.serial)")
         }
     }
 
     /// Safety net, not a feature: if identity was learned too late (old
     /// receiver, renamed service) and one physical device ended up with two
     /// sessions, the transports steal the receiver's single connection from
-    /// each other forever. Keep the cable, drop the WiFi twin.
+    /// each other forever. Keep the wired transport, drop the WiFi twin.
     private func dedupeSessions() {
-        let usbSessionIDs = Set(sessions.compactMap { s -> String? in
-            if case .usb = s.target { return s.deviceID }
-            return nil
+        let wiredSessionIDs = Set(sessions.compactMap { s -> String? in
+            switch s.target {
+            case .usb, .adb: return s.deviceID
+            default: return nil
+            }
         })
         let cabledNames = Set(usbDevices.compactMap { device in
             session(for: "usb:\(device.udid)") != nil ? device.name : nil
         })
         for s in sessions {
             guard case .wifi(let result) = s.target else { continue }
-            let duplicate = (s.deviceID.map { usbSessionIDs.contains($0) } ?? false)
-                || (txtID(of: result).map { usbSessionIDs.contains($0) } ?? false)
+            let duplicate = (s.deviceID.map { wiredSessionIDs.contains($0) } ?? false)
+                || (txtID(of: result).map { wiredSessionIDs.contains($0) } ?? false)
                 || (serviceName(of: result).map { cabledNames.contains($0) } ?? false)
             if duplicate {
                 Log.info("two sessions for one device — keeping the cable, dropping \(s.id)")
@@ -372,6 +436,8 @@ final class SenderController: ObservableObject {
                 return name
             }
             return udid == nil ? "Manual (\(host):\(port))" : "iPhone / iPad"
+        case .adb(let serial, _):
+            return adbDevices.first(where: { $0.serial == serial })?.name ?? "Android device"
         case .wifi(let result):
             return serviceName(of: result) ?? "WiFi device"
         case .manual(let host, let port):
@@ -450,6 +516,9 @@ final class SenderController: ObservableObject {
         case .usb(let udid?):
             covering = usbDevices.first(where: { $0.udid == udid })
                 .flatMap { activeSession(coveringUSB: $0) }
+        case .adb(let serial, _):
+            covering = adbDevices.first(where: { $0.serial == serial })
+                .flatMap { activeSession(coveringADB: $0) }
         case .wifi(let result):
             covering = activeSession(coveringWiFi: result)
         default:
@@ -464,6 +533,7 @@ final class SenderController: ObservableObject {
         // Connecting a device clears its "don't auto-connect" state.
         switch target {
         case .usb: usbDisabled.remove(id)
+        case .adb: usbDisabled.remove(id)
         case .wifi: wifiRemembered.insert(id)
         case .manual(let host, let portNum): manualRemembered.insert("\(host):\(portNum)")
         }
@@ -479,6 +549,9 @@ final class SenderController: ObservableObject {
             } else {
                 transport = .usb(udid: udid, port: portNum)
             }
+        case .adb(_, let localPort):
+            transport = .tcp(.hostPort(host: "127.0.0.1",
+                                       port: NWEndpoint.Port(rawValue: localPort)!))
         case .wifi(let result):
             transport = .tcp(result.endpoint)
         case .manual(let host, let portNum):
@@ -500,6 +573,9 @@ final class SenderController: ObservableObject {
             session.deviceKind = info.device
             if case .usb(let udid?) = session.target, let installID = info.id {
                 self.installIDByUDID[udid] = installID
+            }
+            if case .adb(let serial, _) = session.target, let installID = info.id {
+                self.installIDByADBSerial[serial] = installID
             }
             self.dedupeSessions()
         }
@@ -533,6 +609,7 @@ final class SenderController: ObservableObject {
     func disconnect(_ session: DeviceSession) {
         switch session.target {
         case .usb: usbDisabled.insert(session.id)
+        case .adb: usbDisabled.insert(session.id)
         case .wifi: wifiRemembered.remove(session.id)
         case .manual: break
         }
@@ -563,20 +640,24 @@ final class SenderController: ObservableObject {
         let id: String
         let name: String
         let usbTarget: ConnectionTarget?
+        let adbTarget: ConnectionTarget?
         let wifiTarget: ConnectionTarget?
         var manualTarget: ConnectionTarget? = nil
+        var transportOverride: String? = nil
 
         var transportLabel: String {
+            if let transportOverride { return transportOverride }
             if manualTarget != nil { return "Manual" }
-            switch (usbTarget != nil, wifiTarget != nil) {
-            case (true, true): return "USB · WiFi"
-            case (true, false): return "USB"
-            case (false, true): return "WiFi"
-            default: return ""
-            }
+            var transports: [String] = []
+            if usbTarget != nil { transports.append("USB") }
+            if adbTarget != nil { transports.append("ADB") }
+            if wifiTarget != nil { transports.append("WiFi") }
+            return transports.joined(separator: " · ")
         }
         /// Lowest latency first.
-        var preferredTarget: ConnectionTarget? { usbTarget ?? wifiTarget ?? manualTarget }
+        var preferredTarget: ConnectionTarget? {
+            usbTarget ?? adbTarget ?? wifiTarget ?? manualTarget
+        }
     }
 
     var deviceEntries: [DeviceEntry] {
@@ -599,13 +680,30 @@ final class SenderController: ObservableObject {
                     ?? session(for: usbTarget.sessionID)?.deviceKind
                     ?? "iPhone / iPad",
                 usbTarget: usbTarget,
+                adbTarget: nil,
                 wifiTarget: twin.map { .wifi($0) }))
+        }
+        for device in adbDevices {
+            let twin = discovered.first { sameDevice($0, device) }
+            if let twin, let name = serviceName(of: twin) { mergedServices.insert(name) }
+            let adbTarget = device.localPort.map {
+                ConnectionTarget.adb(serial: device.serial, localPort: $0)
+            }
+            if let adbTarget { coveredSessionIDs.insert(adbTarget.sessionID) }
+            if let twin { coveredSessionIDs.insert(ConnectionTarget.wifi(twin).sessionID) }
+            entries.append(DeviceEntry(
+                id: "device:adb:\(device.serial)",
+                name: device.name,
+                usbTarget: nil,
+                adbTarget: adbTarget,
+                wifiTarget: twin.map { .wifi($0) },
+                transportOverride: device.ready ? nil : device.connectionHint))
         }
         if UserDefaults.standard.object(forKey: "host") != nil {
             let target = ConnectionTarget.usb(udid: nil)
             coveredSessionIDs.insert(target.sessionID)
             entries.append(DeviceEntry(id: target.sessionID, name: label(for: target),
-                                       usbTarget: target, wifiTarget: nil))
+                                       usbTarget: target, adbTarget: nil, wifiTarget: nil))
         }
         for result in discovered {
             guard let name = serviceName(of: result), !mergedServices.contains(name)
@@ -613,26 +711,28 @@ final class SenderController: ObservableObject {
             let target = ConnectionTarget.wifi(result)
             coveredSessionIDs.insert(target.sessionID)
             entries.append(DeviceEntry(id: "service:\(name)", name: name,
-                                       usbTarget: nil, wifiTarget: target))
+                                       usbTarget: nil, adbTarget: nil, wifiTarget: target))
         }
         for endpoint in manualRemembered.sorted() {
             guard let (host, portNum) = Self.parseEndpoint(endpoint) else { continue }
             let target = ConnectionTarget.manual(host: host, port: portNum)
             coveredSessionIDs.insert(target.sessionID)
             entries.append(DeviceEntry(id: target.sessionID, name: "\(host):\(portNum)",
-                                       usbTarget: nil, wifiTarget: nil, manualTarget: target))
+                                       usbTarget: nil, adbTarget: nil, wifiTarget: nil,
+                                       manualTarget: target))
         }
         // Sessions whose device vanished from discovery (e.g. Bonjour record
         // gone while the stream is still alive) keep a row to disconnect.
         for session in sessions where !coveredSessionIDs.contains(session.id) {
             entries.append(DeviceEntry(id: session.id, name: session.name,
-                                       usbTarget: nil, wifiTarget: nil))
+                                       usbTarget: nil, adbTarget: nil, wifiTarget: nil))
         }
         return entries
     }
 
     func session(for entry: DeviceEntry) -> DeviceSession? {
         if let target = entry.usbTarget, let s = session(for: target.sessionID) { return s }
+        if let target = entry.adbTarget, let s = session(for: target.sessionID) { return s }
         if let target = entry.wifiTarget, let s = session(for: target.sessionID) { return s }
         return session(for: entry.id)   // dangling-session rows
     }
@@ -695,7 +795,7 @@ struct ContentView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("OpenDisplay")
                         .font(.title3.bold())
-                    Text("Your iPads and iPhones as extra displays")
+                    Text("Your phones and tablets as extra displays")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -713,7 +813,12 @@ struct ContentView: View {
             Form {
                 Section("Devices") {
                     if controller.deviceEntries.isEmpty {
-                        Text("No devices found — plug one in via USB, or open the OpenDisplay app on a device on this WiFi network.")
+                        Text("No devices found — plug in an iPhone/iPad, connect an Android device with USB debugging, or open OpenDisplay on this WiFi network.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    if !controller.adbAvailable {
+                        Text("Android USB requires Android Platform Tools (adb). Install it with Android Studio or Homebrew; OpenDisplay detects it automatically.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -95,6 +95,7 @@ enum MainWindow {
 enum ConnectionTarget: Hashable {
     case usb(udid: String?)           // wired via built-in usbmuxd; nil = first device
     case wifi(NWBrowser.Result)       // discovered via Bonjour
+    case manual(host: String, port: UInt16)  // user-entered IP:port
 
     /// Stable identity for sessions and persistence — survives Bonjour
     /// re-discovery (fresh NWBrowser.Result) and USB replugs (new DeviceID).
@@ -104,6 +105,7 @@ enum ConnectionTarget: Hashable {
         case .wifi(let result):
             if case .service(let name, _, _, _) = result.endpoint { return "wifi:\(name)" }
             return "wifi:unknown"
+        case .manual(let host, let port): return "manual:\(host):\(port)"
         }
     }
 }
@@ -130,8 +132,11 @@ final class DeviceSession: ObservableObject, Identifiable {
     var deviceKind: String?
 
     var transportLabel: String {
-        if case .usb = target { return "USB" }
-        return "WiFi"
+        switch target {
+        case .usb: return "USB"
+        case .wifi: return "WiFi"
+        case .manual: return "Manual"
+        }
     }
 
     init(id: String, target: ConnectionTarget, name: String, sender: MacSender) {
@@ -164,6 +169,11 @@ final class SenderController: ObservableObject {
     // (debugging escape hatch, e.g. an iproxy or SSH tunnel).
     @Published var host = UserDefaults.standard.string(forKey: "host") ?? "127.0.0.1"
     @Published var port = UserDefaults.standard.string(forKey: "port") ?? "9000"
+    // UI-entered "host[:port]" for connecting to a receiver by address —
+    // e.g. a network where Bonjour/mDNS is filtered.
+    @Published var manualEndpoint = UserDefaults.standard.string(forKey: "manualEndpoint") ?? "" {
+        didSet { UserDefaults.standard.set(manualEndpoint, forKey: "manualEndpoint") }
+    }
     // `-mode mirror` / `-mode extend` launch argument also works.
     @Published var mode = CaptureMode(rawValue: UserDefaults.standard.string(forKey: "mode") ?? "") ?? .extend
     @Published var quality = StreamQuality(rawValue: UserDefaults.standard.string(forKey: "quality") ?? "") ?? .best {
@@ -193,6 +203,12 @@ final class SenderController: ObservableObject {
     }
     private var wifiRemembered = Set(UserDefaults.standard.stringArray(forKey: "wifiRemembered") ?? []) {
         didSet { UserDefaults.standard.set(Array(wifiRemembered), forKey: "wifiRemembered") }
+    }
+    // Manual "host:port" endpoints the user connected to — kept in the device
+    // list (there is no discovery to bring them back) until explicitly removed.
+    // Never auto-dialed: a dead address would sit dialing forever.
+    @Published private var manualRemembered = Set(UserDefaults.standard.stringArray(forKey: "manualRemembered") ?? []) {
+        didSet { UserDefaults.standard.set(Array(manualRemembered), forKey: "manualRemembered") }
     }
     // Install id learned from each USB device's hello, persisted, so the
     // same hardware is recognized across transports even when the user
@@ -358,7 +374,53 @@ final class SenderController: ObservableObject {
             return udid == nil ? "Manual (\(host):\(port))" : "iPhone / iPad"
         case .wifi(let result):
             return serviceName(of: result) ?? "WiFi device"
+        case .manual(let host, let port):
+            return "\(host):\(port)"
         }
+    }
+
+    // MARK: - Manual endpoint (IP:port)
+
+    /// "host", "host:port", or "[v6]:port" — port defaults to the receiver's
+    /// listen port (9000). A bare IPv6 address (multiple colons, no brackets)
+    /// is taken whole.
+    static func parseEndpoint(_ input: String) -> (host: String, port: UInt16)? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.contains(" ") else { return nil }
+        var host = trimmed
+        var port: UInt16 = 9000
+        if trimmed.hasPrefix("["), let end = trimmed.firstIndex(of: "]") {
+            host = String(trimmed[trimmed.index(after: trimmed.startIndex)..<end])
+            let rest = trimmed[trimmed.index(after: end)...]
+            if rest.hasPrefix(":") {
+                guard let p = UInt16(rest.dropFirst()), p > 0 else { return nil }
+                port = p
+            } else if !rest.isEmpty {
+                return nil
+            }
+        } else if let colon = trimmed.lastIndex(of: ":"),
+                  trimmed.firstIndex(of: ":") == colon {
+            guard let p = UInt16(trimmed[trimmed.index(after: colon)...]), p > 0 else { return nil }
+            host = String(trimmed[..<colon])
+            port = p
+        }
+        guard !host.isEmpty else { return nil }
+        return (host, port)
+    }
+
+    var manualEndpointValid: Bool {
+        Self.parseEndpoint(manualEndpoint) != nil
+    }
+
+    func connectManual() {
+        guard let (host, portNum) = Self.parseEndpoint(manualEndpoint) else { return }
+        connect(to: .manual(host: host, port: portNum), userInitiated: true)
+    }
+
+    /// Remove a remembered manual endpoint from the device list.
+    func forget(_ entry: DeviceEntry) {
+        guard case .manual(let host, let portNum)? = entry.manualTarget else { return }
+        manualRemembered.remove("\(host):\(portNum)")
     }
 
     func session(for id: String) -> DeviceSession? {
@@ -403,6 +465,7 @@ final class SenderController: ObservableObject {
         switch target {
         case .usb: usbDisabled.remove(id)
         case .wifi: wifiRemembered.insert(id)
+        case .manual(let host, let portNum): manualRemembered.insert("\(host):\(portNum)")
         }
 
         let transport: SenderTransport
@@ -418,6 +481,9 @@ final class SenderController: ObservableObject {
             }
         case .wifi(let result):
             transport = .tcp(result.endpoint)
+        case .manual(let host, let portNum):
+            transport = .tcp(.hostPort(host: NWEndpoint.Host(host),
+                                       port: NWEndpoint.Port(rawValue: portNum)!))
         }
 
         let name = label(for: target)
@@ -463,10 +529,12 @@ final class SenderController: ObservableObject {
     }
 
     /// User-initiated disconnect: also opt the device out of auto-connect.
+    /// Manual endpoints stay remembered — their row is the only way back.
     func disconnect(_ session: DeviceSession) {
         switch session.target {
         case .usb: usbDisabled.insert(session.id)
         case .wifi: wifiRemembered.remove(session.id)
+        case .manual: break
         }
         end(session)
     }
@@ -496,8 +564,10 @@ final class SenderController: ObservableObject {
         let name: String
         let usbTarget: ConnectionTarget?
         let wifiTarget: ConnectionTarget?
+        var manualTarget: ConnectionTarget? = nil
 
         var transportLabel: String {
+            if manualTarget != nil { return "Manual" }
             switch (usbTarget != nil, wifiTarget != nil) {
             case (true, true): return "USB · WiFi"
             case (true, false): return "USB"
@@ -506,7 +576,7 @@ final class SenderController: ObservableObject {
             }
         }
         /// Lowest latency first.
-        var preferredTarget: ConnectionTarget? { usbTarget ?? wifiTarget }
+        var preferredTarget: ConnectionTarget? { usbTarget ?? wifiTarget ?? manualTarget }
     }
 
     var deviceEntries: [DeviceEntry] {
@@ -544,6 +614,13 @@ final class SenderController: ObservableObject {
             coveredSessionIDs.insert(target.sessionID)
             entries.append(DeviceEntry(id: "service:\(name)", name: name,
                                        usbTarget: nil, wifiTarget: target))
+        }
+        for endpoint in manualRemembered.sorted() {
+            guard let (host, portNum) = Self.parseEndpoint(endpoint) else { continue }
+            let target = ConnectionTarget.manual(host: host, port: portNum)
+            coveredSessionIDs.insert(target.sessionID)
+            entries.append(DeviceEntry(id: target.sessionID, name: "\(host):\(portNum)",
+                                       usbTarget: nil, wifiTarget: nil, manualTarget: target))
         }
         // Sessions whose device vanished from discovery (e.g. Bonjour record
         // gone while the stream is still alive) keep a row to disconnect.
@@ -665,8 +742,30 @@ struct ContentView: View {
                                     }
                                     .controlSize(.small)
                                 }
+                                if entry.manualTarget != nil {
+                                    Button {
+                                        controller.forget(entry)
+                                    } label: {
+                                        Image(systemName: "xmark")
+                                    }
+                                    .controlSize(.small)
+                                    .help("Remove this address from the list")
+                                }
                             }
                         }
+                    }
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            TextField("IP address (host or host:port)", text: $controller.manualEndpoint)
+                                .textFieldStyle(.roundedBorder)
+                                .onSubmit { controller.connectManual() }
+                            Button("Connect") { controller.connectManual() }
+                                .controlSize(.small)
+                                .disabled(!controller.manualEndpointValid)
+                        }
+                        Text("Connect to a receiver by address when it isn't discovered automatically (port defaults to 9000).")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
                 }
 


### PR DESCRIPTION
## What this does

Two additions to the Mac sender app, one commit each:

## **ADB device support**

macOS cannot reach an Android receiver over USB tethering: RNDIS, the protocol most Android devices support, is not supported by macOS, and only newer devices offer NCM. ADB sidesteps this and works with any developer-enabled Android device over a plain USB cable. The app discovers devices via `adb devices -l`, runs a per-device `adb forward tcp:0 tcp:9000`, and dials the allocated loopback port with the existing TCP transport. `adb` is located via `ANDROID_SDK_ROOT`/`ANDROID_HOME`, `~/Library/Android/sdk`, `PATH`, and Homebrew locations (GUI apps don't inherit the shell PATH). Unauthorized or offline devices stay listed with a hint to authorize USB debugging. If `adb` is not installed, ADB discovery simply stays off.

To install `adb` on macOS via Homebrew:

```sh
brew install --cask android-platform-tools
```

## **Manual IP:port connection**

a field in the device list to connect to a receiver by address (`host`, `host:port`, or `[v6]:port`; port defaults to 9000), for networks where Bonjour/mDNS discovery is filtered. Connected endpoints are remembered in the device list until explicitly removed and are never auto-dialed.

## Screenshot

<img width="447" height="361" alt="Screenshot 2026-07-10 at 18 11 48" src="https://github.com/user-attachments/assets/9d484e6e-d169-4526-99e8-754ca3e026db" />

## Related

- https://github.com/peetzweg/opendisplay/pull/121
- https://github.com/peetzweg/opendisplay/pull/130
