### PR TITLE
feat: version compatibility handshake + iOS update gates (#132, #135)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,219 @@
+# Mac ↔ iOS compatibility
+
+How the two OpenDisplay apps stay compatible when they update on **different
+schedules**, who is responsible for detecting a mismatch, and what pairings we
+support. This is the spec for issues
+[#132](https://github.com/peetzweg/opendisplay/issues/132) (release
+orchestration), [#135](https://github.com/peetzweg/opendisplay/issues/135)
+(force update), and the wire-protocol handshake.
+
+> Status: **draft / not yet fully implemented.** Phase 1 (version on the wire +
+> the remote-config force lever) is in progress. Sections marked _(planned)_
+> describe target behavior.
+
+---
+
+## 1. The problem
+
+We cut Mac and iOS from one release tag, but distribution is not simultaneous:
+
+| | Update channel | Time to reach a user |
+|---|---|---|
+| **Mac** | Sparkle appcast (`opendisplay.app/appcast.xml`) | hours — auto, silent |
+| **iOS** | App Store (review + user tapping Update) | days → weeks, with a **long tail** |
+
+So at any moment the field holds many version pairings. The dominant one is
+**new Mac + old iPhone** (Mac raced ahead via Sparkle). But the reverse also
+happens: iOS auto-update is on for most users, so a phone can jump to a build
+whose Mac counterpart the user hasn't installed yet — **new iPhone + old Mac**.
+
+Concretely, roughly half the iOS base sat on an _older_ release than the latest
+at the time of writing (~2.5k users per version). We cannot assume the two ends
+are in lockstep, ever.
+
+## 2. Two different versions
+
+Keep these separate — conflating them is the trap:
+
+- **App version** (`MARKETING_VERSION`, e.g. `0.11.0`) — what users see, tied to
+  the App Store / Sparkle release. Bumped every release.
+- **Protocol version** (`pv`, an integer) — the wire contract between the apps.
+  Bumped **only when the wire changes**, not every release. A release that only
+  touches UI leaves `pv` untouched, so it never triggers a compatibility event.
+
+**Absent `pv` = protocol `1`.** Every install in the field today predates the
+handshake and sends no version, so it is defined as protocol 1. New builds send
+`pv ≥ 2`.
+
+Each side also declares **`minPeer`** — the oldest peer `pv` it still supports.
+Both start at `1` (support everything). We only raise a `minPeer` as the second
+half of a deliberate two-phase breaking change (§6).
+
+## 3. Compatibility matrix
+
+Let `iosPV` / `macPV` be the two protocol versions, and `macMinPeer` /
+`iosMinPeer` the minimum-supported-peer each side declares.
+
+| Condition | Meaning | Outcome |
+|---|---|---|
+| `iosPV ≥ macMinPeer` **and** `macPV ≥ iosMinPeer` | fully compatible | **Stream normally.** New-but-optional features are gated on the peer's `pv` and simply stay off for older peers. |
+| `iosPV < macMinPeer` | iPhone too old for this Mac | **Update the iPhone.** Mac detects it (it sees `iosPV`), drives the UI. |
+| `macPV < iosMinPeer` | Mac too old for this iPhone | **Update the Mac.** iPhone detects it (it sees `macPV`), drives the UI. |
+| both of the above | both behind their floors | Both need updating; each device shows the action that fixes _it_. |
+
+Because `minPeer` stays at `1` by default, the "too old" rows are **empty in
+normal operation** — they only light up after we deliberately raise a floor for
+a breaking change. Day-to-day, everything is the top row: compatible, with
+newer features gated off for older peers.
+
+## 4. Who checks what — and why it can't live on one side alone
+
+**Instinct:** "put the compatibility check solely in the Mac app." Mostly right,
+with one hard exception. The Mac _is_ the natural primary owner:
+
+- It updates first and continuously, so the Mac in the field is always the
+  freshest app and can carry the newest, smartest compatibility table.
+- It already receives the iPhone's `pv` in `hello`, so it can evaluate the pair
+  and **tell the iPhone what to show** (`updateRequired`). The iPhone stays dumb.
+
+**The exception — the side that needs updating may be too old to know it.** If a
+Mac is old enough to be incompatible with a _newer_ iPhone, it may predate the
+handshake entirely and cannot diagnose its own obsolescence. Only the **new
+iPhone** can see that the Mac is behind. So the "update your Mac" nudge has to be
+able to originate on **iOS**.
+
+Ownership therefore splits:
+
+| Detection | Owner | Mechanism |
+|---|---|---|
+| iPhone too old for the Mac (common case) | **Mac** (primary) | reads `hello.pv`; sends `updateRequired` → iPhone renders "Update iPhone"; shows a local menu-bar hint too |
+| Mac too old for the iPhone | **iOS** | reads `welcome.pv` (or notices no `welcome` arrives at all → old Mac); renders "Update your Mac" |
+| Install that never meets a capable Mac (e.g. the old-version tail) | **iOS** | remote-config force lever (§5) — the _only_ thing that reaches it |
+
+**Rule of thumb:** each app enforces its own `minPeer` against the peer's
+advertised `pv`; whichever app is new enough to _detect_ the mismatch is the one
+that surfaces the nudge — for the peer's device if that's what needs updating.
+
+So: Mac is the primary owner and single source of truth for policy, but it
+**cannot be the sole owner.** iOS keeps a minimal check for the "old Mac"
+direction and owns the offline/never-connect case.
+
+## 5. The remote-config force lever (iOS) — issue #135
+
+Connection-independent. On launch the iPhone fetches a small static file we host
+next to the Sparkle appcast:
+
+- **URL:** `https://opendisplay.app/ios-version.json` (source of truth:
+  `public/ios-version.json`; Vite copies it into `docs/` and Pages serves it).
+- **Shape:**
+  ```json
+  {
+    "ios": {
+      "hardMinimumVersion": "0.0.0",
+      "recommendedVersion": "0.11.0",
+      "storeURL": "itms-apps://apps.apple.com/app/id6780264891",
+      "message": "…"
+    }
+  }
+  ```
+- `version < hardMinimumVersion` → **blocking** update screen (App Store deep
+  link, non-dismissible). This is the force.
+- `hardMinimumVersion ≤ version < recommendedVersion` → **soft, dismissible** nag.
+- **`hardMinimumVersion` is the force floor: hand-edited via PR, deliberately and
+  rarely.** It must _not_ auto-track "latest" or every release would force an
+  update (the opposite of what we want). `recommendedVersion` may be
+  CI-auto-stamped, like the appcast.
+- **Fails open:** any network/parse error, or a dormant `0.0.0` floor, shows no
+  gate — a Pages outage can never brick the app. Dev builds (`0.0.0`) skip the
+  check entirely.
+
+Why this is the lever that matters: **you cannot force-update an install that
+doesn't already contain the force-check.** The current old-version tail has no
+check at all — the app can only ever force builds that shipped _with_ it. So we
+ship the check now (dormant floor) to start the saturation clock, and only raise
+the floor once a force-capable build has spread.
+
+## 6. What we support — and what we don't
+
+**Supported:**
+
+- **Additive changes are free and default.** New optional `hello`/`welcome`
+  fields and new message types, gated on the peer's `pv`. Both apps already
+  log-and-ignore unknown message types and tolerate missing optional fields, so
+  additive changes never break an older peer.
+- Mac supports iOS receivers **≥ N releases back** — _N is TBD (see open
+  questions); until decided, "all protocol-1 receivers."_
+- iOS supports Macs back to protocol 1 (no floor raised yet).
+
+**Breaking changes are two-phase (never one-shot):**
+
+1. **Release 1** ships support for _both_ old and new behavior on _both_ apps,
+   the new path gated on `pv`. Nothing breaks; the new path only activates when
+   both peers are new enough.
+2. **Release 2**, only after the iOS build has had an App Store adoption window,
+   raises the relevant `minPeer` and deletes the old path. Now old peers get a
+   clean "please update" instead of a silent break.
+
+**Not supported / hazards:**
+
+- **Silent breaking changes.** Never change framing or field semantics without
+  the two-phase dance — the failure mode is an invisible reconnect loop, not a
+  message.
+- **Control frames ≥ 32 KB or containing a NUL byte on the video channel.** The
+  phone disambiguates JSON control vs. H.264 frames heuristically (`< 32 KB,
+  starts with '{', no NUL`). A large or binary control message would be fed to
+  the video decoder. A typed frame header is a future protocol item, unlocked
+  only because this handshake exists.
+- **Forcing the pre-handshake tail via the app.** Installs older than the first
+  force-capable build have no lever — they are reachable only by the Mac's
+  in-session `updateRequired` (if they connect to a new-enough Mac) or they
+  simply stop working. Graceful degradation for them is mandatory _during the
+  transition_, not a standing commitment.
+
+## 7. Message flow _(planned)_
+
+```mermaid
+sequenceDiagram
+    participant P as iPhone (receiver)
+    participant M as Mac (sender)
+    Note over P: On launch, independent of any Mac
+    P->>P: fetch ios-version.json, decide force or nag or ok (#135)
+    P-->>M: Bonjour TXT advertises id and pv
+    M->>P: connect
+    P->>M: hello (panel, id, pv)
+    M->>M: iosPV = hello.pv or 1 if absent
+    M->>P: welcome (pv = macPV, min = macMinPeer)
+    alt iosPV below macMinPeer
+        M->>P: updateRequired (target ios, store, message)
+        Note over P: blocking Update iPhone screen
+    else macPV below iosMinPeer
+        Note over P: welcome.pv below iOS floor, show Update your Mac
+    else compatible
+        Note over P,M: stream, new features gated on peer pv
+    end
+    Note over P: no welcome ever arrives means old Mac, soft update Mac hint
+```
+
+## 8. Transition plan
+
+1. **Now:** ship, in the _same_ iOS build — `pv` on the wire, `welcome`
+   handling, `updateRequired` handling, and the remote-config check. Mac ships
+   `pv` + `welcome` + `updateRequired` sender. **All floors stay at `1` /
+   `hardMinimumVersion` stays `0.0.0` (dormant).** Nobody is forced yet; the goal
+   is only to get the machinery into the field.
+2. **Saturate:** watch per-version adoption. The levers do nothing until a
+   capable build is widespread.
+3. **Flip, when justified:** raise `ios-version.json`'s `hardMinimumVersion` to
+   retire an ancient iOS base, and/or run a two-phase `minPeer` raise for a
+   specific breaking change. Every transition/graceful shim lands with a removal
+   ticket.
+
+## 9. Open questions (need a decision)
+
+- **`N`** — how many iOS releases back must the Mac support before we're allowed
+  to drop a path? ("All v1" is the placeholder.)
+- **Incompatible pair: refuse or degrade?** Recommendation: keep the link and
+  degrade during the transition; only refuse-to-connect after a floor is
+  deliberately raised.
+- **"Update your Mac" severity on iOS** — blocking or soft? Recommendation: soft
+  hint unless `macPV < iosMinPeer` (a real hard floor), then blocking.

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -71,8 +71,11 @@ struct PhoneInfo: Decodable {
     let id: String?       // per-install identity (older receivers omit it) —
                           // lets the controller match the same physical device
                           // across USB and WiFi
+    let pv: Int?          // receiver protocol version (issue #132); absent on
+                          // every pre-handshake install → treat as protocol 1
 
     var kind: String { device ?? "device" }
+    var protocolVersion: Int { pv ?? WireProtocol.assumedWhenAbsent }
 }
 
 /// How the sender reaches the receiver. Reconnects re-dial from scratch, so
@@ -806,6 +809,16 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 let previous = lastHello
                 lastHello = info
                 Task { @MainActor in self.onHello?(info) }
+                // Version handshake (issue #132). Reply with our identity, and
+                // if the receiver is below the version we support, tell it to
+                // update. Both are additive: older receivers ignore unknown
+                // message types. Sending on every hello is idempotent — the
+                // phone dedupes by content.
+                sendWelcome()
+                if info.protocolVersion < WireProtocol.minSupportedPeer {
+                    Log.info("receiver protocol \(info.protocolVersion) below supported \(WireProtocol.minSupportedPeer) — requesting update")
+                    sendUpdateRequired(kind: info.kind)
+                }
                 if let continuation = helloContinuation {
                     helloContinuation = nil
                     continuation.resume(returning: info)
@@ -1012,6 +1025,29 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     /// Control messages on the video channel (pong etc.) — framed JSON without
     /// start codes; the receiver routes payloads starting with '{'.
+    // MARK: - Version handshake (issue #132)
+
+    /// Identify ourselves to the receiver: our protocol version and the oldest
+    /// receiver version we still support.
+    private func sendWelcome() {
+        sendJSONFrame("{\"type\":\"\(WireMessage.welcome)\",\"pv\":\(WireProtocol.version),\"min\":\(WireProtocol.minSupportedPeer)}")
+    }
+
+    /// Ask the receiver to update from the App Store (built via JSONSerialization
+    /// because the message text is user-facing prose).
+    private func sendUpdateRequired(kind: String) {
+        let dict: [String: Any] = [
+            "type": WireMessage.updateRequired,
+            "target": "ios",
+            "store": AppStore.updateURL.absoluteString,
+            "message": "This \(kind) app is too old for this Mac. Update OpenDisplay from the App Store to reconnect.",
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: dict),
+           let json = String(data: data, encoding: .utf8) {
+            sendJSONFrame(json)
+        }
+    }
+
     private func sendJSONFrame(_ json: String) {
         guard let connection, connectionReady else { return }
         let payload = Data(json.utf8)

--- a/Shared/AppStore.swift
+++ b/Shared/AppStore.swift
@@ -1,0 +1,14 @@
+// Compiled into BOTH targets. The iOS App Store listing — the numeric ID
+// otherwise lives only in the landing page (`src/App.tsx`). Centralized here so
+// the iOS app can deep-link to its own update page AND the Mac can hand the
+// same link to the phone in an `updateRequired` message.
+
+import Foundation
+
+enum AppStore {
+    static let iOSAppID = "6780264891"
+    /// Opens the App Store app directly on the listing (with an Update button).
+    static let updateURL = URL(string: "itms-apps://apps.apple.com/app/id\(iOSAppID)")!
+    /// Web fallback for anywhere the itms-apps scheme can't be handled.
+    static let webURL = URL(string: "https://apps.apple.com/app/id\(iOSAppID)")!
+}

--- a/Shared/Protocol.swift
+++ b/Shared/Protocol.swift
@@ -1,0 +1,31 @@
+// Compiled into BOTH the Mac and iOS targets (see project.yml `sources`).
+// Keep this Foundation-only so it stays platform-neutral.
+
+import Foundation
+
+/// The wire-protocol contract between the two apps, decoupled from the app's
+/// marketing version. See COMPATIBILITY.md.
+///
+/// Bumped only when the wire changes, not every release, so UI-only releases
+/// never trigger a compatibility event. A peer that advertises no version is
+/// protocol 1 — that's every install in the field that predates the handshake.
+enum WireProtocol {
+    /// The protocol version this build speaks.
+    static let version = 2
+
+    /// Oldest peer protocol version this build still supports. Stays at 1
+    /// (support everything) until a deliberate two-phase breaking change
+    /// raises it — raising this is what turns "peer too old" into a hard gate.
+    static let minSupportedPeer = 1
+
+    /// A peer that advertises no `pv` is defined as protocol 1.
+    static let assumedWhenAbsent = 1
+}
+
+/// Control-message `type` strings introduced with the handshake. The pre-
+/// existing types (`hello`, `ping`, `pong`, `touch`, …) stay inline for now to
+/// keep this change additive and low-risk; unify later if we do a wider pass.
+enum WireMessage {
+    static let welcome = "welcome"                  // Mac -> phone: Mac's pv + min supported
+    static let updateRequired = "updateRequired"    // Mac -> phone: peer is below the Mac's floor
+}

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -37,8 +37,10 @@ extension UIWindow {
 
 struct ReceiverScreen: View {
     @StateObject private var model = ReceiverModel()
+    @StateObject private var versionGate = VersionGate()
     @State private var showSettings = false
     @State private var showOnboarding = false
+    @State private var nagDismissed = false
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage("showAnalytics") private var showAnalytics = false
     @AppStorage("metalRenderer") private var metalRenderer = false
@@ -50,6 +52,19 @@ struct ReceiverScreen: View {
     // Streaming = connected and the video format is known.
     private var isStreaming: Bool {
         model.receiver.connected && model.receiver.videoSize != .zero
+    }
+
+    // Below the force floor → present the blocking gate (issue #135). The
+    // fullScreenCover binding's setter is a no-op so the user can't dismiss it.
+    private var requiredUpdate: VersionGate.Update? {
+        if case let .required(update) = versionGate.status { return update }
+        return nil
+    }
+
+    // Soft nag: shown once per launch, dismissible.
+    private var recommendedUpdate: VersionGate.Update? {
+        if case let .recommended(update) = versionGate.status, !nagDismissed { return update }
+        return nil
     }
 
     var body: some View {
@@ -89,6 +104,23 @@ struct ReceiverScreen: View {
         .sheet(isPresented: $showSettings) {
             SettingsView(receiver: model.receiver)
         }
+        // Below the force floor → blocking gate. Setter is a no-op: the user
+        // cannot dismiss it, only update.
+        .fullScreenCover(item: Binding(get: { requiredUpdate }, set: { _ in })) { update in
+            UpdateRequiredView(update: update)
+        }
+        // At/above the floor but behind the recommended version → soft nag.
+        .alert("Update available",
+               isPresented: Binding(get: { recommendedUpdate != nil },
+                                    set: { if !$0 { nagDismissed = true } })) {
+            Button("Update") {
+                if let update = recommendedUpdate { UIApplication.shared.open(update.url) }
+            }
+            Button("Later", role: .cancel) { nagDismissed = true }
+        } message: {
+            if let update = recommendedUpdate { Text(update.message) }
+        }
+        .task { await versionGate.check() }
         .onReceive(NotificationCenter.default.publisher(for: .deviceDidShake)) { _ in
             showSettings = true
         }

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -121,6 +121,8 @@ struct ReceiverScreen: View {
             if let update = recommendedUpdate { Text(update.message) }
         }
         .task { await versionGate.check() }
+        // Merge the connected Mac's compatibility signal into the same gate.
+        .onReceive(model.receiver.$peerSignal) { versionGate.applyPeer($0) }
         .onReceive(NotificationCenter.default.publisher(for: .deviceDidShake)) { _ in
             showSettings = true
         }

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -49,6 +49,9 @@ final class PhoneReceiver: ObservableObject {
     @Published var connected = false
     @Published var videoSize = CGSize.zero   // for touch coordinate mapping
     @Published var perf = PerfStats()
+    // Compatibility signal from the connected Mac (issue #132). Nil = no signal.
+    // Merged into the update gate by ReceiverScreen.
+    @Published var peerSignal: PeerUpdateSignal?
 
     private var listener: NWListener?
     private var listenerHealthy = false
@@ -161,6 +164,7 @@ final class PhoneReceiver: ObservableObject {
     private var advertisedService: NWListener.Service {
         var txt = NWTXTRecord()
         txt["id"] = Self.installID
+        txt["pv"] = String(WireProtocol.version)   // issue #132
         return NWListener.Service(name: serviceName, type: "_opensidecar._tcp",
                                   domain: nil, txtRecord: txt)
     }
@@ -343,6 +347,21 @@ final class PhoneReceiver: ObservableObject {
             let anchor = CGPoint(x: obj["ax"] as? Double ?? 0, y: obj["ay"] as? Double ?? 0)
             let normSize = CGSize(width: nw, height: nh)
             DispatchQueue.main.async { self.onCursorImage?(image, anchor, normSize) }
+        case WireMessage.welcome:
+            // The Mac identified itself (issue #132). If it speaks a protocol
+            // older than we support, it's the Mac that needs updating — and an
+            // old Mac can't diagnose that itself, so we surface it here.
+            let macPV = obj["pv"] as? Int ?? WireProtocol.assumedWhenAbsent
+            if macPV < WireProtocol.minSupportedPeer {
+                let msg = "The OpenDisplay app on your Mac is too old for this \(deviceKind) app. Update OpenDisplay on your Mac to reconnect."
+                DispatchQueue.main.async { self.peerSignal = .updateMac(message: msg) }
+            }
+        case WireMessage.updateRequired:
+            // The Mac refuses this pairing until we update from the App Store.
+            let message = obj["message"] as? String
+                ?? "Update OpenDisplay from the App Store to keep using your second display."
+            let store = (obj["store"] as? String).flatMap { URL(string: $0) } ?? AppStore.updateURL
+            DispatchQueue.main.async { self.peerSignal = .updateIPhone(message: message, storeURL: store) }
         default:
             break
         }
@@ -389,6 +408,7 @@ final class PhoneReceiver: ObservableObject {
             "scale": deviceScale,
             "device": UIDevice.current.userInterfaceIdiom == .pad ? "iPad" : "iPhone",
             "id": Self.installID,
+            "pv": WireProtocol.version,   // issue #132 — absent on old receivers
         ], on: conn)
         Log.info("hello sent")
     }

--- a/iOS/VersionGate.swift
+++ b/iOS/VersionGate.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+
+// `AppStore` (the App Store identity + deep link) lives in Shared/AppStore.swift
+// so the Mac can reference the same link when it asks the phone to update.
+
+// MARK: - Peer-driven update signals (issue #132)
+
+/// What the connected Mac (or its absence) tells us about compatibility. Fed
+/// into the same gate as the remote-config check so there is one update UI.
+enum PeerUpdateSignal: Equatable {
+    case updateIPhone(message: String, storeURL: URL)   // Mac sent `updateRequired`
+    case updateMac(message: String)                     // Mac's pv is below our floor
+}
+
+// MARK: - Version gate (issue #135)
+
+/// Connection-independent update lever. On launch the app fetches a small
+/// policy file we host on GitHub Pages next to the Sparkle appcast and compares
+/// its own version against it. This is the ONLY mechanism that can reach an
+/// install that never connects to an updated Mac (e.g. the large tail still on
+/// an old release) — the peer-driven `updateRequired` path (issue #132) can't.
+///
+/// Privacy: the only egress is a single unauthenticated GET of a static file,
+/// carrying no identifiers. It fails open — any network or parse error, or a
+/// missing/dormant floor, leaves the gate closed so a Pages outage can never
+/// brick the app.
+@MainActor
+final class VersionGate: ObservableObject {
+    struct Update: Identifiable, Equatable {
+        let message: String
+        let url: URL
+        // Content-derived so re-applying the same signal (e.g. the phone
+        // re-sends hello on rotation → Mac re-sends its reply) keeps a stable
+        // identity and doesn't make `fullScreenCover(item:)` re-present.
+        var id: String { url.absoluteString + "\n" + message }
+    }
+
+    enum Status: Equatable {
+        case ok
+        case recommended(Update)   // soft, dismissible nag
+        case required(Update)      // hard floor — blocking, non-dismissible
+    }
+
+    /// The effective gate: the more severe of the remote-config result and the
+    /// peer signal.
+    @Published private(set) var status: Status = .ok
+
+    // The two independent inputs, merged by `recompute()`.
+    private var remoteStatus: Status = .ok
+    private var peerStatus: Status = .ok
+
+    private let manifestURL = URL(string: "https://opendisplay.app/ios-version.json")!
+
+    /// The running app's marketing version. Local/dev builds ship "0.0.0"
+    /// (the project.yml default), which we treat as "skip the gate".
+    private var currentVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
+    }
+
+    func check() async {
+        let current = currentVersion
+        guard current != "0.0.0" else { return }   // dev build — never gate
+
+        var request = URLRequest(url: manifestURL)
+        request.cachePolicy = .reloadRevalidatingCacheData
+        request.timeoutInterval = 8
+        guard
+            let (data, response) = try? await URLSession.shared.data(for: request),
+            (response as? HTTPURLResponse)?.statusCode == 200,
+            let manifest = try? JSONDecoder().decode(Manifest.self, from: data)
+        else { return }   // fail open
+
+        let policy = manifest.ios
+        let url = policy.storeURL.flatMap { URL(string: $0) } ?? AppStore.updateURL
+
+        if let floor = policy.hardMinimumVersion, isVersion(current, olderThan: floor) {
+            remoteStatus = .required(Update(message: policy.message ?? Self.requiredFallback, url: url))
+        } else if let want = policy.recommendedVersion, isVersion(current, olderThan: want) {
+            remoteStatus = .recommended(Update(message: policy.message ?? Self.recommendedFallback, url: url))
+        } else {
+            remoteStatus = .ok
+        }
+        recompute()
+    }
+
+    /// Fold in what the connected Mac told us. `updateIPhone` is a hard gate
+    /// (the Mac refuses this pairing); `updateMac` is a soft nag pointing at the
+    /// Mac app download, since the fix is on the other device. Passing `nil`
+    /// clears the peer signal (e.g. on disconnect).
+    func applyPeer(_ signal: PeerUpdateSignal?) {
+        switch signal {
+        case let .updateIPhone(message, storeURL):
+            peerStatus = .required(Update(message: message, url: storeURL))
+        case let .updateMac(message):
+            peerStatus = .recommended(Update(message: message, url: macAppURL))
+        case nil:
+            peerStatus = .ok
+        }
+        recompute()
+    }
+
+    private func recompute() {
+        status = severity(peerStatus) >= severity(remoteStatus) ? peerStatus : remoteStatus
+    }
+
+    private func severity(_ s: Status) -> Int {
+        switch s {
+        case .ok: return 0
+        case .recommended: return 1
+        case .required: return 2
+        }
+    }
+
+    // MARK: Policy file shape
+
+    private struct Manifest: Decodable {
+        struct Policy: Decodable {
+            let hardMinimumVersion: String?
+            let recommendedVersion: String?
+            let storeURL: String?
+            let message: String?
+        }
+        let ios: Policy
+    }
+
+    private static let requiredFallback =
+        "This version of OpenDisplay is no longer supported. Update from the App Store to keep using your second display."
+    private static let recommendedFallback =
+        "A newer version of OpenDisplay is available."
+}
+
+/// Numeric dotted-version compare (e.g. "0.10.0" older than "0.11.0"). Missing
+/// components count as 0; non-numeric suffixes are ignored so a pre-release tag
+/// never blocks the compare.
+func isVersion(_ a: String, olderThan b: String) -> Bool {
+    let lhs = versionComponents(a), rhs = versionComponents(b)
+    for i in 0..<max(lhs.count, rhs.count) {
+        let x = i < lhs.count ? lhs[i] : 0
+        let y = i < rhs.count ? rhs[i] : 0
+        if x != y { return x < y }
+    }
+    return false
+}
+
+private func versionComponents(_ s: String) -> [Int] {
+    s.split(separator: ".").map { Int($0.prefix { $0.isNumber }) ?? 0 }
+}
+
+// MARK: - Blocking update screen
+
+/// Full-screen, non-dismissible gate shown when the install is below the force
+/// floor. Modeled on `OnboardingView`; the only action is opening the App Store.
+struct UpdateRequiredView: View {
+    let update: VersionGate.Update
+
+    var body: some View {
+        VStack(spacing: 28) {
+            Spacer()
+            Image(systemName: "arrow.up.circle.fill")
+                .font(.system(size: 64, weight: .light))
+                .foregroundStyle(.tint)
+
+            VStack(spacing: 10) {
+                Text("Update required")
+                    .font(.title2.bold())
+                Text(update.message)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Button {
+                UIApplication.shared.open(update.url)
+            } label: {
+                Label("Update on the App Store", systemImage: "arrow.down.circle")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6)
+            }
+            .buttonStyle(.borderedProminent)
+
+            Spacer()
+        }
+        .padding(32)
+        .interactiveDismissDisabled()   // belt-and-suspenders; no dismiss affordance anyway
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -39,6 +39,7 @@ targets:
     deploymentTarget: "14.0"
     sources:
       - Mac
+      - Shared
     dependencies:
       - package: Sparkle
     info:
@@ -89,6 +90,7 @@ targets:
     deploymentTarget: "17.0"
     sources:
       - iOS
+      - Shared
     info:
       path: iOS/Info.plist
       properties:

--- a/public/ios-version.json
+++ b/public/ios-version.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "iOS/iPadOS update policy, served at https://opendisplay.app/ios-version.json (see issue #135). hardMinimumVersion is the FORCE FLOOR: installs below it get a blocking update screen — edit it by hand via PR, deliberately and rarely. Keep it at 0.0.0 (dormant, nobody forced) until a force-capable build has saturated the field, then raise it. recommendedVersion is the soft-nag threshold and may be auto-stamped by release CI. The app fails open: if this file is unreachable or malformed, no gate is shown.",
+  "ios": {
+    "hardMinimumVersion": "0.0.0",
+    "recommendedVersion": "0.11.0",
+    "storeURL": "itms-apps://apps.apple.com/app/id6780264891",
+    "message": "A newer version of OpenDisplay is available with important fixes. Update to keep your second display working smoothly."
+  }
+}


### PR DESCRIPTION
Closes #135, implements Phase 1 of #132.

Adds a protocol-version handshake on the wire plus an iOS update gate (a remote-config force/nag lever and a peer-driven signal from the Mac), so we can detect version drift and prompt updates without breaking old pairings.

**Why:** Mac (Sparkle, hours) and iOS (App Store review + user updates, weeks) never arrive in lockstep — roughly half the iOS base trails the latest. Today nothing is versioned on the wire, so a breaking change would fail silently. We need to (a) start putting a version in the field now and (b) be able to force the stale tail to update — the connection-independent lever is the only thing that reaches phones that never meet an updated Mac.

**How:** additive and dormant. The phone sends `pv` in `hello`/Bonjour TXT; the Mac replies `welcome` and can send `updateRequired`; the phone renders both, merged into one gate together with a remote-config check against `opendisplay.app/ios-version.json`. Old peers ignore the unknown keys/messages. All floors ship at `1`/`0.0.0`, so no update path fires yet — this is machinery only, to start the saturation clock. New `Shared/` module holds the protocol constants + App Store link. Design + matrix in `COMPATIBILITY.md`.

Built both targets; verified on a physical iPhone (extend-mode streaming unaffected, gate correctly dormant). One caveat: the force-gate UI can't self-test on a dev build (`0.0.0` skips the check) — arm it once on a real build before ever raising the floor.
