### PR TITLE
fix(mac): CGDisplayStream fallback when SCShareableContent misses virtual display

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -101,6 +101,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     @MainActor var onHello: ((PhoneInfo) -> Void)?
 
     private var stream: SCStream?
+    /// Fallback when SCShareableContent never lists the CGVirtualDisplay (#142).
+    private var displayStream: CGDisplayStream?
     private var encoder: VTCompressionSession?
     private var connection: NWConnection?
     private var virtualDisplay: VirtualDisplay?
@@ -314,13 +316,25 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         }
         virtualDisplay = vd
         inputInjector = InputInjector(displayID: vd.displayID)
+        _ = await vd.waitUntilReady()
 
-        let display = try await findSCDisplay(id: vd.displayID)
         // Quality scaling: capture/encode below native when requested — the
         // display itself stays native so window layout is unaffected.
         let captureW = (Int(Double(pointsWide * 2) * quality.scale)) & ~1
         let captureH = (Int(Double(pointsHigh * 2) * quality.scale)) & ~1
-        try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
+        // Prefer ScreenCaptureKit. On some Mac mini + external-display-only
+        // setups the virtual display never appears in SCShareableContent
+        // (MacSender Code=3 / issue #142) even though CGVirtualDisplay
+        // returned an id — fall back to CGDisplayStream using that id.
+        do {
+            let display = try await findSCDisplay(id: vd.displayID)
+            try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
+        } catch {
+            Log.info("SCK capture path failed (\(error.localizedDescription)) — CGDisplayStream fallback")
+            await status("Using alternate capture path…")
+            try await startCaptureCGDisplayStream(displayID: vd.displayID,
+                                                  pixelsWide: captureW, pixelsHigh: captureH)
+        }
 
         // Debug aid (`defaults write sh.peet.opensidecar.mac testPattern -bool true`):
         // an animated window on the virtual display generates a constant frame
@@ -344,6 +358,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             Log.info("reconfiguring for \(target.pixelsWide)x\(target.pixelsHigh)")
             if let stream { try? await stream.stopCapture() }
             stream = nil
+            if let displayStream { _ = displayStream.stop() }
+            displayStream = nil
             if let encoder { VTCompressionSessionInvalidate(encoder) }
             encoder = nil
             virtualDisplay = nil   // removes the old display
@@ -365,16 +381,104 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     }
 
     /// The virtual display takes a moment to show up in shareable content.
+    /// Uses the explicit SCShareableContent API, logs diagnostics on failure,
+    /// and matches by size as a secondary key when CG/SCK ids diverge.
     private func findSCDisplay(id: CGDirectDisplayID) async throws -> SCDisplay {
-        for _ in 0..<20 {
-            let content = try await SCShareableContent.current
+        var lastIDs: [CGDirectDisplayID] = []
+        // ~5s — same overall budget as before; then setupExtend falls back.
+        for attempt in 0..<20 {
+            let content: SCShareableContent
+            do {
+                content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+            } catch {
+                content = try await SCShareableContent.current
+            }
+            lastIDs = content.displays.map(\.displayID)
             if let display = content.displays.first(where: { $0.displayID == id }) {
                 return display
             }
+            let bounds = CGDisplayBounds(id)
+            if bounds.width > 0,
+               let bySize = content.displays.first(where: {
+                   abs(Double($0.width) - bounds.width) < 2
+                       && abs(Double($0.height) - bounds.height) < 2
+               }) {
+                Log.info("findSCDisplay: matched by size id=\(bySize.displayID) (want \(id))")
+                return bySize
+            }
+            if attempt == 0 || attempt == 19 {
+                let ns = NSScreen.screens.compactMap {
+                    ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value
+                }
+                Log.info("findSCDisplay attempt \(attempt): sck=\(lastIDs) ns=\(ns) want=\(id) online=\(CGDisplayIsOnline(id))")
+            }
             try await Task.sleep(for: .milliseconds(250))
         }
+        Log.info("findSCDisplay failed want=\(id) lastSCK=\(lastIDs) (connection/hello OK — local capture enumeration failed)")
         throw NSError(domain: "MacSender", code: 3,
                       userInfo: [NSLocalizedDescriptionKey: "virtual display never appeared in SCShareableContent"])
+    }
+
+    /// Fallback capture when ScreenCaptureKit cannot enumerate the virtual display.
+    /// Targets the CGDirectDisplayID from CGVirtualDisplay directly.
+    /// CGDisplayStream is deprecated in favor of SCK — keep this path as a last resort only (#142).
+    private func startCaptureCGDisplayStream(displayID: CGDirectDisplayID,
+                                             pixelsWide: Int, pixelsHigh: Int) async throws {
+        setupEncoder(width: pixelsWide, height: pixelsHigh)
+
+        let handler: CGDisplayStreamFrameAvailableHandler = { [weak self] status, displayTime, surface, _ in
+            guard let self else { return }
+            guard status == .frameComplete, let surface else { return }
+
+            var unmanaged: Unmanaged<CVPixelBuffer>?
+            let err = CVPixelBufferCreateWithIOSurface(
+                kCFAllocatorDefault, surface, nil, &unmanaged
+            )
+            guard err == kCVReturnSuccess, let pixelBuffer = unmanaged?.takeUnretainedValue() else { return }
+
+            self.lastPixelBuffer = pixelBuffer
+            self.lastCaptureAt = Date()
+            self.capFrames += 1
+
+            guard self.connectionReady else { return }
+            if self.pendingSends > self.maxPendingSends {
+                self.needsKeyframe = true
+                self.dropsThisWindow += 1
+                self.dropsTotal += 1
+                return
+            }
+            let pts = CMTime(value: CMTimeValue(displayTime), timescale: 1_000_000_000)
+            self.encode(pixelBuffer, pts: pts)
+        }
+
+        let props = [CGDisplayStream.showCursor: !localCursor] as CFDictionary
+        guard let ds = CGDisplayStream(
+            dispatchQueueDisplay: displayID,
+            outputWidth: pixelsWide,
+            outputHeight: pixelsHigh,
+            pixelFormat: Int32(kCVPixelFormatType_32BGRA),
+            properties: props,
+            queue: queue,
+            handler: handler
+        ) else {
+            throw NSError(domain: "MacSender", code: 4,
+                          userInfo: [NSLocalizedDescriptionKey: "CGDisplayStreamCreate failed"])
+        }
+
+        let startErr = ds.start()
+        guard startErr == .success else {
+            throw NSError(domain: "MacSender", code: 5,
+                          userInfo: [NSLocalizedDescriptionKey: "CGDisplayStreamStart failed: \(startErr.rawValue)"])
+        }
+
+        displayStream = ds
+        captureDisplayID = displayID
+        lastCursorPNGHash = 0
+        lastCursorSent = (-1, -1, false)
+        startCursorEcho()
+        Log.info("capture started (CGDisplayStream fallback): \(pixelsWide)x\(pixelsHigh) display \(displayID) mode \(mode.rawValue)")
+        let kind = lastHello?.kind ?? "device"
+        await status("\(mode == .extend ? "Extending to" : "Mirroring to") \(kind) (\(pixelsWide)×\(pixelsHigh))")
     }
 
     private func startCapture(display: SCDisplay, pixelsWide: Int, pixelsHigh: Int) async throws {
@@ -420,6 +524,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         cursorImageTimer = nil
         stream?.stopCapture { _ in }
         stream = nil
+        if let displayStream { _ = displayStream.stop() }
+        displayStream = nil
         connection?.cancel()
         connection = nil
         if let encoder { VTCompressionSessionInvalidate(encoder) }

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 import CoreGraphics
 
 /// Wraps the private CGVirtualDisplay API: makes macOS believe a real monitor
@@ -81,6 +82,41 @@ final class VirtualDisplay {
                 try? await Task.sleep(for: .milliseconds(settled ? 2000 : 200))
             }
         }
+    }
+
+    /// `applySettings` can succeed before WindowServer attaches the display.
+    /// Poll until the id appears in the online list / NSScreen, or time out.
+    /// Returns whether the display looked attached (capture may still work
+    /// via CGDisplayStream even when this returns false on some systems).
+    @discardableResult
+    func waitUntilReady(timeoutSeconds: Double = 5.0) async -> Bool {
+        let id = display.displayID
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        var attempt = 0
+        while Date() < deadline {
+            var count: UInt32 = 0
+            CGGetOnlineDisplayList(0, nil, &count)
+            var ids = [CGDirectDisplayID](repeating: 0, count: Int(max(count, 1)))
+            CGGetOnlineDisplayList(count, &ids, &count)
+            let list = Array(ids.prefix(Int(count)))
+            let ns = NSScreen.screens.compactMap {
+                ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value
+            }
+            if list.contains(id) || CGDisplayIsActive(id) != 0 || ns.contains(id) {
+                Log.info("virtual display ready: id=\(id) attempt=\(attempt) cg=\(list) ns=\(ns)")
+                return true
+            }
+            if attempt == 0 || attempt % 10 == 9 {
+                Log.info("virtual display waiting: id=\(id) attempt=\(attempt) cg=\(list) ns=\(ns) online=\(CGDisplayIsOnline(id))")
+            }
+            attempt += 1
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+        Log.info("virtual display not listed as online within timeout: id=\(id) — continuing anyway")
+        // One re-apply can help when WindowServer dropped the first attach.
+        _ = display.apply(settings)
+        try? await Task.sleep(for: .milliseconds(300))
+        return CGDisplayIsActive(id) != 0 || CGDisplayIsOnline(id) != 0
     }
 
     /// Returns true when the display is (now) in its HiDPI mode. Silent when


### PR DESCRIPTION
## Summary

Fixes the hard failure path reported in #142:

> `virtual display never appeared in SCShareableContent` (MacSender Code=3)

On affected machines (reproduced: **Mac mini M2 + single external 4K display + macOS 15.7.x**):

1. Wi‑Fi connect + `phone hello` succeed  
2. `CGVirtualDisplay` is created and returns an id  
3. `SCShareableContent` never lists that id → capture never starts  
4. No purple recording indicator; iPad stays on the OpenDisplay UI  

This is **not** a network failure — enumeration fails after a successful handshake.

## Changes

| File | Change |
|------|--------|
| `Mac/VirtualDisplay.swift` | `waitUntilReady()` — poll online/`NSScreen` after `applySettings` (async) |
| `Mac/MacSender.swift` | Richer `findSCDisplay` (explicit SCK API, size match, diagnostic logs) |
| `Mac/MacSender.swift` | **CGDisplayStream fallback** when SCK times out, using the known `CGDirectDisplayID` |
| `Mac/MacSender.swift` | Tear down `displayStream` in `stop()` / `reconfigure()` |

ScreenCaptureKit remains the preferred path. CGDisplayStream is **deprecated** and used only as a last resort so users are not stuck with Code=3 when the virtual display id is already known.

## Test plan

- [x] Local Debug build succeeds (`OpenSidecarMac`)
- [x] On a machine that previously hit Code=3 every session with stock builds: Extend over Wi‑Fi streams after this change (fallback path)
- [ ] Maintainer: Extend on a normal multi-display Mac still uses SCK (no fallback log line)
- [ ] Maintainer: Mirror mode unchanged
- [ ] Maintainer: Disconnect / reconnect / rotate still tear down capture cleanly
- [ ] Maintainer: `/tmp/opensidecar-mac.log` shows either normal `capture started:` or `capture started (CGDisplayStream fallback):`

## Notes / non-goals

- Does not change stable per-device display serials or arrangement restore (product behavior kept).
- Optional follow-ups from #142 (FAQ, SwitchResX EDID override docs) left out of this PR to keep the diff surgical.

Closes #142