### PR TITLE
feat: encrypt the WiFi transport with cert-pinned mutual TLS 1.3 (#16)

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -78,11 +78,19 @@ struct PhoneInfo: Decodable {
     var protocolVersion: Int { pv ?? WireProtocol.assumedWhenAbsent }
 }
 
+/// TLS session material for a pinned WiFi dial. Travels inside the transport
+/// so switchTransport needs zero changes (plan §5/§9).
+struct TLSSessionConfig {
+    let identity: SecIdentity
+    let pinnedPhoneSPKI: Data   // DER SPKI from TrustStore.pin(peerID:)
+    let peerID: String          // TrustStore account the SPKI was pinned under
+}
+
 /// How the sender reaches the receiver. Reconnects re-dial from scratch, so
 /// a USB device that was replugged (new usbmuxd DeviceID) is found again.
 enum SenderTransport {
-    case tcp(NWEndpoint)                   // WiFi (Bonjour) or -host/-port override
-    case usb(udid: String?, port: UInt16)  // native usbmuxd dial; nil = first device
+    case tcp(NWEndpoint, tls: TLSSessionConfig?)   // tls == nil ⇒ legacy plaintext / -host backdoor
+    case usb(udid: String?, port: UInt16)          // native usbmuxd dial; nil = first device
 }
 
 @available(macOS 14.0, *)
@@ -99,6 +107,14 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // Fired on every hello — carries the receiver's install id so the
     // controller can deduplicate USB/WiFi sessions to the same device.
     @MainActor var onHello: ((PhoneInfo) -> Void)?
+    // Fired when the peer revokes the pairing (WireMessage.unpair). All
+    // validation and the pin drop live in the controller — it owns trust.
+    @MainActor var onUnpaired: ((_ fromID: String, _ toID: String) -> Void)?
+    // Fired when a pinned WiFi dial is rejected at the TLS layer repeatedly —
+    // the pin is stale (peer forgot us / reset identity). Carries the peerID
+    // from TLSSessionConfig; the controller drops the pin so the USB
+    // bootstrap trigger (!hasPin) fires on the next cable connect.
+    @MainActor var onPairingRejected: ((String) -> Void)?
 
     private var stream: SCStream?
     private var encoder: VTCompressionSession?
@@ -465,6 +481,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             guard let self, !self.stopped else { return }
             Log.info("manual reconnect requested")
             self.disconnectedSince = Date()   // fresh grace window
+            self.consecutiveTLSDialFailures = 0   // Reconnect button always grants fresh attempts
+            self.consecutiveTLSAuthRejections = 0
             self.scheduleReconnect()
         }
     }
@@ -500,10 +518,23 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // manual reconnect) superseded it. Only touched on `queue`.
     private var dialGeneration = 0
 
+    // Consecutive TLS-dial failures for the current pinned WiFi transport.
+    // Caps out into a parked "pairing invalid" state instead of an infinite
+    // scheduleReconnect loop (plan §7). Reset on every successful TLS ready,
+    // on any USB adoption, and on a manual Reconnect.
+    private var consecutiveTLSDialFailures = 0
+    private static let maxTLSDialFailures = 5
+
+    // Consecutive TLS-layer (auth/cert) handshake rejections — distinct from
+    // transient network failures. Two in a row ⇒ the peer no longer trusts
+    // us (or we no longer match it): the pin is stale.
+    private var consecutiveTLSAuthRejections = 0
+    private static let maxTLSAuthRejections = 2
+
     private func connect() {
         guard !stopped else { return }
         switch transport {
-        case .tcp(let endpoint): connectTCP(endpoint)
+        case .tcp(let endpoint, let tls): connectTCP(endpoint, tls: tls)
         case .usb(let udid, let port): connectUSB(udid: udid, port: port)
         }
     }
@@ -527,20 +558,58 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         Task { await self.status("Connected to \(self.endpointName)") }
     }
 
-    private func connectTCP(_ endpoint: NWEndpoint) {
+    private func connectTCP(_ endpoint: NWEndpoint, tls tlsConfig: TLSSessionConfig?) {
         let options = NWProtocolTCP.Options()
         options.noDelay = true   // latency matters more than throughput here
-        let params = NWParameters(tls: nil, tcp: options)
+        let params: NWParameters
+        if let tlsConfig {
+            let pinned = [tlsConfig.pinnedPhoneSPKI]     // captured copy — no Keychain I/O in the closure
+            guard let tlsOptions = TLSConfigurator.mutualTLSOptions(
+                    identity: tlsConfig.identity, pinnedSPKIs: { pinned },
+                    isListener: false, queue: queue) else {
+                Task { await self.status("TLS identity unavailable — reconnect via USB to re-pair") }
+                return   // hard stop: NEVER plaintext for a pinned peer (invariant 3)
+            }
+            params = NWParameters(tls: tlsOptions, tcp: options)
+        } else {
+            params = NWParameters(tls: nil, tcp: options)   // legacy pv≤2 phones, -host backdoor
+        }
         let conn = NWConnection(to: endpoint, using: params)
         connection = conn
         conn.stateUpdateHandler = { [weak self] state in
             guard let self else { return }
             switch state {
             case .ready:
+                self.consecutiveTLSDialFailures = 0
+                self.consecutiveTLSAuthRejections = 0
                 self.becomeReady(conn)
             case .failed(let error):
                 Log.info("connection failed: \(error)")
                 self.connectionReady = false
+                if let tlsConfig {
+                    self.consecutiveTLSDialFailures += 1
+                    if case .tls = error {
+                        self.consecutiveTLSAuthRejections += 1
+                    } else {
+                        self.consecutiveTLSAuthRejections = 0   // transient — not evidence of a stale pin
+                    }
+                    if self.consecutiveTLSAuthRejections >= Self.maxTLSAuthRejections {
+                        // The peer actively rejected the handshake: our pin (or
+                        // its pin of us) is stale. Hand the peerID to the
+                        // controller to forget — USB bootstrap re-pairs. NEVER
+                        // fall back to plaintext (invariant 3).
+                        Log.info("TLS handshake rejected by pinned peer \(tlsConfig.peerID) — treating pin as stale")
+                        Task { await self.status("Pairing no longer valid — reconnect via USB to re-pair") }
+                        Task { @MainActor in self.onPairingRejected?(tlsConfig.peerID) }
+                        return   // park: controller tears the session down
+                    }
+                    if self.consecutiveTLSDialFailures >= Self.maxTLSDialFailures {
+                        // Pairing-invalid: phone forgot us / reinstalled. Park with
+                        // guidance — no infinite scheduleReconnect loop (plan §7).
+                        Task { await self.status("Pairing no longer valid — reconnect via USB to re-pair") }
+                        return
+                    }
+                }
                 self.scheduleReconnect()
             case .waiting(let error):
                 // On loopback there is no "path change" to wake us up again
@@ -573,6 +642,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                         conn.cancel()
                         return
                     }
+                    self.consecutiveTLSDialFailures = 0
+                    self.consecutiveTLSAuthRejections = 0
                     self.connection = conn
                     conn.stateUpdateHandler = { [weak self] state in
                         guard let self else { return }
@@ -858,6 +929,12 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             // periodic keyframes are off) — force an IDR on the next frame.
             Log.info("phone requested keyframe")
             needsKeyframe = true
+        case WireMessage.unpair:
+            if let fromID = obj["fromID"] as? String, !fromID.isEmpty,
+               let toID = obj["toID"] as? String, !toID.isEmpty {
+                Log.info("unpair received from \(fromID)")
+                Task { @MainActor in self.onUnpaired?(fromID, toID) }
+            }
         default:
             Log.info("unknown control message type: \(type)")
         }
@@ -1031,6 +1108,45 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     /// receiver version we still support.
     private func sendWelcome() {
         sendJSONFrame("{\"type\":\"\(WireMessage.welcome)\",\"pv\":\(WireProtocol.version),\"min\":\(WireProtocol.minSupportedPeer)}")
+    }
+
+    /// Symmetric unpair: tell the connected peer to drop its pin for us.
+    /// `completion` fires on the main actor once the frame is handed to the
+    /// transport (or immediately when there is no live connection), so the
+    /// caller can tear the session down without racing the send. Guarded so
+    /// it fires exactly once: a half-open TLS socket can leave
+    /// `.contentProcessed` pending until an OS-level timeout, which would
+    /// otherwise strand the doomed session (pin already dropped locally,
+    /// peer never told, socket never torn down) — a 2s fallback forces
+    /// teardown to proceed regardless.
+    func sendUnpair(fromID: String, toID: String, completion: @escaping @MainActor () -> Void) {
+        queue.async {
+            guard let connection = self.connection, self.connectionReady else {
+                Task { @MainActor in completion() }
+                return
+            }
+            let payload = Data("{\"type\":\"\(WireMessage.unpair)\",\"fromID\":\"\(fromID)\",\"toID\":\"\(toID)\"}".utf8)
+            var header = UInt32(payload.count).bigEndian
+            var frame = Data(bytes: &header, count: 4)
+            frame.append(payload)
+            Log.info("unpair sent to \(toID)")
+            let fired = NSLock()
+            var didFire = false
+            let fireOnce = {
+                fired.lock()
+                let shouldFire = !didFire
+                didFire = true
+                fired.unlock()
+                if shouldFire { Task { @MainActor in completion() } }
+            }
+            connection.send(content: frame, completion: .contentProcessed { _ in
+                fireOnce()
+            })
+            self.queue.asyncAfter(deadline: .now() + 2.0) {
+                Log.info("unpair send to \(toID) did not complete in time — tearing down anyway")
+                fireOnce()
+            }
+        }
     }
 
     /// Ask the receiver to update from the App Store (built via JSONSerialization

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -79,7 +79,7 @@ struct PhoneInfo: Decodable {
 }
 
 /// TLS session material for a pinned WiFi dial. Travels inside the transport
-/// so switchTransport needs zero changes (plan §5/§9).
+/// so switchTransport needs zero changes.
 struct TLSSessionConfig {
     let identity: SecIdentity
     let pinnedPhoneSPKI: Data   // DER SPKI from TrustStore.pin(peerID:)
@@ -520,7 +520,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     // Consecutive TLS-dial failures for the current pinned WiFi transport.
     // Caps out into a parked "pairing invalid" state instead of an infinite
-    // scheduleReconnect loop (plan §7). Reset on every successful TLS ready,
+    // scheduleReconnect loop. Reset on every successful TLS ready,
     // on any USB adoption, and on a manual Reconnect.
     private var consecutiveTLSDialFailures = 0
     private static let maxTLSDialFailures = 5
@@ -568,7 +568,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                     identity: tlsConfig.identity, pinnedSPKIs: { pinned },
                     isListener: false, queue: queue) else {
                 Task { await self.status("TLS identity unavailable — reconnect via USB to re-pair") }
-                return   // hard stop: NEVER plaintext for a pinned peer (invariant 3)
+                return   // hard stop: NEVER plaintext for a pinned peer
             }
             params = NWParameters(tls: tlsOptions, tcp: options)
         } else {
@@ -597,7 +597,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                         // The peer actively rejected the handshake: our pin (or
                         // its pin of us) is stale. Hand the peerID to the
                         // controller to forget — USB bootstrap re-pairs. NEVER
-                        // fall back to plaintext (invariant 3).
+                        // fall back to plaintext.
                         Log.info("TLS handshake rejected by pinned peer \(tlsConfig.peerID) — treating pin as stale")
                         Task { await self.status("Pairing no longer valid — reconnect via USB to re-pair") }
                         Task { @MainActor in self.onPairingRejected?(tlsConfig.peerID) }
@@ -605,7 +605,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                     }
                     if self.consecutiveTLSDialFailures >= Self.maxTLSDialFailures {
                         // Pairing-invalid: phone forgot us / reinstalled. Park with
-                        // guidance — no infinite scheduleReconnect loop (plan §7).
+                        // guidance — no infinite scheduleReconnect loop.
                         Task { await self.status("Pairing no longer valid — reconnect via USB to re-pair") }
                         return
                     }

--- a/Mac/OpenSidecarMac.entitlements
+++ b/Mac/OpenSidecarMac.entitlements
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<!-- Required to use the data-protection keychain (kSecUseDataProtectionKeychain)
+	     on macOS; without a keychain-access-group entitlement SecItemAdd fails
+	     with errSecMissingEntitlement (-34018). See Shared/TrustStore.swift. -->
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	</array>
+</dict>
 </plist>

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -128,7 +128,7 @@ final class DeviceSession: ObservableObject, Identifiable {
     @Published var status = "Starting…"
     @Published var framesSent = 0
     @Published var mbps = 0.0
-    // USB trust-bootstrap diagnostics (plan §2/§7) — separate from the
+    // USB trust-bootstrap diagnostics — separate from the
     // streaming `status` line so a pairing message never clobbers it.
     @Published var pairingStatus: String?
     // Receiver's per-install identity (from hello) — the key for recognizing
@@ -313,9 +313,9 @@ final class SenderController: ObservableObject {
         return nil
     }
 
-    // MARK: - WiFi transport routing (SEV-1: THE single .tcp builder)
+    // MARK: - WiFi transport routing (THE single .tcp builder)
 
-    /// THE ONLY legal source of a WiFi SenderTransport (SEV-1). Both connect()
+    /// THE ONLY legal source of a WiFi SenderTransport. Both connect()
     /// and failover() route through here — no other call site may construct
     /// .tcp for a Bonjour result.
     private func wifiTransport(for result: NWBrowser.Result,
@@ -334,9 +334,10 @@ final class SenderController: ObservableObject {
                                                                pinnedPhoneSPKI: pin,
                                                                peerID: peerID))
         }
-        // Phase 2 (wifi-tls-pairing-plan §8): plaintext WiFi is gone. Any
-        // unpinned peer is refused (pv≤2 is hard-gated by minSupportedPeer
-        // anyway); callers show "Connect via USB once to enable Wi-Fi".
+        // Plaintext WiFi is gone: any unpinned peer is refused — pairing
+        // happens over the USB bootstrap, which a pre-TLS (pv < minWiFiPeer)
+        // peer can't complete, making old peers USB-only by construction.
+        // Callers show "Connect via USB once to enable Wi-Fi".
         return nil
     }
 
@@ -356,7 +357,7 @@ final class SenderController: ObservableObject {
     /// "Forget Pairing" context-menu action. Forgetting also drops any live
     /// session for that peer immediately — the pin is only checked at TLS
     /// handshake, so an established session would otherwise keep streaming
-    /// until it happened to reconnect. (Reverses plan §6(ii).)
+    /// until it happened to reconnect.
     ///
     /// Teardown uses `end(_:)`, not `disconnect(_:)`: this is a forget, not a
     /// user "disconnect this device" action, so a still-attached cable must
@@ -465,7 +466,7 @@ final class SenderController: ObservableObject {
             if wifiRemembered.contains(target.sessionID),
                activeSession(coveringWiFi: result) == nil,
                !cabled(result) {
-                // Phase 2: only pinned peers are ever auto-dialed over WiFi.
+                // Only pinned peers are ever auto-dialed over WiFi.
                 guard let id = txtID(of: result), TrustStore.shared.hasPin(peerID: id) else {
                     wifiGuidance[target.sessionID] = Self.usbOnceGuidance
                     continue
@@ -652,7 +653,13 @@ final class SenderController: ObservableObject {
             if let name = session.wifiServiceName, let installID = info.id {
                 self.installIDByWifiName[name] = installID   // remember for future manual WiFi connects
             }
-            // USB trust bootstrap (plan §2/§7): self-verifying — runs once per
+            // Pre-TLS receiver: streams fine over the cable, but can never
+            // pair for WiFi until it's updated — say so, instead of letting
+            // the "Connect via USB once to enable Wi-Fi" guidance loop.
+            if session.onUSB, info.protocolVersion < WireProtocol.minWiFiPeer {
+                session.pairingStatus = "Update the \(info.kind) app to enable Wi-Fi — USB works without updating."
+            }
+            // USB trust bootstrap: self-verifying — runs once per
             // USB session REGARDLESS of our own pin state; the phone is the
             // single source of truth (auto-accepts silently on an exact pin
             // match, prompts otherwise). This heals asymmetric trust (phone
@@ -661,7 +668,7 @@ final class SenderController: ObservableObject {
             // onto the cable is covered too; the -host backdoor has
             // usbUDID == nil and is excluded.
             if session.onUSB, let bootUDID = session.usbUDID,
-               let phoneID = info.id, info.protocolVersion >= 3,
+               let phoneID = info.id, info.protocolVersion >= WireProtocol.minWiFiPeer,
                !session.bootstrapAttempted,
                !self.bootstrapInFlight.contains(bootUDID) {
                 session.bootstrapAttempted = true

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -466,8 +466,14 @@ final class SenderController: ObservableObject {
             if wifiRemembered.contains(target.sessionID),
                activeSession(coveringWiFi: result) == nil,
                !cabled(result) {
-                // Only pinned peers are ever auto-dialed over WiFi.
-                guard let id = txtID(of: result), TrustStore.shared.hasPin(peerID: id) else {
+                // Only pinned peers are ever auto-dialed over WiFi. Resolve the
+                // peer the SAME way connect(to:) does: the TXT id is often
+                // absent from a browse result, so fall back to the WiFi-name →
+                // installID map (wifiTransport ORs txtID with knownPeerID) —
+                // otherwise an already-paired device never auto-reconnects over
+                // WiFi and is wrongly told to "connect via USB once".
+                let knownID = serviceName(of: result).flatMap { installIDByWifiName[$0] }
+                guard wifiTransport(for: result, knownPeerID: knownID) != nil else {
                     wifiGuidance[target.sessionID] = Self.usbOnceGuidance
                     continue
                 }
@@ -677,7 +683,17 @@ final class SenderController: ObservableObject {
                 Task { [weak self, weak session] in
                     await TrustBootstrapClient.run(udid: bootUDID, expectedPhoneID: phoneID,
                                                    phoneDisplayName: displayName) { text in
-                        Task { @MainActor in session?.pairingStatus = text }
+                        Task { @MainActor in
+                            session?.pairingStatus = text
+                            // text == nil signals a successful pin: the peer is
+                            // now trusted, so drop any stale "connect via USB
+                            // once" caption on its WiFi row. (No WiFi connect()
+                            // — which is what normally clears it — runs while the
+                            // device is still cabled.)
+                            if text == nil, let session {
+                                self?.wifiGuidance["wifi:\(session.wifiServiceName ?? session.name)"] = nil
+                            }
+                        }
                     }
                     await MainActor.run { self?.bootstrapInFlight.remove(bootUDID) }
                 }

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -46,6 +46,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Reinstall-cleanup purge itself now happens in SenderController.init()
+        // — it must run before startBrowsing()/UsbmuxDeviceWatcher are armed,
+        // and SwiftUI constructs the App's @StateObject (and so the
+        // controller) before this delegate callback fires. Doing it here
+        // instead would be too late: the USB bootstrap path has no arming
+        // delay and could already be using a stale keychain identity.
         // Hand the updater to the control window, which is built outside the
         // SwiftUI App scene (NSHostingView), so it can offer the same button.
         MainWindow.updater = updater
@@ -122,6 +128,9 @@ final class DeviceSession: ObservableObject, Identifiable {
     @Published var status = "Starting…"
     @Published var framesSent = 0
     @Published var mbps = 0.0
+    // USB trust-bootstrap diagnostics (plan §2/§7) — separate from the
+    // streaming `status` line so a pairing message never clobbers it.
+    @Published var pairingStatus: String?
     // Receiver's per-install identity (from hello) — the key for recognizing
     // the same physical device across USB and WiFi.
     var deviceID: String?
@@ -135,6 +144,10 @@ final class DeviceSession: ObservableObject, Identifiable {
     // The udid the session is (or was last) cabled through, so a usbmuxd
     // detach can be matched back to this session for failover.
     var usbUDID: String?
+    // Self-verifying USB trust bootstrap: the offer runs at most once per
+    // session. Set when the bootstrap task is launched; a fresh session
+    // (reconnect) gets a fresh flag, so every replug re-verifies.
+    var bootstrapAttempted = false
     // The Bonjour service name this session was started from or failed over
     // to. Kept because browse results routinely arrive without their TXT
     // record (no install id to match on) and the USB device is detached
@@ -176,6 +189,11 @@ final class SenderController: ObservableObject {
     @Published var sessions: [DeviceSession] = []
     @Published var discovered: [NWBrowser.Result] = []
     @Published var usbDevices: [UsbmuxDevice] = []
+    /// Per-target user guidance ("Connect via USB once…"), keyed by
+    /// ConnectionTarget.sessionID.
+    @Published var wifiGuidance: [String: String] = [:]
+    private var bootstrapInFlight = Set<String>()   // udids with a bootstrap dial running
+    private static let usbOnceGuidance = "Connect via USB once to enable Wi-Fi"
     // `-host x.x.x.x` / `-port n` bypass usbmuxd with a manual TCP endpoint
     // (debugging escape hatch, e.g. an iproxy or SSH tunnel).
     @Published var host = UserDefaults.standard.string(forKey: "host") ?? "127.0.0.1"
@@ -220,6 +238,14 @@ final class SenderController: ObservableObject {
         UserDefaults.standard.dictionary(forKey: "installIDByUDID") as? [String: String] ?? [:] {
         didSet { UserDefaults.standard.set(installIDByUDID, forKey: "installIDByUDID") }
     }
+    // WiFi service name -> installID, learned from a live session's hello. Lets a
+    // manual WiFi connect resolve the pinned peer when the browse result carries
+    // no TXT `id` (NWBrowser often omits it), so it isn't limited to cable-unplug
+    // failover (which passes knownPeerID from the live session).
+    @Published private var installIDByWifiName: [String: String] =
+        UserDefaults.standard.dictionary(forKey: "installIDByWifiName") as? [String: String] ?? [:] {
+        didSet { UserDefaults.standard.set(installIDByWifiName, forKey: "installIDByWifiName") }
+    }
     private let autoConnectEnabled = UserDefaults.standard.object(forKey: "autostart") == nil
         || UserDefaults.standard.bool(forKey: "autostart")
 
@@ -232,6 +258,20 @@ final class SenderController: ObservableObject {
     private let wifiAutoConnectDeadline = Date().addingTimeInterval(12)
 
     init() {
+        // Reinstall-cleanup purge MUST run before startBrowsing()/the USB
+        // watcher are armed — both drive autoConnect()/failover(), which read
+        // TrustStore.shared.pin/ownIdentity, and the USB bootstrap path
+        // (onHello → TrustBootstrapClient) has no arming delay, unlike the
+        // 2s-delayed WiFi auto-connect below. Placed here (not
+        // applicationDidFinishLaunching) because SwiftUI creates the App's
+        // @StateObject — and therefore this controller — before the
+        // NSApplicationDelegate's didFinishLaunching runs, so doing it there
+        // would already be too late on a reinstall's first launch. Mirrors
+        // iOS, where purgeAll() precedes model.start() in the same onAppear.
+        if !UserDefaults.standard.bool(forKey: WireCrypto.trustStoreInitializedDefaultsKey) {
+            TrustStore.shared.purgeAll()
+            UserDefaults.standard.set(true, forKey: WireCrypto.trustStoreInitializedDefaultsKey)
+        }
         startBrowsing()
         usbWatcher = UsbmuxDeviceWatcher { [weak self] devices in
             guard let self else { return }
@@ -271,6 +311,92 @@ final class SenderController: ObservableObject {
     private func txtID(of result: NWBrowser.Result) -> String? {
         if case .bonjour(let txt) = result.metadata { return txt["id"] }
         return nil
+    }
+
+    // MARK: - WiFi transport routing (SEV-1: THE single .tcp builder)
+
+    /// THE ONLY legal source of a WiFi SenderTransport (SEV-1). Both connect()
+    /// and failover() route through here — no other call site may construct
+    /// .tcp for a Bonjour result.
+    private func wifiTransport(for result: NWBrowser.Result,
+                               knownPeerID: String? = nil) -> SenderTransport? {
+        let peerID = txtID(of: result) ?? knownPeerID   // TXT often missing on browse results
+        if let peerID, let pin = TrustStore.shared.pin(peerID: peerID) {
+            // Pinned ⇒ TLS-only, always (downgrade resistance).
+            guard let identity = TrustStore.shared.ownIdentity() else {
+                Log.info("wifiTransport: pinned peer \(peerID) — ownIdentity() nil, refusing WiFi")
+                return nil   // hard refuse; NEVER plaintext for a pinned peer
+            }
+            // The "_opensidecar._tcp" advertisement is published by the
+            // phone's TLS listener, so this browsed (Local-Network-
+            // authorized) endpoint resolves straight to the mTLS port.
+            return .tcp(result.endpoint, tls: TLSSessionConfig(identity: identity,
+                                                               pinnedPhoneSPKI: pin,
+                                                               peerID: peerID))
+        }
+        // Phase 2 (wifi-tls-pairing-plan §8): plaintext WiFi is gone. Any
+        // unpinned peer is refused (pv≤2 is hard-gated by minSupportedPeer
+        // anyway); callers show "Connect via USB once to enable Wi-Fi".
+        return nil
+    }
+
+    /// Pinned peer id behind a device row, if any (deviceID ?? txtID ?? installIDByUDID), gated on hasPin.
+    func pinnedPeerID(for entry: DeviceEntry) -> String? {
+        var candidates: [String] = []
+        if let s = session(for: entry) { if let d = s.deviceID { candidates.append(d) } }
+        if let target = entry.wifiTarget, case .wifi(let result) = target, let id = txtID(of: result) {
+            candidates.append(id)
+        }
+        if let target = entry.usbTarget, case .usb(let udid?) = target, let id = installIDByUDID[udid] {
+            candidates.append(id)
+        }
+        return candidates.first { TrustStore.shared.hasPin(peerID: $0) }
+    }
+
+    /// "Forget Pairing" context-menu action. Forgetting also drops any live
+    /// session for that peer immediately — the pin is only checked at TLS
+    /// handshake, so an established session would otherwise keep streaming
+    /// until it happened to reconnect. (Reverses plan §6(ii).)
+    ///
+    /// Teardown uses `end(_:)`, not `disconnect(_:)`: this is a forget, not a
+    /// user "disconnect this device" action, so a still-attached cable must
+    /// stay eligible for USB auto-connect — otherwise the peer forgot us (or
+    /// we forgot it) but the cable sits there doing nothing until the user
+    /// manually taps the device row. A stale WiFi service is nudged into the
+    /// USB-first bootstrap via wifiGuidance, matching onPairingRejected.
+    func forgetPairing(peerID: String) {
+        let doomed = sessions.filter { s in
+            if s.deviceID == peerID { return true }
+            if case .wifi(let result) = s.target, txtID(of: result) == peerID { return true }
+            return false
+        }
+        // Symmetric revoke (WireMessage.unpair): tell the live peer to drop
+        // its pin for us BEFORE the sockets die. toID scopes the revoke to
+        // the forgotten device; disconnect happens in the send completion so
+        // the frame is flushed first. The iPad also drops the connection on
+        // receipt, so teardown is cooperative.
+        let macID = TrustStore.shared.installID()
+        if macID == nil {
+            // installID() should never be nil once TrustStore is initialized —
+            // this leaves the peer with a pin for us that we can no longer
+            // revoke (we drop our own pin below regardless, so re-pairing
+            // still works, but trust is asymmetric until the peer's own
+            // stale-pin self-heal kicks in). Loud because it signals a
+            // TrustStore/keychain problem worth investigating.
+            Log.info("ERROR: forgetPairing(\(peerID)) — installID() is nil, cannot send unpair; peer will keep a stale pin for us")
+        }
+        TrustStore.shared.forget(peerID: peerID)
+        for s in doomed {
+            wifiGuidance["wifi:\(s.wifiServiceName ?? s.name)"] = Self.usbOnceGuidance
+            if let macID {
+                s.sender.sendUnpair(fromID: macID, toID: peerID) { [weak self] in
+                    self?.end(s)
+                }
+            } else {
+                end(s)
+            }
+        }
+        objectWillChange.send()
     }
 
     /// Same hardware? Strong match: the service's install id equals the id
@@ -339,6 +465,11 @@ final class SenderController: ObservableObject {
             if wifiRemembered.contains(target.sessionID),
                activeSession(coveringWiFi: result) == nil,
                !cabled(result) {
+                // Phase 2: only pinned peers are ever auto-dialed over WiFi.
+                guard let id = txtID(of: result), TrustStore.shared.hasPin(peerID: id) else {
+                    wifiGuidance[target.sessionID] = Self.usbOnceGuidance
+                    continue
+                }
                 connect(to: target)
             }
         }
@@ -373,10 +504,14 @@ final class SenderController: ObservableObject {
         for session in sessions where session.onUSB {
             guard let udid = session.usbUDID, detachedUDIDs.contains(udid),
                   let result = wifiService(for: session) else { continue }
+            guard let t = wifiTransport(for: result, knownPeerID: session.deviceID) else {
+                session.status = Self.usbOnceGuidance   // pending-confirmation unplug: no pin yet ⇒ refuse WiFi
+                continue
+            }
             Log.info("cable detached for \(session.id) — failing over to WiFi")
             session.onUSB = false
             session.wifiServiceName = serviceName(of: result)
-            session.sender.switchTransport(to: .tcp(result.endpoint))
+            session.sender.switchTransport(to: t)
         }
     }
 
@@ -480,12 +615,20 @@ final class SenderController: ObservableObject {
             if UserDefaults.standard.object(forKey: "host") != nil, udid == nil {
                 // Manual override: dial a plain TCP endpoint instead of usbmuxd.
                 transport = .tcp(.hostPort(host: NWEndpoint.Host(host),
-                                           port: NWEndpoint.Port(rawValue: portNum)!))
+                                           port: NWEndpoint.Port(rawValue: portNum)!), tls: nil)
             } else {
                 transport = .usb(udid: udid, port: portNum)
             }
         case .wifi(let result):
-            transport = .tcp(result.endpoint)
+            // Resolve the pinned peer even when the browse result has no TXT `id`,
+            // by falling back to the name->installID map learned from prior sessions.
+            let knownID = serviceName(of: result).flatMap { installIDByWifiName[$0] }
+            guard let t = wifiTransport(for: result, knownPeerID: knownID) else {
+                wifiGuidance[target.sessionID] = Self.usbOnceGuidance
+                return   // no session created; the device row shows the guidance caption
+            }
+            wifiGuidance[target.sessionID] = nil
+            transport = t
         }
 
         let name = label(for: target)
@@ -506,6 +649,32 @@ final class SenderController: ObservableObject {
             if case .usb(let udid?) = session.target, let installID = info.id {
                 self.installIDByUDID[udid] = installID
             }
+            if let name = session.wifiServiceName, let installID = info.id {
+                self.installIDByWifiName[name] = installID   // remember for future manual WiFi connects
+            }
+            // USB trust bootstrap (plan §2/§7): self-verifying — runs once per
+            // USB session REGARDLESS of our own pin state; the phone is the
+            // single source of truth (auto-accepts silently on an exact pin
+            // match, prompts otherwise). This heals asymmetric trust (phone
+            // forgot us while we still hold a pin). session.onUSB/usbUDID
+            // (not session.target) is used so a WiFi-identity session migrated
+            // onto the cable is covered too; the -host backdoor has
+            // usbUDID == nil and is excluded.
+            if session.onUSB, let bootUDID = session.usbUDID,
+               let phoneID = info.id, info.protocolVersion >= 3,
+               !session.bootstrapAttempted,
+               !self.bootstrapInFlight.contains(bootUDID) {
+                session.bootstrapAttempted = true
+                self.bootstrapInFlight.insert(bootUDID)
+                let displayName = self.usbDevices.first(where: { $0.udid == bootUDID })?.name ?? session.name
+                Task { [weak self, weak session] in
+                    await TrustBootstrapClient.run(udid: bootUDID, expectedPhoneID: phoneID,
+                                                   phoneDisplayName: displayName) { text in
+                        Task { @MainActor in session?.pairingStatus = text }
+                    }
+                    await MainActor.run { self?.bootstrapInFlight.remove(bootUDID) }
+                }
+            }
             self.dedupeSessions()
             // The learned identity may reveal that this WiFi session's device
             // is cabled — take the upgrade opportunity right away.
@@ -522,6 +691,29 @@ final class SenderController: ObservableObject {
             guard let self, let session else { return }
             Log.info("device disconnected — session \(session.id) stopped")
             self.end(session)
+        }
+        sender.onUnpaired = { [weak self, weak session] fromID, toID in
+            guard let self, let session else { return }
+            guard toID == TrustStore.shared.installID() else {
+                Log.info("unpair ignored — addressed to \(toID), not us")
+                return
+            }
+            guard fromID == session.deviceID else {
+                Log.info("unpair ignored — fromID \(fromID) does not match session peer")
+                return
+            }
+            Log.info("peer \(fromID) revoked pairing — forgetting pin and disconnecting")
+            TrustStore.shared.forget(peerID: fromID)   // no-op if not pinned
+            self.wifiGuidance["wifi:\(session.wifiServiceName ?? session.name)"] = Self.usbOnceGuidance
+            self.end(session)   // not disconnect(): keep USB auto-connect eligible for the re-pair
+            self.objectWillChange.send()
+        }
+        sender.onPairingRejected = { [weak self, weak session] peerID in
+            guard let self, let session else { return }
+            Log.info("stale pin for \(peerID) — forgetting so the USB bootstrap can re-pair")
+            TrustStore.shared.forget(peerID: peerID)
+            self.wifiGuidance["wifi:\(session.wifiServiceName ?? session.name)"] = Self.usbOnceGuidance
+            self.end(session)   // not disconnect(): keep USB auto-connect eligible for the re-pair
         }
         sessions.append(session)
         Task {
@@ -748,6 +940,11 @@ struct ContentView: View {
                             // often before lockdown resolved the real name.
                             SessionRow(title: entry.name, session: session,
                                        controller: controller)
+                                .contextMenu {
+                                    if let id = controller.pinnedPeerID(for: entry) {
+                                        Button("Forget Pairing") { controller.forgetPairing(peerID: id) }
+                                    }
+                                }
                         } else {
                             HStack(alignment: .firstTextBaseline) {
                                 Circle()
@@ -758,6 +955,11 @@ struct ContentView: View {
                                     Text(entry.transportLabel)
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
+                                    if let guidance = controller.wifiGuidance[entry.wifiTarget?.sessionID ?? entry.id] {
+                                        Text(guidance)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
                                 }
                                 Spacer()
                                 if let target = entry.preferredTarget {
@@ -765,6 +967,11 @@ struct ContentView: View {
                                         controller.connect(to: target, userInitiated: true)
                                     }
                                     .controlSize(.small)
+                                }
+                            }
+                            .contextMenu {
+                                if let id = controller.pinnedPeerID(for: entry) {
+                                    Button("Forget Pairing") { controller.forgetPairing(peerID: id) }
                                 }
                             }
                         }
@@ -959,6 +1166,12 @@ struct SessionRow: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
+                if let pairingStatus = session.pairingStatus {
+                    Text(pairingStatus)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
             }
             Spacer()
             if session.mbps > 0 {

--- a/Mac/TrustBootstrapClient.swift
+++ b/Mac/TrustBootstrapClient.swift
@@ -1,5 +1,5 @@
-// TrustBootstrapClient — one-shot USB trust bootstrap (wifi-tls-pairing-plan
-// §2). Dials the phone's loopback-bound bootstrap listener through usbmuxd,
+// TrustBootstrapClient — one-shot USB trust bootstrap (issue #16).
+// Dials the phone's loopback-bound bootstrap listener through usbmuxd,
 // offers this Mac's identity, and waits for the phone's accept/deny.
 //
 // Owns a single dedicated connection on its own queue with its own

--- a/Mac/TrustBootstrapClient.swift
+++ b/Mac/TrustBootstrapClient.swift
@@ -1,0 +1,172 @@
+// TrustBootstrapClient — one-shot USB trust bootstrap (wifi-tls-pairing-plan
+// §2). Dials the phone's loopback-bound bootstrap listener through usbmuxd,
+// offers this Mac's identity, and waits for the phone's accept/deny.
+//
+// Owns a single dedicated connection on its own queue with its own
+// lifecycle — NEVER touches MacSender.connection, dialGeneration, or the
+// video channel. Framing mirrors MacSender.sendJSONFrame's:
+//   [UInt32 big-endian payload length][UTF-8 JSON]
+
+import Foundation
+import Network
+
+/// One-shot USB trust bootstrap. Self-verifying: always offers; the phone
+/// auto-accepts silently on an exact pin match and prompts otherwise.
+enum TrustBootstrapClient {
+    private static let dialAttempts = 3
+    private static let dialRetryDelay: Duration = .seconds(2)
+
+    /// - Parameters:
+    ///   - udid: the usbmuxd device to dial the bootstrap port through.
+    ///   - expectedPhoneID: the phone's installID from its hello — the Mac
+    ///     verifies the phone's trustAccept.phoneID matches this.
+    ///   - phoneDisplayName: mac-known name (usbDevices name ?? session.name).
+    ///   - status: diagnostic surface (DeviceSession.pairingStatus); nil = clear.
+    static func run(udid: String,
+                    expectedPhoneID: String,
+                    phoneDisplayName: String,
+                    status: @escaping @Sendable (String?) -> Void) async {
+        // 1. Our own identity — no force-unwrap anywhere.
+        guard let macID = TrustStore.shared.installID(),
+              let spki = TrustStore.shared.ownSPKI() else {
+            status("Pairing unavailable — identity error")
+            return
+        }
+
+        let queue = DispatchQueue(label: "trustbootstrap.\(udid)")
+
+        // 2. Dial the loopback-bound bootstrap listener through usbmuxd, with
+        //    limited retries — the phone's listener may not be up yet.
+        var connection: NWConnection?
+        var lastError: Error?
+        for attempt in 0..<dialAttempts {
+            if attempt > 0 {
+                try? await Task.sleep(for: dialRetryDelay)
+            }
+            do {
+                connection = try await Usbmux.dial(udid: udid, port: WireCrypto.bootstrapPort, queue: queue)
+                break
+            } catch {
+                lastError = error
+            }
+        }
+        guard let conn = connection else {
+            Log.info("TrustBootstrapClient: dial failed after \(dialAttempts) attempts: \(String(describing: lastError))")
+            status("Pairing channel unavailable — is another app using port 9010?")
+            return
+        }
+        defer { conn.cancel() }
+
+        // Install a benign state handler; we drive everything explicitly
+        // below via the async send/receive helpers.
+        conn.stateUpdateHandler = { _ in }
+        conn.start(queue: queue)
+
+        // 3. Send trustOffer.
+        let macName = Host.current().localizedName ?? "Mac"
+        let offer: [String: Any] = [
+            "type": WireMessage.trustOffer,
+            "pv": WireProtocol.version,
+            "macID": macID,
+            "macName": macName,
+            "spki": spki.base64EncodedString(),
+        ]
+        do {
+            try await sendFrame(offer, on: conn, queue: queue)
+        } catch {
+            Log.info("TrustBootstrapClient: send trustOffer failed: \(error)")
+            status("Pairing channel unavailable — is another app using port 9010?")
+            return
+        }
+        // Only surface the "confirm on device" hint if the phone doesn't
+        // auto-accept near-instantly (exact pin match) — no flash on the
+        // routine plug-in path.
+        let prompt = Task {
+            try? await Task.sleep(for: .milliseconds(750))
+            guard !Task.isCancelled else { return }
+            status("Confirm the pairing on your iPhone or iPad…")
+        }
+        defer { prompt.cancel() }
+
+        // 4. Await exactly one reply frame — no read timeout; the user may
+        //    deliberate. Connection death just returns silently; the next
+        //    hello retries.
+        let reply: [String: Any]
+        do {
+            reply = try await receiveFrame(on: conn, queue: queue)
+        } catch {
+            Log.info("TrustBootstrapClient: no reply (connection closed): \(error)")
+            return
+        }
+
+        guard let type = reply["type"] as? String else {
+            Log.info("TrustBootstrapClient: malformed reply (no type)")
+            return
+        }
+
+        switch type {
+        case WireMessage.trustDeny:
+            status("Pairing declined on the device")
+        case WireMessage.trustAccept:
+            guard let phoneID = reply["phoneID"] as? String, phoneID == expectedPhoneID,
+                  let spkiB64 = reply["spki"] as? String,
+                  let decoded = Data(base64Encoded: spkiB64), !decoded.isEmpty else {
+                Log.info("TrustBootstrapClient: trustAccept failed validation")
+                status("Pairing failed — device identity mismatch")
+                return
+            }
+            // Mac pins strictly after the phone's accept, which itself is
+            // strictly after user confirmation.
+            if TrustStore.shared.setPin(peerID: expectedPhoneID, spki: decoded, displayName: phoneDisplayName) {
+                status(nil)
+            } else {
+                status("Pairing failed — device identity mismatch")
+            }
+        default:
+            Log.info("TrustBootstrapClient: unexpected reply type \(type)")
+        }
+    }
+
+    // MARK: - Framing: [UInt32 big-endian length][UTF-8 JSON]
+
+    private static func sendFrame(_ message: [String: Any], on conn: NWConnection, queue: DispatchQueue) async throws {
+        let payload = try JSONSerialization.data(withJSONObject: message)
+        var header = UInt32(payload.count).bigEndian
+        var frame = Data(bytes: &header, count: 4)
+        frame.append(payload)
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            conn.send(content: frame, completion: .contentProcessed { error in
+                if let error { cont.resume(throwing: error) } else { cont.resume() }
+            })
+        }
+    }
+
+    private static func receiveFrame(on conn: NWConnection, queue: DispatchQueue) async throws -> [String: Any] {
+        let header = try await receive(exactly: 4, on: conn)
+        let len = Int(UInt32(bigEndian: header.withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }))
+        guard len > 0, len < WireCrypto.maxBootstrapFrameBytes else {
+            throw NSError(domain: "TrustBootstrapClient", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "bad frame length \(len)"])
+        }
+        let payload = try await receive(exactly: len, on: conn)
+        guard let obj = try JSONSerialization.jsonObject(with: payload) as? [String: Any] else {
+            throw NSError(domain: "TrustBootstrapClient", code: 2,
+                          userInfo: [NSLocalizedDescriptionKey: "non-object JSON reply"])
+        }
+        return obj
+    }
+
+    private static func receive(exactly count: Int, on conn: NWConnection) async throws -> Data {
+        try await withCheckedThrowingContinuation { cont in
+            conn.receive(minimumIncompleteLength: count, maximumLength: count) { data, _, _, error in
+                if let data, data.count == count {
+                    cont.resume(returning: data)
+                } else {
+                    cont.resume(throwing: error ?? NSError(
+                        domain: "TrustBootstrapClient", code: 3,
+                        userInfo: [NSLocalizedDescriptionKey: "socket closed"]))
+                }
+            }
+        }
+    }
+}

--- a/Shared/Protocol.swift
+++ b/Shared/Protocol.swift
@@ -13,11 +13,20 @@ enum WireProtocol {
     /// The protocol version this build speaks.
     static let version = 3
 
-    /// Oldest peer protocol version this build still supports. Raised 1 → 3
-    /// in Phase 2 of the WiFi TLS rollout (wifi-tls-pairing-plan §8): pv≤2
-    /// peers predate the cert-pinned TLS transport, and plaintext WiFi is
-    /// closed — "peer too old" is now a hard welcome/updateRequired gate.
-    static let minSupportedPeer = 3
+    /// Oldest peer protocol version this build still supports — over ANY
+    /// transport. Stays 1: USB streaming is plaintext over a physical
+    /// loopback channel and has no security floor, and iOS (App Store) and
+    /// Mac (Sparkle) update independently, so raising this would strand
+    /// working USB setups mid-rollout. WiFi compatibility is NOT enforced
+    /// here — the WiFi path is cert-pinned TLS-only, which a peer below
+    /// `minWiFiPeer` can never establish. Bump only for a genuine wire break.
+    static let minSupportedPeer = 1
+
+    /// First protocol version that can pair (USB trust bootstrap) and stream
+    /// over WiFi (cert-pinned mutual TLS). Older peers are USB-only. Used
+    /// for soft "update to use Wi-Fi" hints and the bootstrap capability
+    /// check — never as a connection gate.
+    static let minWiFiPeer = 3
 
     /// A peer that advertises no `pv` is defined as protocol 1.
     static let assumedWhenAbsent = 1
@@ -30,14 +39,14 @@ enum WireMessage {
     static let welcome = "welcome"                  // Mac -> phone: Mac's pv + min supported
     static let updateRequired = "updateRequired"    // Mac -> phone: peer is below the Mac's floor
 
-    // USB trust-bootstrap channel (wifi-tls-pairing-plan §2). Spoken ONLY on
+    // USB trust-bootstrap channel. Spoken ONLY on
     // the loopback-bound bootstrap port, framed [UInt32 BE length][JSON],
     // single message < WireCrypto.maxBootstrapFrameBytes.
     static let trustOffer  = "trustOffer"    // Mac -> phone: {"type","pv","macID","macName","spki"}
     static let trustAccept = "trustAccept"   // phone -> Mac: {"type","phoneID","spki"}
     static let trustDeny   = "trustDeny"     // phone -> Mac: {"type"}
 
-    // Symmetric unpair (revocation), issue: one-sided forget leaves trust
+    // Symmetric unpair (revocation): without it, a one-sided forget leaves trust
     // asymmetric. Sent on the live control channel by the side whose user
     // tapped Forget/Reset, BEFORE that side tears the connection down.
     // fromID = the sender's installID — the pin the receiver must drop.
@@ -49,16 +58,16 @@ enum WireMessage {
 }
 
 /// Constants for the cert-pinned mutual-TLS transport and USB trust bootstrap
-/// (wifi-tls-pairing-plan §2-§4, §8). Foundation-only, like the rest of this file.
+/// (issue #16). Foundation-only, like the rest of this file.
 enum WireCrypto {
-    /// Loopback-only USB trust-bootstrap listener port (plan §2, §6(i)).
+    /// Loopback-only USB trust-bootstrap listener port.
     static let bootstrapPort: UInt16 = 9010
-    /// Mutual-TLS 1.3 video/control listener port (plan §4).
+    /// Mutual-TLS 1.3 video/control listener port.
     static let tlsPort: UInt16 = 9001
-    /// Upper bound for a single framed bootstrap message (plan §2).
+    /// Upper bound for a single framed bootstrap message.
     static let maxBootstrapFrameBytes = 1 << 20
 
-    // Keychain namespace (plan §3 table; ".v1" is the migration lever).
+    // Keychain namespace (".v1" is the migration lever).
     /// kSecAttrApplicationTag (as UTF-8 Data) of our private key AND
     /// kSecAttrLabel of our certificate — identity forms implicitly from the pair.
     static let identityKeychainLabel = "com.opendisplay.identity.v1"
@@ -67,13 +76,13 @@ enum WireCrypto {
     static let pinKeychainService = "com.opendisplay.trust.v1"
     /// Account name of the generic-password row storing this install's ID in
     /// the SAME service namespace as the identity, so id+key live and die
-    /// together (plan §3, SEV-5 fix).
+    /// together.
     static let installIDAccount = "macInstallID"
-    /// UserDefaults flag for reinstall cleanup (plan §6(ii)) — consumed by the
+    /// UserDefaults flag for reinstall cleanup — consumed by the
     /// platform apps in the NEXT milestone; defined here so both use one key.
     static let trustStoreInitializedDefaultsKey = "trustStoreInitialized.v1"
 
-    // Fingerprint derivation (plan §0 "Signal safety-number style", §6(iii)).
+    // Fingerprint derivation ("Signal safety-number" style).
     // HKDF-SHA256(ikm: SPKI DER, salt:, info:, out: 10 bytes) — domain-separated
     // so the displayed digits can never be confused with any other hash of the key.
     static let fingerprintHKDFSalt = Data("OpenDisplay-TLS-Pairing-v1".utf8)

--- a/Shared/Protocol.swift
+++ b/Shared/Protocol.swift
@@ -78,8 +78,9 @@ enum WireCrypto {
     /// the SAME service namespace as the identity, so id+key live and die
     /// together.
     static let installIDAccount = "macInstallID"
-    /// UserDefaults flag for reinstall cleanup — consumed by the
-    /// platform apps in the NEXT milestone; defined here so both use one key.
+    /// UserDefaults flag for reinstall cleanup — both platform apps consume
+    /// it on first launch (purge stale Keychain state after a reinstall);
+    /// defined here so both use one key.
     static let trustStoreInitializedDefaultsKey = "trustStoreInitialized.v1"
 
     // Fingerprint derivation ("Signal safety-number" style).

--- a/Shared/Protocol.swift
+++ b/Shared/Protocol.swift
@@ -11,12 +11,13 @@ import Foundation
 /// protocol 1 — that's every install in the field that predates the handshake.
 enum WireProtocol {
     /// The protocol version this build speaks.
-    static let version = 2
+    static let version = 3
 
-    /// Oldest peer protocol version this build still supports. Stays at 1
-    /// (support everything) until a deliberate two-phase breaking change
-    /// raises it — raising this is what turns "peer too old" into a hard gate.
-    static let minSupportedPeer = 1
+    /// Oldest peer protocol version this build still supports. Raised 1 → 3
+    /// in Phase 2 of the WiFi TLS rollout (wifi-tls-pairing-plan §8): pv≤2
+    /// peers predate the cert-pinned TLS transport, and plaintext WiFi is
+    /// closed — "peer too old" is now a hard welcome/updateRequired gate.
+    static let minSupportedPeer = 3
 
     /// A peer that advertises no `pv` is defined as protocol 1.
     static let assumedWhenAbsent = 1
@@ -28,4 +29,53 @@ enum WireProtocol {
 enum WireMessage {
     static let welcome = "welcome"                  // Mac -> phone: Mac's pv + min supported
     static let updateRequired = "updateRequired"    // Mac -> phone: peer is below the Mac's floor
+
+    // USB trust-bootstrap channel (wifi-tls-pairing-plan §2). Spoken ONLY on
+    // the loopback-bound bootstrap port, framed [UInt32 BE length][JSON],
+    // single message < WireCrypto.maxBootstrapFrameBytes.
+    static let trustOffer  = "trustOffer"    // Mac -> phone: {"type","pv","macID","macName","spki"}
+    static let trustAccept = "trustAccept"   // phone -> Mac: {"type","phoneID","spki"}
+    static let trustDeny   = "trustDeny"     // phone -> Mac: {"type"}
+
+    // Symmetric unpair (revocation), issue: one-sided forget leaves trust
+    // asymmetric. Sent on the live control channel by the side whose user
+    // tapped Forget/Reset, BEFORE that side tears the connection down.
+    // fromID = the sender's installID — the pin the receiver must drop.
+    // toID   = the intended receiver's installID — a receiver whose own ID
+    //          differs ignores the message (protects an unrelated Mac on the
+    //          USB cable, where there is no cryptographic peer identity).
+    // Additive: old peers log-and-ignore unknown types.
+    static let unpair = "unpair"    // either direction: {"type","fromID","toID"}
+}
+
+/// Constants for the cert-pinned mutual-TLS transport and USB trust bootstrap
+/// (wifi-tls-pairing-plan §2-§4, §8). Foundation-only, like the rest of this file.
+enum WireCrypto {
+    /// Loopback-only USB trust-bootstrap listener port (plan §2, §6(i)).
+    static let bootstrapPort: UInt16 = 9010
+    /// Mutual-TLS 1.3 video/control listener port (plan §4).
+    static let tlsPort: UInt16 = 9001
+    /// Upper bound for a single framed bootstrap message (plan §2).
+    static let maxBootstrapFrameBytes = 1 << 20
+
+    // Keychain namespace (plan §3 table; ".v1" is the migration lever).
+    /// kSecAttrApplicationTag (as UTF-8 Data) of our private key AND
+    /// kSecAttrLabel of our certificate — identity forms implicitly from the pair.
+    static let identityKeychainLabel = "com.opendisplay.identity.v1"
+    /// kSecClassGenericPassword service holding one row per pinned peer
+    /// (account = peer installID, label = display name, value = SPKI DER).
+    static let pinKeychainService = "com.opendisplay.trust.v1"
+    /// Account name of the generic-password row storing this install's ID in
+    /// the SAME service namespace as the identity, so id+key live and die
+    /// together (plan §3, SEV-5 fix).
+    static let installIDAccount = "macInstallID"
+    /// UserDefaults flag for reinstall cleanup (plan §6(ii)) — consumed by the
+    /// platform apps in the NEXT milestone; defined here so both use one key.
+    static let trustStoreInitializedDefaultsKey = "trustStoreInitialized.v1"
+
+    // Fingerprint derivation (plan §0 "Signal safety-number style", §6(iii)).
+    // HKDF-SHA256(ikm: SPKI DER, salt:, info:, out: 10 bytes) — domain-separated
+    // so the displayed digits can never be confused with any other hash of the key.
+    static let fingerprintHKDFSalt = Data("OpenDisplay-TLS-Pairing-v1".utf8)
+    static let fingerprintHKDFInfo = Data("fingerprint".utf8)
 }

--- a/Shared/TLSConfigurator.swift
+++ b/Shared/TLSConfigurator.swift
@@ -7,17 +7,17 @@ import Security
 import CryptoKit
 
 /// Builds pinned mutual-TLS 1.3 `NWProtocolTLS.Options` for both the phone
-/// listener and the Mac dialer (wifi-tls-pairing-plan §4). Returns nil on any
+/// listener and the Mac dialer. Returns nil on any
 /// failure — the caller treats that as a hard stop; it must NEVER fall back
-/// to plaintext for a pinned peer (plan invariant 3), and there is no
-/// force-unwrap in the identity path (SEV-2).
+/// to plaintext for a pinned peer, and there is no force-unwrap in the
+/// identity path.
 enum TLSConfigurator {
     /// - identity:    own SecIdentity from TrustStore.ownIdentity()
     /// - pinnedSPKIs: closure returning the current pinned-SPKI set; MUST read
     ///                an in-memory snapshot (TrustStore.allPinnedPeerSPKIs on
     ///                the phone, a captured single-element array on the Mac).
     ///                It is invoked on `queue` during handshakes — Keychain
-    ///                I/O in it is forbidden (SEV-7).
+    ///                I/O in it is forbidden.
     /// - isListener:  true ⇒ additionally require a client certificate.
     /// - queue:       the connection's serial queue; verify block runs here.
     static func mutualTLSOptions(identity: SecIdentity,
@@ -26,7 +26,7 @@ enum TLSConfigurator {
                                   queue: DispatchQueue) -> NWProtocolTLS.Options? {
         guard let secIdentity = sec_identity_create(identity) else {
             Log.info("ERROR: sec_identity_create failed — identity unusable, refusing TLS setup")
-            return nil // SEV-2: no crash, no plaintext fallback
+            return nil // no crash, no plaintext fallback
         }
         let tls = NWProtocolTLS.Options()
         let sec = tls.securityProtocolOptions
@@ -35,12 +35,12 @@ enum TLSConfigurator {
         sec_protocol_options_set_local_identity(sec, secIdentity)       // both roles present a cert
         if isListener {
             // Without this the listener silently degrades to one-way server
-            // auth (plan §4).
+            // auth.
             sec_protocol_options_set_peer_authentication_required(sec, true)
         }
         sec_protocol_options_set_verify_block(sec, { _, sec_trust, complete in
             // Self-signed world: pinning REPLACES chain trust — deliberately
-            // no SecTrustEvaluateWithError (plan §4/§10).
+            // no SecTrustEvaluateWithError.
             let trust = sec_trust_copy_ref(sec_trust).takeRetainedValue()
             guard let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate],
                   let leaf = chain.first,
@@ -50,10 +50,10 @@ enum TLSConfigurator {
                 complete(false)
                 return
             }
-            // SEV-2 same-source: re-encode through the SAME CryptoKit encoder
+            // Same-source rule: re-encode through the SAME CryptoKit encoder
             // that produced every pinned value, so pinned == extracted
             // byte-for-byte. Plain Data equality — both operands public,
-            // constant-time explicitly rejected by plan §2.
+            // so a constant-time compare is deliberately not needed.
             complete(pinnedSPKIs().contains(pub.derRepresentation))
         }, queue)
         return tls

--- a/Shared/TLSConfigurator.swift
+++ b/Shared/TLSConfigurator.swift
@@ -1,0 +1,61 @@
+// Compiled into BOTH the Mac and iOS targets (see project.yml `sources`).
+// Shared but NOT Foundation-only: imports Network, Security, CryptoKit.
+
+import Foundation
+import Network
+import Security
+import CryptoKit
+
+/// Builds pinned mutual-TLS 1.3 `NWProtocolTLS.Options` for both the phone
+/// listener and the Mac dialer (wifi-tls-pairing-plan §4). Returns nil on any
+/// failure — the caller treats that as a hard stop; it must NEVER fall back
+/// to plaintext for a pinned peer (plan invariant 3), and there is no
+/// force-unwrap in the identity path (SEV-2).
+enum TLSConfigurator {
+    /// - identity:    own SecIdentity from TrustStore.ownIdentity()
+    /// - pinnedSPKIs: closure returning the current pinned-SPKI set; MUST read
+    ///                an in-memory snapshot (TrustStore.allPinnedPeerSPKIs on
+    ///                the phone, a captured single-element array on the Mac).
+    ///                It is invoked on `queue` during handshakes — Keychain
+    ///                I/O in it is forbidden (SEV-7).
+    /// - isListener:  true ⇒ additionally require a client certificate.
+    /// - queue:       the connection's serial queue; verify block runs here.
+    static func mutualTLSOptions(identity: SecIdentity,
+                                  pinnedSPKIs: @escaping () -> [Data],
+                                  isListener: Bool,
+                                  queue: DispatchQueue) -> NWProtocolTLS.Options? {
+        guard let secIdentity = sec_identity_create(identity) else {
+            Log.info("ERROR: sec_identity_create failed — identity unusable, refusing TLS setup")
+            return nil // SEV-2: no crash, no plaintext fallback
+        }
+        let tls = NWProtocolTLS.Options()
+        let sec = tls.securityProtocolOptions
+        sec_protocol_options_set_min_tls_protocol_version(sec, .TLSv13)
+        sec_protocol_options_set_max_tls_protocol_version(sec, .TLSv13) // min == max: downgrade-proof
+        sec_protocol_options_set_local_identity(sec, secIdentity)       // both roles present a cert
+        if isListener {
+            // Without this the listener silently degrades to one-way server
+            // auth (plan §4).
+            sec_protocol_options_set_peer_authentication_required(sec, true)
+        }
+        sec_protocol_options_set_verify_block(sec, { _, sec_trust, complete in
+            // Self-signed world: pinning REPLACES chain trust — deliberately
+            // no SecTrustEvaluateWithError (plan §4/§10).
+            let trust = sec_trust_copy_ref(sec_trust).takeRetainedValue()
+            guard let chain = SecTrustCopyCertificateChain(trust) as? [SecCertificate],
+                  let leaf = chain.first,
+                  let key = SecCertificateCopyKey(leaf),
+                  let x963 = SecKeyCopyExternalRepresentation(key, nil) as Data?,
+                  let pub = try? P256.Signing.PublicKey(x963Representation: x963) else {
+                complete(false)
+                return
+            }
+            // SEV-2 same-source: re-encode through the SAME CryptoKit encoder
+            // that produced every pinned value, so pinned == extracted
+            // byte-for-byte. Plain Data equality — both operands public,
+            // constant-time explicitly rejected by plan §2.
+            complete(pinnedSPKIs().contains(pub.derRepresentation))
+        }, queue)
+        return tls
+    }
+}

--- a/Shared/TrustStore.swift
+++ b/Shared/TrustStore.swift
@@ -26,9 +26,11 @@ final class TrustStore {
     static let shared = TrustStore()
 
     private let lock = NSLock()
-    /// In-memory snapshot of all pinned peer SPKI DER blobs. Refreshed
-    /// from the Keychain by `refreshSnapshot()`; read lock-only everywhere else.
-    private var snapshot: [Data] = []
+    /// In-memory snapshot of all pinned peers as (peerID, SPKI DER) pairs.
+    /// Refreshed from the Keychain by `refreshSnapshot()`; read lock-only
+    /// everywhere else, so both the TLS verify block (SPKI membership) and
+    /// resolvePeerID (SPKI → peerID) run with zero Keychain I/O on the queue.
+    private var snapshot: [(peerID: String, spki: Data)] = []
 
     private init() {
         refreshSnapshot()
@@ -221,7 +223,16 @@ final class TrustStore {
     func allPinnedPeerSPKIs() -> [Data] {
         lock.lock()
         defer { lock.unlock() }
-        return snapshot
+        return snapshot.map { $0.spki }
+    }
+
+    /// Which pinned peerID owns this leaf SPKI, from the in-memory snapshot
+    /// ONLY — no Keychain I/O, so it is safe on the TLS/video queue right after
+    /// a handshake (resolvePeerID). nil if the SPKI matches no current pin.
+    func peerID(forSPKI spki: Data) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return snapshot.first { $0.spki == spki }?.peerID
     }
 
     /// Re-read all pins from the Keychain into the snapshot. Called by
@@ -230,19 +241,26 @@ final class TrustStore {
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: WireCrypto.pinKeychainService,
+            kSecReturnAttributes: true,
             kSecReturnData: true,
             kSecMatchLimit: kSecMatchLimitAll,
             kSecUseDataProtectionKeychain: true,
         ]
         var out: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &out)
-        var fresh: [Data] = []
-        // kSecReturnData + kSecMatchLimitAll returns an array of the raw value
-        // Data blobs — NOT an array of attribute dictionaries. Casting to
-        // [[CFString: Any]] silently fails and leaves the snapshot empty, which
-        // makes the TLS verify block reject every pinned peer (NoAuth).
-        if status == errSecSuccess, let items = out as? [Data] {
-            fresh = items
+        var fresh: [(peerID: String, spki: Data)] = []
+        // kSecReturnAttributes + kSecReturnData + kSecMatchLimitAll returns an
+        // array of attribute dictionaries, each carrying the pin bytes under
+        // kSecValueData and the peerID under kSecAttrAccount. (With
+        // kSecReturnData ALONE the shape is instead a bare [Data]; casting the
+        // wrong shape silently yields an empty snapshot, which makes the TLS
+        // verify block reject every pinned peer as NoAuth.)
+        if status == errSecSuccess, let items = out as? [[CFString: Any]] {
+            fresh = items.compactMap { item in
+                guard let spki = item[kSecValueData] as? Data,
+                      let peerID = item[kSecAttrAccount] as? String else { return nil }
+                return (peerID: peerID, spki: spki)
+            }
         } else if status != errSecItemNotFound {
             Log.info("ERROR: refreshSnapshot lookup failed (status \(status))")
         }

--- a/Shared/TrustStore.swift
+++ b/Shared/TrustStore.swift
@@ -1,0 +1,477 @@
+// Compiled into BOTH the Mac and iOS targets (see project.yml `sources`).
+// Shared but NOT Foundation-only (unlike Protocol.swift): imports CryptoKit,
+// Security, X509, SwiftASN1.
+
+import Foundation
+import CryptoKit
+import Security
+import X509
+import SwiftASN1
+
+/// Own TLS identity + per-peer SPKI pin store. Shared by both targets.
+///
+/// All Keychain access uses the data-protection keychain (TN3137) under the
+/// `WireCrypto.*` namespace. Thread-safe: every public method is internally
+/// synchronized (private `NSLock`); `allPinnedPeerSPKIs()` reads ONLY the
+/// in-memory snapshot (no Keychain I/O) so it is safe to call from a TLS
+/// verify block (wifi-tls-pairing-plan §4, SEV-7).
+///
+/// Runtime caveat (not a compile-time concern): on macOS, the data-protection
+/// keychain requires the app to be signed with an application identifier
+/// (TN3137). Normal team-signed Debug/Release builds are fine; a fully
+/// unsigned build (`DEVELOPMENT_TEAM` unset, as in CI) will get
+/// `errSecMissingEntitlement` at runtime. Every method below fails soft
+/// (nil / false / empty, logged) in that case — never crashes.
+final class TrustStore {
+    static let shared = TrustStore()
+
+    private let lock = NSLock()
+    /// In-memory snapshot of all pinned peer SPKI DER blobs (SEV-7). Refreshed
+    /// from the Keychain by `refreshSnapshot()`; read lock-only everywhere else.
+    private var snapshot: [Data] = []
+
+    private init() {
+        refreshSnapshot()
+    }
+
+    // MARK: - Own identity (plan §3, SEV-2 same-source fix)
+
+    /// Fetch the stored identity, generating and persisting a fresh one on
+    /// first call. nil = keychain unusable (logged, never crashes).
+    func ownIdentity() -> SecIdentity? {
+        lock.lock()
+        defer { lock.unlock() }
+        if let existing = queryIdentity() {
+            return existing
+        }
+        return generateAndStoreIdentity()
+    }
+
+    /// DER SubjectPublicKeyInfo of our own public key — the exact bytes the
+    /// bootstrap exchange sends and the peer pins. Always produced by
+    /// CryptoKit's `P256.Signing.PublicKey.derRepresentation` (same-source).
+    func ownSPKI() -> Data? {
+        guard let identity = ownIdentity() else { return nil }
+        var cert: SecCertificate?
+        let status = SecIdentityCopyCertificate(identity, &cert)
+        guard status == errSecSuccess, let cert else {
+            Log.info("ERROR: ownSPKI failed to copy certificate from identity (status \(status))")
+            return nil
+        }
+        return spkiFromCertificate(cert)
+    }
+
+    /// Keychain-backed install ID, created atomically with the identity and
+    /// deleted by `purgeAll()` — id and key live and die together (SEV-5).
+    /// The Mac app adopts this as macInstallID in the next milestone.
+    func installID() -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        if let existing = queryInstallID() {
+            return existing
+        }
+        // No identity yet ⇒ nothing generated ⇒ no install ID either. Drive
+        // generation through the same path as ownIdentity() so the two never
+        // diverge (SEV-5: id+key created together, in the same call).
+        guard generateAndStoreIdentity() != nil else { return nil }
+        return queryInstallID()
+    }
+
+    // MARK: - Peer pins (kSecClassGenericPassword rows, plan §3 table)
+
+    func hasPin(peerID: String) -> Bool {
+        pin(peerID: peerID) != nil
+    }
+
+    /// Pinned SPKI DER for a peer, or nil. Reads the Keychain (cold path).
+    func pin(peerID: String) -> Data? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: WireCrypto.pinKeychainService,
+            kSecAttrAccount: peerID,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne,
+            kSecUseDataProtectionKeychain: true,
+        ]
+        var out: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &out)
+        guard status == errSecSuccess, let data = out as? Data else {
+            if status != errSecItemNotFound {
+                Log.info("ERROR: pin(peerID:) lookup failed (status \(status))")
+            }
+            return nil
+        }
+        return data
+    }
+
+    /// Persist/overwrite a pin, then refresh the snapshot. Delete-then-add
+    /// semantics. false = Keychain write failed (logged).
+    @discardableResult
+    func setPin(peerID: String, spki: Data, displayName: String) -> Bool {
+        let deleteQuery: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: WireCrypto.pinKeychainService,
+            kSecAttrAccount: peerID,
+            kSecUseDataProtectionKeychain: true,
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        let addQuery: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: WireCrypto.pinKeychainService,
+            kSecAttrAccount: peerID,
+            kSecAttrLabel: displayName,
+            kSecValueData: spki,
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            kSecUseDataProtectionKeychain: true,
+        ]
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            Log.info("ERROR: setPin failed for peer \(peerID) (status \(status))")
+            return false
+        }
+        refreshSnapshot()
+        return true
+    }
+
+    /// Remove one peer's pin and refresh the snapshot.
+    func forget(peerID: String) {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: WireCrypto.pinKeychainService,
+            kSecAttrAccount: peerID,
+            kSecUseDataProtectionKeychain: true,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        if status != errSecSuccess, status != errSecItemNotFound {
+            Log.info("ERROR: forget(peerID:) failed for \(peerID) (status \(status))")
+        }
+        refreshSnapshot()
+    }
+
+    /// Nuke everything in both namespaces: all pins, identity key+cert,
+    /// install-ID row; empty the snapshot. (Reinstall cleanup §6(ii) and
+    /// "Reset identity" both land here.)
+    func purgeAll() {
+        let deletions: [[CFString: Any]] = [
+            [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: WireCrypto.pinKeychainService,
+                kSecUseDataProtectionKeychain: true,
+            ],
+            [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: WireCrypto.identityKeychainLabel,
+                kSecUseDataProtectionKeychain: true,
+            ],
+            [
+                kSecClass: kSecClassCertificate,
+                kSecAttrLabel: WireCrypto.identityKeychainLabel,
+                kSecUseDataProtectionKeychain: true,
+            ],
+            [
+                kSecClass: kSecClassKey,
+                kSecAttrApplicationTag: Data(WireCrypto.identityKeychainLabel.utf8),
+                kSecUseDataProtectionKeychain: true,
+            ],
+        ]
+        for query in deletions {
+            let status = SecItemDelete(query as CFDictionary)
+            if status != errSecSuccess, status != errSecItemNotFound {
+                Log.info("ERROR: purgeAll deletion failed for class \(query[kSecClass] ?? "?") (status \(status))")
+            }
+        }
+        lock.lock()
+        snapshot = []
+        lock.unlock()
+    }
+
+    /// (peerID, displayName) rows for the "Paired Macs"/forget UI
+    /// (kSecMatchLimitAll enumeration, plan §3). UI wiring is next milestone.
+    func pinnedPeers() -> [(peerID: String, displayName: String)] {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: WireCrypto.pinKeychainService,
+            kSecReturnAttributes: true,
+            kSecMatchLimit: kSecMatchLimitAll,
+            kSecUseDataProtectionKeychain: true,
+        ]
+        var out: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &out)
+        guard status == errSecSuccess, let items = out as? [[CFString: Any]] else {
+            if status != errSecItemNotFound {
+                Log.info("ERROR: pinnedPeers lookup failed (status \(status))")
+            }
+            return []
+        }
+        return items.compactMap { item in
+            guard let account = item[kSecAttrAccount] as? String else { return nil }
+            let label = item[kSecAttrLabel] as? String ?? account
+            return (peerID: account, displayName: label)
+        }
+    }
+
+    // MARK: - In-memory SPKI snapshot (SEV-7)
+
+    /// Lock-protected copy of the snapshot. NEVER touches the Keychain —
+    /// this is what TLS verify blocks read via the `pinnedSPKIs` closure.
+    func allPinnedPeerSPKIs() -> [Data] {
+        lock.lock()
+        defer { lock.unlock() }
+        return snapshot
+    }
+
+    /// Re-read all pins from the Keychain into the snapshot. Called by
+    /// init, setPin, forget, purgeAll; listeners also call it on start.
+    func refreshSnapshot() {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: WireCrypto.pinKeychainService,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitAll,
+            kSecUseDataProtectionKeychain: true,
+        ]
+        var out: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &out)
+        var fresh: [Data] = []
+        // kSecReturnData + kSecMatchLimitAll returns an array of the raw value
+        // Data blobs — NOT an array of attribute dictionaries. Casting to
+        // [[CFString: Any]] silently fails and leaves the snapshot empty, which
+        // makes the TLS verify block reject every pinned peer (NoAuth).
+        if status == errSecSuccess, let items = out as? [Data] {
+            fresh = items
+        } else if status != errSecItemNotFound {
+            Log.info("ERROR: refreshSnapshot lookup failed (status \(status))")
+        }
+        lock.lock()
+        snapshot = fresh
+        lock.unlock()
+    }
+
+    // MARK: - Fingerprint (plan §0/§6(iii))
+
+    /// Human-comparable grouped digits: HKDF-SHA256(ikm: spki,
+    /// salt: WireCrypto.fingerprintHKDFSalt, info: WireCrypto.fingerprintHKDFInfo,
+    /// outputByteCount: 10); split into five 2-byte big-endian integers; each
+    /// rendered `% 10000` zero-padded to 4 digits; joined with single spaces.
+    /// Example: "0421 9977 1024 0003 8810".
+    static func fingerprint(spki: Data) -> String {
+        let key = SymmetricKey(data: spki)
+        let output = HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: key,
+            salt: WireCrypto.fingerprintHKDFSalt,
+            info: WireCrypto.fingerprintHKDFInfo,
+            outputByteCount: 10)
+        let bytes = output.withUnsafeBytes { Array($0) }
+        var groups: [String] = []
+        groups.reserveCapacity(5)
+        for i in stride(from: 0, to: 10, by: 2) {
+            let value = (UInt16(bytes[i]) << 8) | UInt16(bytes[i + 1])
+            groups.append(String(format: "%04d", value % 10000))
+        }
+        return groups.joined(separator: " ")
+    }
+
+    // MARK: - Private helpers
+
+    /// The ONLY sanctioned identity retrieval path (plan §3) — never
+    /// `SecIdentityCreateWithCertificate`. Must be called with `lock` held.
+    private func queryIdentity() -> SecIdentity? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassIdentity,
+            kSecAttrLabel: WireCrypto.identityKeychainLabel,
+            kSecReturnRef: true,
+            kSecMatchLimit: kSecMatchLimitOne,
+            kSecUseDataProtectionKeychain: true,
+        ]
+        var out: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &out)
+        guard status == errSecSuccess else { return nil }
+        // Safe force-cast: errSecSuccess + kSecReturnRef on kSecClassIdentity
+        // is documented to yield a SecIdentity; `as!` here is a type-system
+        // formality, not a possible-failure force-unwrap.
+        return (out as! SecIdentity)
+    }
+
+    /// Must be called with `lock` held.
+    private func queryInstallID() -> String? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: WireCrypto.identityKeychainLabel,
+            kSecAttrAccount: WireCrypto.installIDAccount,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne,
+            kSecUseDataProtectionKeychain: true,
+        ]
+        var out: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &out)
+        guard status == errSecSuccess, let data = out as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Frozen identity-generation call sequence (plan §3). Must be called
+    /// with `lock` held. On any failure, deletes whatever partial items were
+    /// added and returns nil — no orphans, no crash (SEV-2).
+    private func generateAndStoreIdentity() -> SecIdentity? {
+        // 1. CryptoKit key — we own the SPKI bytes end to end.
+        let priv = P256.Signing.PrivateKey()
+        let installID = UUID().uuidString
+
+        // 2. Self-sign with swift-certificates (native CryptoKit signer, no
+        //    SecKey bridge for signing).
+        let certKey: Certificate.PrivateKey
+        let certificate: Certificate
+        do {
+            certKey = Certificate.PrivateKey(priv)
+            let name = try DistinguishedName { CommonName(installID) }
+            let now = Date()
+            certificate = try Certificate(
+                version: .v3,
+                serialNumber: Certificate.SerialNumber(),
+                publicKey: certKey.publicKey,
+                notValidBefore: now.addingTimeInterval(-86_400),
+                notValidAfter: now.addingTimeInterval(20 * 365 * 86_400),
+                issuer: name,
+                subject: name,
+                signatureAlgorithm: .ecdsaWithSHA256,
+                extensions: try Certificate.Extensions {
+                    Critical(BasicConstraints.notCertificateAuthority)
+                },
+                issuerPrivateKey: certKey)
+        } catch {
+            Log.info("ERROR: identity self-sign failed: \(error)")
+            return nil
+        }
+
+        // 3. DER-serialize (SwiftASN1).
+        let certDER: Data
+        do {
+            var serializer = DER.Serializer()
+            try serializer.serialize(certificate)
+            certDER = Data(serializer.serializedBytes)
+        } catch {
+            Log.info("ERROR: identity DER serialization failed: \(error)")
+            return nil
+        }
+
+        // 4. Import the private key as a SecKey (X9.63: 04||X||Y||K).
+        var cfErr: Unmanaged<CFError>?
+        guard let secKey = SecKeyCreateWithData(priv.x963Representation as CFData, [
+            kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
+            kSecAttrKeyClass: kSecAttrKeyClassPrivate,
+        ] as CFDictionary, &cfErr) else {
+            Log.info("ERROR: SecKeyCreateWithData failed: \(String(describing: cfErr?.takeRetainedValue()))")
+            return nil
+        }
+
+        // 5. Add key, then cert. The keychain auto-derives the key's
+        //    kSecAttrApplicationLabel (SHA-1 of public key); the identity
+        //    forms when that matches the cert's public key — byte-identical
+        //    by construction here.
+        var status = SecItemAdd([
+            kSecClass: kSecClassKey,
+            kSecValueRef: secKey,
+            kSecAttrApplicationTag: Data(WireCrypto.identityKeychainLabel.utf8),
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            kSecUseDataProtectionKeychain: true,
+        ] as CFDictionary, nil)
+        guard status == errSecSuccess || status == errSecDuplicateItem else {
+            Log.info("ERROR: SecItemAdd(key) failed (status \(status))")
+            return nil
+        }
+
+        guard let secCert = SecCertificateCreateWithData(nil, certDER as CFData) else {
+            Log.info("ERROR: SecCertificateCreateWithData failed")
+            deletePartialIdentityItems()
+            return nil
+        }
+        status = SecItemAdd([
+            kSecClass: kSecClassCertificate,
+            kSecValueRef: secCert,
+            kSecAttrLabel: WireCrypto.identityKeychainLabel,
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            kSecUseDataProtectionKeychain: true,
+        ] as CFDictionary, nil)
+        guard status == errSecSuccess || status == errSecDuplicateItem else {
+            Log.info("ERROR: SecItemAdd(certificate) failed (status \(status))")
+            deletePartialIdentityItems()
+            return nil
+        }
+
+        // 6. Persist installID in the SAME namespace (SEV-5: id+key die together).
+        status = SecItemAdd([
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: WireCrypto.identityKeychainLabel,
+            kSecAttrAccount: WireCrypto.installIDAccount,
+            kSecValueData: Data(installID.utf8),
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            kSecUseDataProtectionKeychain: true,
+        ] as CFDictionary, nil)
+        guard status == errSecSuccess || status == errSecDuplicateItem else {
+            Log.info("ERROR: SecItemAdd(installID) failed (status \(status))")
+            deletePartialIdentityItems()
+            return nil
+        }
+
+        // 7. Fetch the implicitly-formed identity — the ONLY sanctioned
+        //    retrieval (plan §3's fallback ladder item (a) is NOT
+        //    implemented in this phase).
+        var out: CFTypeRef?
+        status = SecItemCopyMatching([
+            kSecClass: kSecClassIdentity,
+            kSecAttrLabel: WireCrypto.identityKeychainLabel,
+            kSecReturnRef: true,
+            kSecMatchLimit: kSecMatchLimitOne,
+            kSecUseDataProtectionKeychain: true,
+        ] as CFDictionary, &out)
+        guard status == errSecSuccess else {
+            Log.info("ERROR: identity fetch after generation failed (status \(status))")
+            deletePartialIdentityItems()
+            return nil
+        }
+        guard let identity = out else {
+            Log.info("ERROR: identity fetch after generation returned no ref")
+            deletePartialIdentityItems()
+            return nil
+        }
+        // Safe force-cast: errSecSuccess + kSecReturnRef on kSecClassIdentity
+        // is documented to yield a SecIdentity.
+        return (identity as! SecIdentity)
+    }
+
+    /// Cleanup for a failed/partial generateAndStoreIdentity() run: deletes
+    /// the key (by tag) and cert (by label) so nothing orphaned survives.
+    /// Does NOT touch the install-ID row from a prior successful generation.
+    private func deletePartialIdentityItems() {
+        SecItemDelete([
+            kSecClass: kSecClassKey,
+            kSecAttrApplicationTag: Data(WireCrypto.identityKeychainLabel.utf8),
+            kSecUseDataProtectionKeychain: true,
+        ] as CFDictionary)
+        SecItemDelete([
+            kSecClass: kSecClassCertificate,
+            kSecAttrLabel: WireCrypto.identityKeychainLabel,
+            kSecUseDataProtectionKeychain: true,
+        ] as CFDictionary)
+    }
+
+    /// SEV-2 same-source SPKI extraction from a certificate already in the
+    /// Keychain: cert → SecKey → X9.63 → CryptoKit → DER. Never hand-assemble
+    /// SPKI headers; never return raw X9.63 from any public API.
+    private func spkiFromCertificate(_ cert: SecCertificate) -> Data? {
+        guard let key = SecCertificateCopyKey(cert) else {
+            Log.info("ERROR: SecCertificateCopyKey failed")
+            return nil
+        }
+        var cfErr: Unmanaged<CFError>?
+        guard let x963 = SecKeyCopyExternalRepresentation(key, &cfErr) as Data? else {
+            Log.info("ERROR: SecKeyCopyExternalRepresentation failed: \(String(describing: cfErr?.takeRetainedValue()))")
+            return nil
+        }
+        guard let pub = try? P256.Signing.PublicKey(x963Representation: x963) else {
+            Log.info("ERROR: P256 public key reconstruction from X9.63 failed")
+            return nil
+        }
+        return pub.derRepresentation
+    }
+}

--- a/Shared/TrustStore.swift
+++ b/Shared/TrustStore.swift
@@ -63,7 +63,9 @@ final class TrustStore {
 
     /// Keychain-backed install ID, created atomically with the identity and
     /// deleted by `purgeAll()` — id and key live and die together.
-    /// The Mac app adopts this as macInstallID in the next milestone.
+    /// The caller's own self-id: the Mac uses it as macInstallID for its wire
+    /// identity. Never called on iOS — the phone's wire id is
+    /// PhoneReceiver.installID (UserDefaults-backed).
     func installID() -> String? {
         lock.lock()
         defer { lock.unlock() }
@@ -187,7 +189,8 @@ final class TrustStore {
     }
 
     /// (peerID, displayName) rows for the "Paired Macs"/forget UI
-    /// (kSecMatchLimitAll enumeration). UI wiring is next milestone.
+    /// (kSecMatchLimitAll enumeration). Wired to the iOS Settings
+    /// "Paired Macs" list.
     func pinnedPeers() -> [(peerID: String, displayName: String)] {
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,

--- a/Shared/TrustStore.swift
+++ b/Shared/TrustStore.swift
@@ -14,7 +14,7 @@ import SwiftASN1
 /// `WireCrypto.*` namespace. Thread-safe: every public method is internally
 /// synchronized (private `NSLock`); `allPinnedPeerSPKIs()` reads ONLY the
 /// in-memory snapshot (no Keychain I/O) so it is safe to call from a TLS
-/// verify block (wifi-tls-pairing-plan §4, SEV-7).
+/// verify block.
 ///
 /// Runtime caveat (not a compile-time concern): on macOS, the data-protection
 /// keychain requires the app to be signed with an application identifier
@@ -26,7 +26,7 @@ final class TrustStore {
     static let shared = TrustStore()
 
     private let lock = NSLock()
-    /// In-memory snapshot of all pinned peer SPKI DER blobs (SEV-7). Refreshed
+    /// In-memory snapshot of all pinned peer SPKI DER blobs. Refreshed
     /// from the Keychain by `refreshSnapshot()`; read lock-only everywhere else.
     private var snapshot: [Data] = []
 
@@ -34,7 +34,7 @@ final class TrustStore {
         refreshSnapshot()
     }
 
-    // MARK: - Own identity (plan §3, SEV-2 same-source fix)
+    // MARK: - Own identity
 
     /// Fetch the stored identity, generating and persisting a fresh one on
     /// first call. nil = keychain unusable (logged, never crashes).
@@ -62,7 +62,7 @@ final class TrustStore {
     }
 
     /// Keychain-backed install ID, created atomically with the identity and
-    /// deleted by `purgeAll()` — id and key live and die together (SEV-5).
+    /// deleted by `purgeAll()` — id and key live and die together.
     /// The Mac app adopts this as macInstallID in the next milestone.
     func installID() -> String? {
         lock.lock()
@@ -72,12 +72,12 @@ final class TrustStore {
         }
         // No identity yet ⇒ nothing generated ⇒ no install ID either. Drive
         // generation through the same path as ownIdentity() so the two never
-        // diverge (SEV-5: id+key created together, in the same call).
+        // diverge (id+key created together, in the same call).
         guard generateAndStoreIdentity() != nil else { return nil }
         return queryInstallID()
     }
 
-    // MARK: - Peer pins (kSecClassGenericPassword rows, plan §3 table)
+    // MARK: - Peer pins (kSecClassGenericPassword rows)
 
     func hasPin(peerID: String) -> Bool {
         pin(peerID: peerID) != nil
@@ -150,7 +150,7 @@ final class TrustStore {
     }
 
     /// Nuke everything in both namespaces: all pins, identity key+cert,
-    /// install-ID row; empty the snapshot. (Reinstall cleanup §6(ii) and
+    /// install-ID row; empty the snapshot. (Reinstall cleanup and
     /// "Reset identity" both land here.)
     func purgeAll() {
         let deletions: [[CFString: Any]] = [
@@ -187,7 +187,7 @@ final class TrustStore {
     }
 
     /// (peerID, displayName) rows for the "Paired Macs"/forget UI
-    /// (kSecMatchLimitAll enumeration, plan §3). UI wiring is next milestone.
+    /// (kSecMatchLimitAll enumeration). UI wiring is next milestone.
     func pinnedPeers() -> [(peerID: String, displayName: String)] {
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
@@ -211,7 +211,7 @@ final class TrustStore {
         }
     }
 
-    // MARK: - In-memory SPKI snapshot (SEV-7)
+    // MARK: - In-memory SPKI snapshot
 
     /// Lock-protected copy of the snapshot. NEVER touches the Keychain —
     /// this is what TLS verify blocks read via the `pinnedSPKIs` closure.
@@ -248,7 +248,7 @@ final class TrustStore {
         lock.unlock()
     }
 
-    // MARK: - Fingerprint (plan §0/§6(iii))
+    // MARK: - Fingerprint
 
     /// Human-comparable grouped digits: HKDF-SHA256(ikm: spki,
     /// salt: WireCrypto.fingerprintHKDFSalt, info: WireCrypto.fingerprintHKDFInfo,
@@ -274,7 +274,7 @@ final class TrustStore {
 
     // MARK: - Private helpers
 
-    /// The ONLY sanctioned identity retrieval path (plan §3) — never
+    /// The ONLY sanctioned identity retrieval path — never
     /// `SecIdentityCreateWithCertificate`. Must be called with `lock` held.
     private func queryIdentity() -> SecIdentity? {
         let query: [CFString: Any] = [
@@ -309,9 +309,9 @@ final class TrustStore {
         return String(data: data, encoding: .utf8)
     }
 
-    /// Frozen identity-generation call sequence (plan §3). Must be called
+    /// Frozen identity-generation call sequence. Must be called
     /// with `lock` held. On any failure, deletes whatever partial items were
-    /// added and returns nil — no orphans, no crash (SEV-2).
+    /// added and returns nil — no orphans, no crash.
     private func generateAndStoreIdentity() -> SecIdentity? {
         // 1. CryptoKit key — we own the SPKI bytes end to end.
         let priv = P256.Signing.PrivateKey()
@@ -398,7 +398,7 @@ final class TrustStore {
             return nil
         }
 
-        // 6. Persist installID in the SAME namespace (SEV-5: id+key die together).
+        // 6. Persist installID in the SAME namespace (id+key die together).
         status = SecItemAdd([
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: WireCrypto.identityKeychainLabel,
@@ -414,8 +414,8 @@ final class TrustStore {
         }
 
         // 7. Fetch the implicitly-formed identity — the ONLY sanctioned
-        //    retrieval (plan §3's fallback ladder item (a) is NOT
-        //    implemented in this phase).
+        //    retrieval (a SecIdentityCreateWithCertificate fallback is
+        //    deliberately NOT implemented).
         var out: CFTypeRef?
         status = SecItemCopyMatching([
             kSecClass: kSecClassIdentity,
@@ -455,7 +455,7 @@ final class TrustStore {
         ] as CFDictionary)
     }
 
-    /// SEV-2 same-source SPKI extraction from a certificate already in the
+    /// Same-source SPKI extraction from a certificate already in the
     /// Keychain: cert → SecKey → X9.63 → CryptoKit → DER. Never hand-assemble
     /// SPKI headers; never return raw X9.63 from any public API.
     private func spkiFromCertificate(_ cert: SecCertificate) -> Data? {

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -104,6 +104,17 @@ struct ReceiverScreen: View {
         .sheet(isPresented: $showSettings) {
             SettingsView(receiver: model.receiver)
         }
+        // USB trust bootstrap confirmation (interactive dismiss = Deny).
+        // Programmatic clearing (bootstrap conn death) sets pendingTrust to
+        // nil directly on main and does NOT invoke this setter.
+        .sheet(item: Binding(
+            get: { model.receiver.pendingTrust },
+            set: { if $0 == nil { model.receiver.resolveTrust(allow: false) } }
+        )) { request in
+            TrustConfirmationView(request: request,
+                                  allow: { model.receiver.resolveTrust(allow: true) },
+                                  deny:  { model.receiver.resolveTrust(allow: false) })
+        }
         // Below the force floor → blocking gate. Setter is a no-op: the user
         // cannot dismiss it, only update.
         .fullScreenCover(item: Binding(get: { requiredUpdate }, set: { _ in })) { update in
@@ -138,6 +149,10 @@ struct ReceiverScreen: View {
             }
         }
         .onAppear {
+            if !UserDefaults.standard.bool(forKey: WireCrypto.trustStoreInitializedDefaultsKey) {
+                TrustStore.shared.purgeAll()
+                UserDefaults.standard.set(true, forKey: WireCrypto.trustStoreInitializedDefaultsKey)
+            }
             UIApplication.shared.isIdleTimerDisabled = true
             model.start()
             // Show the first-run hint unless the device has connected before
@@ -276,6 +291,81 @@ struct OnboardingView: View {
                 }
             }
         }
+    }
+}
+
+// MARK: - USB trust bootstrap confirmation (SEV-4 hardening)
+
+/// Confirmation sheet for a USB trust offer. The fingerprint is the PRIMARY
+/// identity — it's the only value that's cryptographically tied to the
+/// Mac's actual key; the Mac's self-reported name is decorative.
+struct TrustConfirmationView: View {
+    let request: TrustRequest
+    let allow: () -> Void
+    let deny: () -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
+
+                Text("Allow this Mac to connect over Wi-Fi?")
+                    .font(.title2.bold())
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+
+                VStack(spacing: 6) {
+                    Text(request.fingerprint)
+                        .font(.system(.title2, design: .monospaced).bold())
+                        .multilineTextAlignment(.center)
+                    Text("Verify this key fingerprint matches the Mac")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                VStack(spacing: 4) {
+                    Text(request.macName)
+                        .font(.body)
+                    Text("Name reported by the device (unverified)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if request.isIdentityChange {
+                    Text("This Mac's identity is different from the last time — this can happen when the app was reinstalled. If you didn't expect this, don't allow.")
+                        .font(.footnote)
+                        .foregroundStyle(.orange)
+                        .multilineTextAlignment(.center)
+                        .padding(12)
+                        .background(Color.orange.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+                        .padding(.horizontal)
+                }
+
+                Spacer()
+
+                VStack(spacing: 12) {
+                    Button("Allow") {
+                        allow()
+                        dismiss()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .frame(maxWidth: .infinity)
+
+                    Button("Don't Allow") {
+                        deny()
+                        dismiss()
+                    }
+                    .buttonStyle(.bordered)
+                    .frame(maxWidth: .infinity)
+                }
+                .padding(.horizontal)
+                .padding(.bottom, 24)
+            }
+            .padding(.top, 12)
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .interactiveDismissDisabled(false)
     }
 }
 
@@ -463,6 +553,8 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @AppStorage("showAnalytics") private var showAnalytics = false
     @AppStorage("metalRenderer") private var metalRenderer = false
+    @State private var pairedMacs: [(peerID: String, displayName: String)] = []
+    @State private var showResetIdentityConfirm = false
 
     private var version: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "dev"
@@ -472,7 +564,7 @@ struct SettingsView: View {
         NavigationStack {
             Form {
                 Section("Status") {
-                    LabeledContent("Listening", value: "Port 9000")
+                    LabeledContent("Listening", value: "Ready")
                     LabeledContent("Connection",
                                    value: receiver.connected ? "Connected" : "Waiting for Mac")
                     if receiver.videoSize != .zero {
@@ -492,6 +584,40 @@ struct SettingsView: View {
                     Text("Name")
                 } footer: {
                     Text("Shown in the Mac app's WiFi connection menu. iOS hides this \(deviceKind)'s real name from apps, so set it here once.")
+                }
+
+                if !pairedMacs.isEmpty {
+                    Section {
+                        ForEach(pairedMacs, id: \.peerID) { mac in
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(mac.displayName)
+                                Text(mac.peerID)
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .onDelete { offsets in
+                            for index in offsets {
+                                let peerID = pairedMacs[index].peerID
+                                receiver.sendUnpair(toPeerID: peerID)          // NEW — before forget/drop
+                                TrustStore.shared.forget(peerID: peerID)
+                                receiver.dropActiveConnection(peerID: peerID)
+                            }
+                            pairedMacs = TrustStore.shared.pinnedPeers()
+                        }
+                    } header: {
+                        Text("Paired Macs")
+                    } footer: {
+                        Text("Macs you've allowed to connect over Wi-Fi. Removing one requires pairing again over USB.")
+                    }
+                }
+
+                Section {
+                    Button("Reset identity", role: .destructive) {
+                        showResetIdentityConfirm = true
+                    }
+                } footer: {
+                    Text("Forgets all paired Macs and creates a new identity. Every Mac will need to re-pair over USB.")
                 }
 
                 Section {
@@ -552,6 +678,26 @@ struct SettingsView: View {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
                 }
+            }
+            .onAppear {
+                pairedMacs = TrustStore.shared.pinnedPeers()
+            }
+            .confirmationDialog(
+                "This forgets all paired Macs and creates a new identity. Every Mac will need to re-pair over USB.",
+                isPresented: $showResetIdentityConfirm,
+                titleVisibility: .visible
+            ) {
+                Button("Reset identity", role: .destructive) {
+                    for mac in TrustStore.shared.pinnedPeers() {               // NEW — before purgeAll
+                        receiver.sendUnpair(toPeerID: mac.peerID)
+                    }
+                    TrustStore.shared.purgeAll()
+                    _ = TrustStore.shared.ownIdentity()
+                    receiver.restartAllListeners()
+                    receiver.dropActiveConnection()
+                    pairedMacs = []
+                }
+                Button("Cancel", role: .cancel) {}
             }
         }
     }

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -294,7 +294,7 @@ struct OnboardingView: View {
     }
 }
 
-// MARK: - USB trust bootstrap confirmation (SEV-4 hardening)
+// MARK: - USB trust bootstrap confirmation
 
 /// Confirmation sheet for a USB trust offer. The fingerprint is the PRIMARY
 /// identity — it's the only value that's cryptographically tied to the

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -12,6 +12,8 @@ import AVFoundation
 import CoreMedia
 import VideoToolbox
 import UIKit
+import Security
+import CryptoKit
 
 /// One-second window of pipeline health, plus per-frame timing samples for
 /// the performance overlay graph.
@@ -42,6 +44,25 @@ struct PerfStats: Equatable {
     var photonP95 = 0.0
 }
 
+/// How an inbound connection was accepted — decided BY THE LISTENER (TLS
+/// listener ⇒ .tls; :9000 ⇒ loopback-prefix heuristic, which stays a mere
+/// transport label and priority rank, never a trust decision — invariant 4).
+private enum TransportLabel {
+    case loopback, tls, plaintextWiFi
+    var rank: Int { self == .loopback ? 2 : self == .tls ? 1 : 0 }
+    var statsName: String { self == .loopback ? "USB" : "WiFi" }
+}
+
+/// One pending USB trust offer, published for the confirmation sheet.
+struct TrustRequest: Identifiable, Equatable {
+    let macID: String
+    let macName: String        // cosmetic, UNVERIFIED
+    let spki: Data
+    let fingerprint: String    // TrustStore.fingerprint(spki:)
+    let isIdentityChange: Bool // pin exists but SPKI differs
+    var id: String { macID + "|" + fingerprint }
+}
+
 final class PhoneReceiver: ObservableObject {
 
     @Published var status = "Starting…"
@@ -52,15 +73,41 @@ final class PhoneReceiver: ObservableObject {
     // Compatibility signal from the connected Mac (issue #132). Nil = no signal.
     // Merged into the update gate by ReceiverScreen.
     @Published var peerSignal: PeerUpdateSignal?
+    // Main-thread mirror of pendingOffer; drives the trust-confirmation sheet.
+    @Published var pendingTrust: TrustRequest?
 
     private var listener: NWListener?
     private var listenerHealthy = false
     private var connection: NWConnection?
+    // peerID (TrustStore account) of the Mac behind `connection`, resolved
+    // from its TLS client certificate at `.ready`. Only ever set for `.tls`
+    // connections — loopback/USB has no cryptographic peer identity to
+    // resolve (invariant 4: never a trust decision), so this stays nil for
+    // it. Scopes per-Mac "forget" (dropActiveConnection(peerID:)) so
+    // forgetting Mac A can never kick an unrelated, still-trusted Mac B.
+    private var connectedPeerID: String?
     private let queue = DispatchQueue(label: "receiver.video")
     private var buffer = Data()
+    // Upper bound on a single length-prefixed video-channel frame, so a
+    // corrupt or hostile 4-byte length prefix can't grow `buffer` unbounded
+    // while trickled bytes keep resetting the liveness watchdog (mirrors the
+    // bound already enforced on the bootstrap channel via
+    // WireCrypto.maxBootstrapFrameBytes). Generous enough for any real H.264
+    // keyframe at the highest supported quality/resolution.
+    private static let maxVideoFrameBytes = 64 << 20   // 64 MiB
     private var formatDesc: CMVideoFormatDescription?
     private var sps: Data?
     private var pps: Data?
+
+    // USB trust bootstrap (loopback-only) + TLS listener state.
+    private var bootstrapListener: NWListener?
+    private var bootstrapListenerHealthy = false
+    private var tlsListener: NWListener?
+    private var tlsListenerHealthy = false
+    private var currentLabel: TransportLabel?          // label of self.connection
+    private var bootstrapConn: NWConnection?           // one at a time
+    private var bootstrapBuffer = Data()
+    private var pendingOffer: TrustRequest?             // queue-confined mirror of pendingTrust
 
     // Liveness: the Mac streams video and pings every 2s; if nothing arrives
     // for 5s the connection is half-open (Mac killed, tunnel died) — drop it
@@ -161,7 +208,7 @@ final class PhoneReceiver: ObservableObject {
         return fresh
     }()
 
-    private var advertisedService: NWListener.Service {
+    private func advertisedService() -> NWListener.Service {
         var txt = NWTXTRecord()
         txt["id"] = Self.installID
         txt["pv"] = String(WireProtocol.version)   // issue #132
@@ -176,8 +223,8 @@ final class PhoneReceiver: ObservableObject {
         queue.async {
             guard resolved != self.serviceName else { return }
             self.serviceName = resolved
-            if self.listener != nil {
-                self.listener?.service = self.advertisedService
+            if self.tlsListener != nil {
+                self.tlsListener?.service = self.advertisedService()
                 Log.info("re-advertising as \"\(resolved)\"")
             }
         }
@@ -210,7 +257,12 @@ final class PhoneReceiver: ObservableObject {
 
     func start(port: UInt16 = 9000) {
         self.port = port
-        queue.async { self.startListener() }
+        queue.async {
+            TrustStore.shared.refreshSnapshot()   // arm the verify-block snapshot before any TLS accept
+            self.startListener()                  // legacy :9000 — unchanged internals
+            self.startBootstrapListener()
+            self.startTLSListener()
+        }
         if !monitorsStarted {
             monitorsStarted = true
             schedulePing()
@@ -218,13 +270,69 @@ final class PhoneReceiver: ObservableObject {
         }
     }
 
-    /// Recreate the listener if it isn't healthy — called when the app
-    /// returns to the foreground (iOS may have torn it down while suspended).
+    /// Recreate any listener that isn't healthy — called when the app
+    /// returns to the foreground (iOS may have torn listeners down while
+    /// suspended). Per-listener recovery: a healthy listener (and its live
+    /// accepted connection) is never churned because a sibling is down.
     func ensureListening() {
         queue.async {
-            guard !self.listenerHealthy else { return }
-            Log.info("listener not healthy — restarting")
+            if !self.listenerHealthy          { Log.info("legacy listener unhealthy — restarting");    self.restartListener() }
+            if !self.bootstrapListenerHealthy { Log.info("bootstrap listener unhealthy — restarting"); self.restartBootstrapListener() }
+            if !self.tlsListenerHealthy       { Log.info("TLS listener unhealthy — restarting");       self.restartTLSListener() }
+        }
+    }
+
+    /// Reset-identity hook: tear down and rebuild all three listeners (e.g.
+    /// the TLS listener needs the freshly generated identity).
+    func restartAllListeners() {
+        queue.async {
             self.restartListener()
+            self.restartBootstrapListener()
+            self.restartTLSListener()
+        }
+    }
+
+    /// Per-Mac forget hook: kick the live connection ONLY if it belongs to
+    /// the forgotten peer. `peerID` is resolved from the peer's TLS client
+    /// certificate at connect time (see `resolvePeerID`), so this can't kick
+    /// an unrelated, still-trusted Mac's active session. If `connectedPeerID`
+    /// couldn't be resolved (e.g. USB/loopback, which has no cryptographic
+    /// peer identity — invariant 4) the active connection is left alone;
+    /// forgetting a USB-pinned peer while it's the live connection is a rare
+    /// edge case and erring toward NOT disconnecting an unrelated session is
+    /// the safer default.
+    func dropActiveConnection(peerID: String) {
+        queue.async {
+            guard let conn = self.connection, self.connectedPeerID == peerID else { return }
+            Log.info("dropping active connection for forgotten peer \(peerID)")
+            conn.cancel()
+        }
+    }
+
+    /// Reset-identity hook: purgeAll() drops every pin, so unlike the
+    /// per-Mac forget above there is no "unrelated" session to protect —
+    /// kick whatever is connected, unconditionally.
+    func dropActiveConnection() {
+        queue.async {
+            guard let conn = self.connection else { return }
+            Log.info("dropping active connection after identity reset")
+            conn.cancel()
+        }
+    }
+
+    /// Symmetric revoke: tell the connected Mac to drop its pin for us. On a
+    /// TLS connection the send is scoped to the forgotten peer via
+    /// `connectedPeerID`; on loopback/USB there is no cryptographic peer
+    /// identity (invariant 4), so the message is sent as-is and the Mac
+    /// ignores it unless `toID` matches its own installID.
+    func sendUnpair(toPeerID peerID: String) {
+        queue.async {
+            guard let conn = self.connection, conn.state == .ready else { return }
+            if self.currentLabel == .tls, self.connectedPeerID != peerID { return }
+            Log.info("unpair sent to \(peerID)")
+            self.sendControl(["type": WireMessage.unpair,
+                              "fromID": Self.installID,
+                              "toID": peerID], on: conn)
         }
     }
 
@@ -233,6 +341,20 @@ final class PhoneReceiver: ObservableObject {
         listener = nil
         listenerHealthy = false
         startListener()
+    }
+
+    private func restartBootstrapListener() {
+        bootstrapListener?.cancel()
+        bootstrapListener = nil
+        bootstrapListenerHealthy = false
+        startBootstrapListener()
+    }
+
+    private func restartTLSListener() {
+        tlsListener?.cancel()
+        tlsListener = nil
+        tlsListenerHealthy = false
+        startTLSListener()
     }
 
     private func startListener() {
@@ -245,46 +367,37 @@ final class PhoneReceiver: ObservableObject {
             let params = NWParameters(tls: nil, tcp: tcp)
             params.allowLocalEndpointReuse = true
             params.serviceClass = .interactiveVideo
-            listener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: port)!)
+            // Phase 2 (wifi-tls-pairing-plan §8): the legacy plaintext port now
+            // serves ONLY usbmux-forwarded traffic, which arrives on loopback —
+            // bind loopback-only so LAN plaintext can never reach it again. Same
+            // anchor as the bootstrap listener below: the port comes from
+            // requiredLocalEndpoint — do NOT also pass `on:`.
+            params.requiredLocalEndpoint = NWEndpoint.hostPort(
+                host: "127.0.0.1",
+                port: NWEndpoint.Port(rawValue: port)!)
+            listener = try NWListener(using: params)
         } catch {
             setStatus("Listener failed: \(error.localizedDescription)")
             return
         }
-        // Advertise on the local network so the Mac can discover us for WiFi
-        // mode (USB/usbmux connects straight to the port and ignores this).
-        listener?.service = advertisedService
         listener?.newConnectionHandler = { [weak self] conn in
             guard let self else { return }
-            Log.info("new connection from \(String(describing: conn.endpoint))")
             // usbmux-forwarded (cable) connections arrive from loopback;
-            // anything else came over the network.
+            // anything else came over the network. This prefix check is a
+            // mere transport label / priority rank — never a trust decision
+            // (invariant 4); TLS acceptance derives solely from the
+            // completed pinned handshake in the TLS listener below.
             let peer = String(describing: conn.endpoint)
-            self.transport = (peer.hasPrefix("127.0.0.1") || peer.hasPrefix("::1")
-                              || peer.hasPrefix("localhost")) ? "USB" : "WiFi"
-            // Replace any existing connection and reset decoder state.
-            self.connection?.cancel()
-            self.connection = conn
-            self.resetStreamState()
-            conn.stateUpdateHandler = { [weak self] state in
-                switch state {
-                case .ready:
-                    self?.lastDataReceived = Date()
-                    self?.setConnected(true)
-                    self?.sendHello(on: conn)
-                case .failed, .cancelled:
-                    self?.setConnected(false)
-                default: break
-                }
-            }
-            conn.start(queue: self.queue)
-            self.receive(on: conn)
+            let label: TransportLabel = (peer.hasPrefix("127.0.0.1") || peer.hasPrefix("::1")
+                              || peer.hasPrefix("localhost")) ? .loopback : .plaintextWiFi
+            self.adopt(conn, label: label)
         }
         listener?.stateUpdateHandler = { [weak self] state in
             guard let self else { return }
             switch state {
             case .ready:
                 self.listenerHealthy = true
-                self.setStatus("Listening on :\(self.port)")
+                self.setStatus("Waiting for your Mac to connect…")
             case .failed(let error):
                 Log.info("listener failed: \(error) — restarting in 1s")
                 self.listenerHealthy = false
@@ -296,6 +409,351 @@ final class PhoneReceiver: ObservableObject {
             }
         }
         listener?.start(queue: queue)
+    }
+
+    // MARK: - Connection adoption / replacement priority (§2)
+
+    /// Single adoption path for every inbound connection, regardless of
+    /// listener. Rank: loopback = 2, TLS = 1, plaintext-WiFi = 0. Accept iff
+    /// no active existing connection OR incoming.rank >= existing.rank.
+    /// Rejection cancels the INCOMING conn (never started); acceptance
+    /// cancels the existing one.
+    /// True unless the connection has cancelled or failed — `.failed` carries
+    /// an associated `NWError`, so it can't be matched with a bare `!=` and
+    /// needs an explicit switch instead.
+    private func isActive(_ state: NWConnection.State) -> Bool {
+        switch state {
+        case .cancelled, .failed: return false
+        default: return true
+        }
+    }
+
+    private func adopt(_ conn: NWConnection, label: TransportLabel) {
+        Log.info("new \(label) connection from \(String(describing: conn.endpoint))")
+        if let existing = connection,
+           isActive(existing.state),
+           let existingLabel = currentLabel,
+           label.rank < existingLabel.rank {
+            Log.info("rejecting \(label) connection — active \(existingLabel) connection has priority")
+            conn.cancel()
+            return
+        }
+        connection?.cancel()
+        connection = conn
+        currentLabel = label
+        transport = label.statsName          // stats/overlay label ONLY (invariant 4)
+        resetStreamState()
+        conn.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .ready:
+                self.lastDataReceived = Date()
+                self.setConnected(true)
+                if label == .tls {
+                    self.connectedPeerID = self.resolvePeerID(for: conn)
+                } else {
+                    self.connectedPeerID = nil   // loopback/USB: no cryptographic identity (invariant 4)
+                }
+                self.sendHello(on: conn)
+            case .failed, .cancelled:
+                if self.connection === conn {   // a replaced conn must not clobber its successor
+                    self.connection = nil
+                    self.currentLabel = nil
+                    self.connectedPeerID = nil
+                    self.setConnected(false)
+                }
+            default: break
+            }
+        }
+        conn.start(queue: queue)
+        receive(on: conn)
+    }
+
+    /// Resolves which pinned peerID's certificate matches this TLS
+    /// connection's peer, by re-deriving its SPKI the SAME way
+    /// TLSConfigurator's verify_block does (same-source encoding, so
+    /// pinned == extracted byte-for-byte) and looking it up against
+    /// TrustStore's pinned peers. Runs on `queue`, post-handshake, so the
+    /// connection has already passed pin verification — this only answers
+    /// "which pin", never "is it pinned".
+    private func resolvePeerID(for conn: NWConnection) -> String? {
+        guard let tlsMetadata = conn.metadata(definition: NWProtocolTLS.definition) as? NWProtocolTLS.Metadata else {
+            return nil
+        }
+        let secMetadata = tlsMetadata.securityProtocolMetadata
+        var leaf: SecCertificate?
+        // Block is invoked once per chain certificate, leaf first — grab only
+        // the first and ignore the rest (self-signed world: pinning already
+        // verified the leaf's SPKI is trusted; we just need to know WHICH one).
+        _ = sec_protocol_metadata_access_peer_certificate_chain(secMetadata) { certificate in
+            if leaf == nil { leaf = sec_certificate_copy_ref(certificate).takeRetainedValue() }
+        }
+        guard let leaf,
+              let key = SecCertificateCopyKey(leaf),
+              let x963 = SecKeyCopyExternalRepresentation(key, nil) as Data?,
+              let pub = try? P256.Signing.PublicKey(x963Representation: x963) else {
+            return nil
+        }
+        let spki = pub.derRepresentation
+        return TrustStore.shared.pinnedPeers().first { TrustStore.shared.pin(peerID: $0.peerID) == spki }?.peerID
+    }
+
+    // MARK: - USB trust bootstrap listener (loopback-only; §5, §6)
+
+    private func startBootstrapListener() {
+        do {
+            let tcp = NWProtocolTCP.Options()
+            let params = NWParameters(tls: nil, tcp: tcp)
+            params.allowLocalEndpointReuse = true
+            // THE trust anchor: only loopback-delivered traffic (i.e. usbmux
+            // forwarding) can reach this listener. No .service ⇒ no Bonjour ⇒
+            // no Local Network prompt.
+            params.requiredLocalEndpoint = NWEndpoint.hostPort(
+                host: "127.0.0.1",
+                port: NWEndpoint.Port(rawValue: WireCrypto.bootstrapPort)!)
+            bootstrapListener = try NWListener(using: params)   // port comes from requiredLocalEndpoint — do NOT also pass `on:`
+        } catch {
+            bootstrapListenerHealthy = false
+            Log.info("bootstrap listener bind failed: \(error)")
+            return
+        }
+        bootstrapListener?.newConnectionHandler = { [weak self] conn in
+            guard let self else { return }
+            // One at a time; a fresh dial (Mac retry) replaces a stale one.
+            self.bootstrapConn?.cancel()
+            self.bootstrapBuffer.removeAll()
+            self.clearPendingTrust()
+            self.bootstrapConn = conn
+            conn.stateUpdateHandler = { [weak self] state in
+                if case .failed = state { self?.dropBootstrapConn(conn) }
+                if case .cancelled = state { self?.dropBootstrapConn(conn) }
+            }
+            conn.start(queue: self.queue)
+            self.handleBootstrapData(on: conn)
+        }
+        bootstrapListener?.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .ready: self.bootstrapListenerHealthy = true
+            case .failed(let error):
+                Log.info("bootstrap listener failed: \(error) — restarting in 1s")
+                self.bootstrapListenerHealthy = false
+                self.queue.asyncAfter(deadline: .now() + 1) { self.restartBootstrapListener() }
+            case .cancelled: self.bootstrapListenerHealthy = false
+            default: break
+            }
+        }
+        bootstrapListener?.start(queue: queue)
+    }
+
+    /// If `conn` is still the active bootstrap connection, tear it down and
+    /// retract any pending sheet (pending unplug ⇒ sheet retracts; the Mac's
+    /// next USB hello retries).
+    private func dropBootstrapConn(_ conn: NWConnection) {
+        guard bootstrapConn === conn else { return }
+        bootstrapConn = nil
+        bootstrapBuffer.removeAll()
+        clearPendingTrust()
+    }
+
+    private func clearPendingTrust() {
+        pendingOffer = nil
+        DispatchQueue.main.async { self.pendingTrust = nil }
+    }
+
+    // MARK: - TLS listener (pinned mutual TLS; §4, §5)
+
+    private func startTLSListener() {
+        guard let identity = TrustStore.shared.ownIdentity() else {
+            tlsListenerHealthy = false
+            Log.info("TLS listener: no identity available — will retry via ensureListening")
+            return
+        }
+        guard let tlsOptions = TLSConfigurator.mutualTLSOptions(
+                identity: identity,
+                pinnedSPKIs: { TrustStore.shared.allPinnedPeerSPKIs() },   // live snapshot: new pins take effect with NO restart
+                isListener: true, queue: queue) else {
+            tlsListenerHealthy = false
+            Log.info("TLS listener: mutualTLSOptions failed — refusing TLS (never plaintext)")
+            return
+        }
+        do {
+            let tcp = NWProtocolTCP.Options()
+            tcp.noDelay = true
+            let params = NWParameters(tls: tlsOptions, tcp: tcp)
+            params.allowLocalEndpointReuse = true
+            params.serviceClass = .interactiveVideo
+            tlsListener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: WireCrypto.tlsPort)!)
+        } catch {
+            tlsListenerHealthy = false
+            Log.info("TLS listener bind failed: \(error)")
+            return
+        }
+        // Advertise on the local network so the Mac can discover us for WiFi
+        // mode. This is the ONE Bonjour advertisement — the same
+        // "_opensidecar._tcp" type the app has always declared, so upgrades
+        // never need a fresh Local Network grant (macOS snapshots the
+        // declared types at grant time; a new type browses as NoAuth -65555).
+        // It resolves to the TLS port: WiFi is mTLS-only by construction.
+        tlsListener?.service = advertisedService()
+        tlsListener?.newConnectionHandler = { [weak self] conn in
+            guard let self else { return }
+            // A completed handshake already proves pinned mutual auth by
+            // construction — always .tls, no endpoint-string inspection.
+            self.adopt(conn, label: .tls)
+        }
+        tlsListener?.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .ready:
+                self.tlsListenerHealthy = true
+            case .failed(let error):
+                Log.info("TLS listener failed: \(error) — restarting in 1s")
+                self.tlsListenerHealthy = false
+                self.queue.asyncAfter(deadline: .now() + 1) { self.restartTLSListener() }
+            case .cancelled:
+                self.tlsListenerHealthy = false
+            default: break
+            }
+        }
+        tlsListener?.start(queue: queue)
+    }
+
+    // MARK: - Bootstrap wire protocol (§3, §6)
+
+    /// Framed read loop on the bootstrap connection: [UInt32 BE length][UTF-8 JSON].
+    private func handleBootstrapData(on conn: NWConnection) {
+        conn.receive(minimumIncompleteLength: 1, maximumLength: 1 << 16) { [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            guard self.bootstrapConn === conn else { return }   // superseded by a fresh dial
+            if let data, !data.isEmpty {
+                self.bootstrapBuffer.append(data)
+                self.drainBootstrapFrames(on: conn)
+            }
+            if error != nil || isComplete {
+                self.dropBootstrapConn(conn)
+                return
+            }
+            if self.bootstrapConn === conn {
+                self.handleBootstrapData(on: conn)
+            }
+        }
+    }
+
+    private func drainBootstrapFrames(on conn: NWConnection) {
+        while bootstrapBuffer.count >= 4 {
+            let len = bootstrapBuffer.prefix(4).withUnsafeBytes {
+                Int(UInt32(bigEndian: $0.loadUnaligned(as: UInt32.self)))
+            }
+            guard len > 0, len < WireCrypto.maxBootstrapFrameBytes else {
+                Log.info("bootstrap frame length out of bounds (\(len)) — closing")
+                conn.cancel()
+                return
+            }
+            guard bootstrapBuffer.count >= 4 + len else { break }
+            let payload = bootstrapBuffer.subdata(in: bootstrapBuffer.index(bootstrapBuffer.startIndex, offsetBy: 4)..<bootstrapBuffer.index(bootstrapBuffer.startIndex, offsetBy: 4 + len))
+            bootstrapBuffer.removeSubrange(bootstrapBuffer.startIndex..<bootstrapBuffer.index(bootstrapBuffer.startIndex, offsetBy: 4 + len))
+            processBootstrapFrame(payload, on: conn)
+        }
+    }
+
+    /// State machine (§6): idle → offerReceived → {autoAccepted | awaitingUser}
+    /// → {accepted | denied | aborted} → idle.
+    private func processBootstrapFrame(_ payload: Data, on conn: NWConnection) {
+        guard let obj = try? JSONSerialization.jsonObject(with: payload) as? [String: Any],
+              let type = obj["type"] as? String, type == WireMessage.trustOffer,
+              let macID = obj["macID"] as? String, !macID.isEmpty,
+              let spkiB64 = obj["spki"] as? String,
+              let spki = Data(base64Encoded: spkiB64),
+              spki.count >= 1, spki.count <= 4096 else {
+            sendBootstrapReply(["type": WireMessage.trustDeny], on: conn, thenClose: true)
+            return
+        }
+        let macName = (obj["macName"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? "Mac"
+        let fingerprint = TrustStore.fingerprint(spki: spki)
+
+        if let existingPin = TrustStore.shared.pin(peerID: macID) {
+            if existingPin == spki {
+                // Auto-accept (idempotent): no write, no UI.
+                replyTrustAccept(on: conn)
+                return
+            }
+            // Changed identity: pin exists but SPKI differs. Old pin is NOT
+            // touched until Allow.
+            let request = TrustRequest(macID: macID, macName: macName, spki: spki,
+                                       fingerprint: fingerprint, isIdentityChange: true)
+            pendingOffer = request
+            DispatchQueue.main.async { self.pendingTrust = request }
+            return
+        }
+        // First contact: no pin.
+        let request = TrustRequest(macID: macID, macName: macName, spki: spki,
+                                   fingerprint: fingerprint, isIdentityChange: false)
+        pendingOffer = request
+        DispatchQueue.main.async { self.pendingTrust = request }
+    }
+
+    /// UI entry point (main thread) — hops to `queue`. Idempotent.
+    func resolveTrust(allow: Bool) {
+        queue.async {
+            guard let offer = self.pendingOffer, let conn = self.bootstrapConn else { return }
+            guard allow else {
+                self.sendBootstrapReply(["type": WireMessage.trustDeny], on: conn, thenClose: true)
+                self.pendingOffer = nil
+                DispatchQueue.main.async { self.pendingTrust = nil }
+                return
+            }
+            guard let mySPKI = TrustStore.shared.ownSPKI() else {
+                self.sendBootstrapReply(["type": WireMessage.trustDeny], on: conn, thenClose: true)
+                self.pendingOffer = nil
+                DispatchQueue.main.async { self.pendingTrust = nil }
+                return
+            }
+            guard TrustStore.shared.setPin(peerID: offer.macID, spki: offer.spki, displayName: offer.macName) else {
+                self.sendBootstrapReply(["type": WireMessage.trustDeny], on: conn, thenClose: true)
+                self.pendingOffer = nil
+                DispatchQueue.main.async { self.pendingTrust = nil }
+                return
+            }
+            if self.tlsListener == nil { self.startTLSListener() }
+            self.pendingOffer = nil
+            DispatchQueue.main.async { self.pendingTrust = nil }
+            self.replyTrustAccept(on: conn, mySPKI: mySPKI)
+        }
+    }
+
+    private func replyTrustAccept(on conn: NWConnection) {
+        guard let mySPKI = TrustStore.shared.ownSPKI() else {
+            sendBootstrapReply(["type": WireMessage.trustDeny], on: conn, thenClose: true)
+            return
+        }
+        replyTrustAccept(on: conn, mySPKI: mySPKI)
+    }
+
+    private func replyTrustAccept(on conn: NWConnection, mySPKI: Data) {
+        let message: [String: Any] = [
+            "type": WireMessage.trustAccept,
+            "phoneID": Self.installID,
+            "spki": mySPKI.base64EncodedString(),
+        ]
+        sendBootstrapReply(message, on: conn, thenClose: true)
+    }
+
+    private func sendBootstrapReply(_ message: [String: Any], on conn: NWConnection, thenClose: Bool) {
+        guard let payload = try? JSONSerialization.data(withJSONObject: message) else {
+            if thenClose { conn.cancel() }
+            return
+        }
+        var header = UInt32(payload.count).bigEndian
+        var frame = Data(bytes: &header, count: 4)
+        frame.append(payload)
+        conn.send(content: frame, completion: .contentProcessed { [weak self] error in
+            if let error { Log.info("bootstrap reply send error: \(error)") }
+            if thenClose {
+                conn.cancel()
+                if self?.bootstrapConn === conn { self?.bootstrapConn = nil }
+            }
+        })
     }
 
     // MARK: - Liveness (ping + watchdog)
@@ -362,6 +820,22 @@ final class PhoneReceiver: ObservableObject {
                 ?? "Update OpenDisplay from the App Store to keep using your second display."
             let store = (obj["store"] as? String).flatMap { URL(string: $0) } ?? AppStore.updateURL
             DispatchQueue.main.async { self.peerSignal = .updateIPhone(message: message, storeURL: store) }
+        case WireMessage.unpair:
+            guard let fromID = obj["fromID"] as? String, !fromID.isEmpty,
+                  let toID = obj["toID"] as? String, toID == Self.installID else {
+                Log.info("unpair ignored — malformed or not addressed to us")
+                break
+            }
+            // TLS: the authenticated peer must BE the revoking Mac. Loopback
+            // has no cryptographic peer identity (invariant 4) — the physical
+            // cable is the same trust anchor the bootstrap channel uses.
+            if currentLabel == .tls, connectedPeerID != fromID {
+                Log.info("unpair ignored — fromID \(fromID) does not match authenticated peer")
+                break
+            }
+            Log.info("Mac \(fromID) revoked pairing — forgetting pin and dropping connection")
+            TrustStore.shared.forget(peerID: fromID)   // no-op if not pinned; refreshes snapshot
+            connection?.cancel()                        // adopt()'s state handler clears connection/connectedPeerID/setConnected
         default:
             break
         }
@@ -375,6 +849,8 @@ final class PhoneReceiver: ObservableObject {
                 Log.info("watchdog: nothing from the Mac for >5s — dropping connection")
                 conn.cancel()
                 self.connection = nil
+                self.currentLabel = nil
+                self.connectedPeerID = nil
                 self.setConnected(false)
             }
             self.scheduleWatchdog()
@@ -448,7 +924,7 @@ final class PhoneReceiver: ObservableObject {
                 self.lastDataReceived = Date()
                 self.bytesThisWindow += data.count
                 self.buffer.append(data)
-                self.drainFrames()
+                self.drainFrames(on: conn)
             }
             if let error {
                 Log.info("receive error: \(error)")
@@ -463,12 +939,20 @@ final class PhoneReceiver: ObservableObject {
         }
     }
 
-    private func drainFrames() {
+    private func drainFrames(on conn: NWConnection) {
         // Cursor-based drain so we only compact the buffer once per batch.
         var cursor = buffer.startIndex
         while buffer.distance(from: cursor, to: buffer.endIndex) >= 4 {
             let len = buffer[cursor..<buffer.index(cursor, offsetBy: 4)]
                 .withUnsafeBytes { Int(UInt32(bigEndian: $0.loadUnaligned(as: UInt32.self))) }
+            // Bound the length prefix so a corrupt/hostile value can't grow
+            // `buffer` unboundedly — trickled bytes would otherwise keep
+            // resetting the liveness watchdog while data piles up in memory.
+            guard len <= Self.maxVideoFrameBytes else {
+                Log.info("video frame length out of bounds (\(len)) — closing")
+                conn.cancel()
+                return
+            }
             guard buffer.distance(from: cursor, to: buffer.endIndex) >= 4 + len else { break }
             let start = buffer.index(cursor, offsetBy: 4)
             let end = buffer.index(start, offsetBy: len)
@@ -823,7 +1307,7 @@ final class PhoneReceiver: ObservableObject {
 
     private func setConnected(_ value: Bool) {
         DispatchQueue.main.async { self.connected = value }
-        if !value { setStatus("Listening on :9000") }
+        if !value { setStatus("Waiting for your Mac to connect…") }
         else {
             setStatus("Connected")
             // Remember the first ever successful connection to a Mac so the

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -46,7 +46,7 @@ struct PerfStats: Equatable {
 
 /// How an inbound connection was accepted — decided BY THE LISTENER (TLS
 /// listener ⇒ .tls; :9000 ⇒ loopback-prefix heuristic, which stays a mere
-/// transport label and priority rank, never a trust decision — invariant 4).
+/// transport label and priority rank, never a trust decision).
 private enum TransportLabel {
     case loopback, tls, plaintextWiFi
     var rank: Int { self == .loopback ? 2 : self == .tls ? 1 : 0 }
@@ -82,7 +82,7 @@ final class PhoneReceiver: ObservableObject {
     // peerID (TrustStore account) of the Mac behind `connection`, resolved
     // from its TLS client certificate at `.ready`. Only ever set for `.tls`
     // connections — loopback/USB has no cryptographic peer identity to
-    // resolve (invariant 4: never a trust decision), so this stays nil for
+    // resolve (never a trust decision), so this stays nil for
     // it. Scopes per-Mac "forget" (dropActiveConnection(peerID:)) so
     // forgetting Mac A can never kick an unrelated, still-trusted Mac B.
     private var connectedPeerID: String?
@@ -297,7 +297,7 @@ final class PhoneReceiver: ObservableObject {
     /// certificate at connect time (see `resolvePeerID`), so this can't kick
     /// an unrelated, still-trusted Mac's active session. If `connectedPeerID`
     /// couldn't be resolved (e.g. USB/loopback, which has no cryptographic
-    /// peer identity — invariant 4) the active connection is left alone;
+    /// peer identity) the active connection is left alone;
     /// forgetting a USB-pinned peer while it's the live connection is a rare
     /// edge case and erring toward NOT disconnecting an unrelated session is
     /// the safer default.
@@ -323,7 +323,7 @@ final class PhoneReceiver: ObservableObject {
     /// Symmetric revoke: tell the connected Mac to drop its pin for us. On a
     /// TLS connection the send is scoped to the forgotten peer via
     /// `connectedPeerID`; on loopback/USB there is no cryptographic peer
-    /// identity (invariant 4), so the message is sent as-is and the Mac
+    /// identity, so the message is sent as-is and the Mac
     /// ignores it unless `toID` matches its own installID.
     func sendUnpair(toPeerID peerID: String) {
         queue.async {
@@ -367,7 +367,7 @@ final class PhoneReceiver: ObservableObject {
             let params = NWParameters(tls: nil, tcp: tcp)
             params.allowLocalEndpointReuse = true
             params.serviceClass = .interactiveVideo
-            // Phase 2 (wifi-tls-pairing-plan §8): the legacy plaintext port now
+            // The legacy plaintext port now
             // serves ONLY usbmux-forwarded traffic, which arrives on loopback —
             // bind loopback-only so LAN plaintext can never reach it again. Same
             // anchor as the bootstrap listener below: the port comes from
@@ -384,8 +384,8 @@ final class PhoneReceiver: ObservableObject {
             guard let self else { return }
             // usbmux-forwarded (cable) connections arrive from loopback;
             // anything else came over the network. This prefix check is a
-            // mere transport label / priority rank — never a trust decision
-            // (invariant 4); TLS acceptance derives solely from the
+            // mere transport label / priority rank — never a trust decision;
+            // TLS acceptance derives solely from the
             // completed pinned handshake in the TLS listener below.
             let peer = String(describing: conn.endpoint)
             let label: TransportLabel = (peer.hasPrefix("127.0.0.1") || peer.hasPrefix("::1")
@@ -411,7 +411,7 @@ final class PhoneReceiver: ObservableObject {
         listener?.start(queue: queue)
     }
 
-    // MARK: - Connection adoption / replacement priority (§2)
+    // MARK: - Connection adoption / replacement priority
 
     /// Single adoption path for every inbound connection, regardless of
     /// listener. Rank: loopback = 2, TLS = 1, plaintext-WiFi = 0. Accept iff
@@ -441,7 +441,7 @@ final class PhoneReceiver: ObservableObject {
         connection?.cancel()
         connection = conn
         currentLabel = label
-        transport = label.statsName          // stats/overlay label ONLY (invariant 4)
+        transport = label.statsName          // stats/overlay label ONLY — never a trust decision
         resetStreamState()
         conn.stateUpdateHandler = { [weak self] state in
             guard let self else { return }
@@ -452,7 +452,7 @@ final class PhoneReceiver: ObservableObject {
                 if label == .tls {
                     self.connectedPeerID = self.resolvePeerID(for: conn)
                 } else {
-                    self.connectedPeerID = nil   // loopback/USB: no cryptographic identity (invariant 4)
+                    self.connectedPeerID = nil   // loopback/USB: no cryptographic identity
                 }
                 self.sendHello(on: conn)
             case .failed, .cancelled:
@@ -498,7 +498,7 @@ final class PhoneReceiver: ObservableObject {
         return TrustStore.shared.pinnedPeers().first { TrustStore.shared.pin(peerID: $0.peerID) == spki }?.peerID
     }
 
-    // MARK: - USB trust bootstrap listener (loopback-only; §5, §6)
+    // MARK: - USB trust bootstrap listener (loopback-only)
 
     private func startBootstrapListener() {
         do {
@@ -561,7 +561,7 @@ final class PhoneReceiver: ObservableObject {
         DispatchQueue.main.async { self.pendingTrust = nil }
     }
 
-    // MARK: - TLS listener (pinned mutual TLS; §4, §5)
+    // MARK: - TLS listener (pinned mutual TLS)
 
     private func startTLSListener() {
         guard let identity = TrustStore.shared.ownIdentity() else {
@@ -619,7 +619,7 @@ final class PhoneReceiver: ObservableObject {
         tlsListener?.start(queue: queue)
     }
 
-    // MARK: - Bootstrap wire protocol (§3, §6)
+    // MARK: - Bootstrap wire protocol
 
     /// Framed read loop on the bootstrap connection: [UInt32 BE length][UTF-8 JSON].
     private func handleBootstrapData(on conn: NWConnection) {
@@ -657,7 +657,7 @@ final class PhoneReceiver: ObservableObject {
         }
     }
 
-    /// State machine (§6): idle → offerReceived → {autoAccepted | awaitingUser}
+    /// State machine: idle → offerReceived → {autoAccepted | awaitingUser}
     /// → {accepted | denied | aborted} → idle.
     private func processBootstrapFrame(_ payload: Data, on conn: NWConnection) {
         guard let obj = try? JSONSerialization.jsonObject(with: payload) as? [String: Any],
@@ -806,12 +806,14 @@ final class PhoneReceiver: ObservableObject {
             let normSize = CGSize(width: nw, height: nh)
             DispatchQueue.main.async { self.onCursorImage?(image, anchor, normSize) }
         case WireMessage.welcome:
-            // The Mac identified itself (issue #132). If it speaks a protocol
-            // older than we support, it's the Mac that needs updating — and an
-            // old Mac can't diagnose that itself, so we surface it here.
+            // The Mac identified itself (issue #132). A Mac older than the
+            // TLS WiFi transport still streams over USB (which is how this
+            // welcome arrived — the plaintext port is loopback-only), but
+            // can never do Wi-Fi — and an old Mac can't diagnose that
+            // itself, so surface a soft hint here.
             let macPV = obj["pv"] as? Int ?? WireProtocol.assumedWhenAbsent
-            if macPV < WireProtocol.minSupportedPeer {
-                let msg = "The OpenDisplay app on your Mac is too old for this \(deviceKind) app. Update OpenDisplay on your Mac to reconnect."
+            if macPV < WireProtocol.minWiFiPeer {
+                let msg = "The OpenDisplay app on your Mac is too old for Wi-Fi streaming. Update OpenDisplay on your Mac to use Wi-Fi — USB keeps working."
                 DispatchQueue.main.async { self.peerSignal = .updateMac(message: msg) }
             }
         case WireMessage.updateRequired:
@@ -827,7 +829,7 @@ final class PhoneReceiver: ObservableObject {
                 break
             }
             // TLS: the authenticated peer must BE the revoking Mac. Loopback
-            // has no cryptographic peer identity (invariant 4) — the physical
+            // has no cryptographic peer identity — the physical
             // cable is the same trust anchor the bootstrap channel uses.
             if currentLabel == .tls, connectedPeerID != fromID {
                 Log.info("unpair ignored — fromID \(fromID) does not match authenticated peer")

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -199,6 +199,11 @@ final class PhoneReceiver: ObservableObject {
     // transport" — the service name can't serve that role since it's
     // user-editable, and iOS offers no public API for the hardware UDID
     // that usbmuxd reports.
+    //
+    // This UserDefaults UUID is the phone's wire identity everywhere (TXT
+    // "id", hello id, trustAccept.phoneID, unpair fromID/toID). The phone
+    // deliberately does NOT use TrustStore.installID() — that Keychain-backed
+    // id is the caller's own self-id, read only by the Mac.
     static let installID: String = {
         if let existing = UserDefaults.standard.string(forKey: "installID") {
             return existing

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -435,6 +435,15 @@ final class PhoneReceiver: ObservableObject {
 
     private func adopt(_ conn: NWConnection, label: TransportLabel) {
         Log.info("new \(label) connection from \(String(describing: conn.endpoint))")
+        // Higher rank preempts lower: loopback(2) > tls(1) > plaintextWiFi(0).
+        // A loopback (usbmux, 127.0.0.1:9000) connection is INTENTIONALLY
+        // allowed to take over an active WiFi TLS session — the cable is the
+        // stronger trust anchor and legit cable-in migration relies on it. That
+        // port is unreachable from the LAN; an app already running ON this
+        // device could reach loopback, but on-device compromise is out of scope
+        // (same posture as the :9010 bootstrap listener) and could at most
+        // DoS/spoof the local display — never read the Mac's screen or decrypt
+        // the WiFi session.
         if let existing = connection,
            isActive(existing.state),
            let existingLabel = currentLabel,
@@ -500,7 +509,9 @@ final class PhoneReceiver: ObservableObject {
             return nil
         }
         let spki = pub.derRepresentation
-        return TrustStore.shared.pinnedPeers().first { TrustStore.shared.pin(peerID: $0.peerID) == spki }?.peerID
+        // In-memory snapshot lookup — no Keychain I/O on `queue` (which also
+        // drives video framing); the snapshot is armed before any TLS accept.
+        return TrustStore.shared.peerID(forSPKI: spki)
     }
 
     // MARK: - USB trust bootstrap listener (loopback-only)
@@ -510,9 +521,12 @@ final class PhoneReceiver: ObservableObject {
             let tcp = NWProtocolTCP.Options()
             let params = NWParameters(tls: nil, tcp: tcp)
             params.allowLocalEndpointReuse = true
-            // THE trust anchor: only loopback-delivered traffic (i.e. usbmux
-            // forwarding) can reach this listener. No .service ⇒ no Bonjour ⇒
-            // no Local Network prompt.
+            // Loopback-bound: unreachable from the LAN — only traffic delivered
+            // to 127.0.0.1 (usbmux forwarding over the cable) reaches it, and
+            // with no .service there is no Bonjour and no Local Network prompt.
+            // An app already running ON this device could also reach loopback,
+            // but on-device compromise is out of scope: an offer still requires
+            // on-screen confirmation and cannot forge a real Mac's key.
             params.requiredLocalEndpoint = NWEndpoint.hostPort(
                 host: "127.0.0.1",
                 port: NWEndpoint.Port(rawValue: WireCrypto.bootstrapPort)!)

--- a/project.yml
+++ b/project.yml
@@ -11,7 +11,7 @@ packages:
     # 2.x is the current major (latest 2.9.x) and the first Sparkle line to
     # support SPM. `from:` allows compatible 2.x updates.
     from: "2.6.0"
-  # X.509 identity minting for cert-pinned mutual TLS (wifi-tls-pairing-plan §3).
+  # X.509 identity minting for cert-pinned mutual TLS (issue #16).
   # Compiled into BOTH targets alongside Shared/TrustStore.swift.
   SwiftCertificates:
     url: https://github.com/apple/swift-certificates

--- a/project.yml
+++ b/project.yml
@@ -11,6 +11,16 @@ packages:
     # 2.x is the current major (latest 2.9.x) and the first Sparkle line to
     # support SPM. `from:` allows compatible 2.x updates.
     from: "2.6.0"
+  # X.509 identity minting for cert-pinned mutual TLS (wifi-tls-pairing-plan §3).
+  # Compiled into BOTH targets alongside Shared/TrustStore.swift.
+  SwiftCertificates:
+    url: https://github.com/apple/swift-certificates
+    from: "1.19.1"
+  # Explicit because Shared/TrustStore.swift imports SwiftASN1 (DER.Serializer)
+  # directly; do not rely on it transitively via SwiftCertificates.
+  SwiftASN1:
+    url: https://github.com/apple/swift-asn1
+    from: "1.1.0"
 schemes:
   OpenSidecarMac:
     build:
@@ -42,6 +52,10 @@ targets:
       - Shared
     dependencies:
       - package: Sparkle
+      - package: SwiftCertificates
+        product: X509
+      - package: SwiftASN1
+        product: SwiftASN1
     info:
       path: Mac/Info.plist
       properties:
@@ -91,6 +105,11 @@ targets:
     sources:
       - iOS
       - Shared
+    dependencies:
+      - package: SwiftCertificates
+        product: X509
+      - package: SwiftASN1
+        product: SwiftASN1
     info:
       path: iOS/Info.plist
       properties:


### PR DESCRIPTION
# Encrypt the WiFi transport: USB-bootstrapped trust + cert-pinned mutual TLS 1.3

Addresses #16.

## Motivation

Today WiFi mode streams H.264 in the clear on the local network and accepts any Mac that connects — anyone on the same Wi-Fi can passively record the screen or inject input. This PR makes WiFi private and authenticated before it's promoted to a first-class mode. USB stays point-to-point and unchanged.

## What it does

- **Pairing is anchored to the physical USB cable, not a typed code.** The first time a device is cabled, the Mac and iPad exchange self-signed P-256 identities over a **loopback-only** usbmux channel (`:9010`). The iPad shows a one-time confirmation displaying the key **fingerprint** (Signal-style grouped digits). On accept, each side pins the peer's public key (SPKI) in the data-protection Keychain.
- **WiFi then runs mutual TLS 1.3** (`:9001`) authenticated by those pinned identities. No low-entropy secret is ever on the wire, so there's nothing to brute-force; an unpinned Mac fails the handshake.
- **Unauthenticated connections are rejected** — WiFi is TLS-only, there is no plaintext fallback on the LAN.
- **Self-healing re-pairing.** The USB bootstrap runs once per USB session and the iPad is the source of truth: it silently auto-accepts on an exact pin match (so routine plug-ins never prompt) and shows the confirmation sheet otherwise. "Forget"/"Reset identity" revoke symmetrically over the wire and drop the live session immediately; a stale pin also self-heals on a TLS rejection. Every forget/reconnect combination ends at a fresh confirmation.

## Relationship to #16

The **goal and acceptance criteria of #16 are met**: WiFi is encrypted and authenticated, and a third machine on the LAN can neither view the stream nor connect.

The **approach differs deliberately** from the one sketched in the issue:

| #16 suggested | This PR | Why |
|---|---|---|
| `NWProtocolTLS` with a **PSK** | **cert-pinned mutual TLS 1.3** | Network.framework PSK is TLS-1.2-only on Apple platforms, and a PSK derived from a low-entropy code is offline-dictionary-attackable (TLS-PSK is not a PAKE). Pinned self-signed identities give TLS 1.3 + forward secrecy with no crackable secret. |
| **Short numeric pairing code** | **USB physical-trust bootstrap** | The cable is a stronger trust anchor than a low-entropy code: no offline-crackable secret, no remote attack surface during pairing. Mirrors Apple's own "Trust This Computer" model. |

**Tradeoff to flag:** because pairing is USB-first, a device that is *never* cabled to a given Mac cannot pair over WiFi. If cable-less pairing is desired, a numeric-code path would need a real PAKE (e.g. SPAKE2) — happy to do it as a follow-up if you'd prefer to keep #16's original code-based flow.

## Security properties

- Screen content and input are encrypted end-to-end over WiFi (mutual TLS 1.3).
- MITM-resistant: both ends present and verify pinned self-signed certs; private keys never leave the device.
- The bootstrap listener is bound to `127.0.0.1` (usbmux only, unreachable from the LAN) and needs no Local Network permission.
- Auto-accept only on an exact `installID` + SPKI match; a new or changed identity always requires on-screen confirmation.

**Threat model** is the local network. A malicious app *already running on the iPad* can reach the loopback USB ports (`127.0.0.1:9000`/`:9010`) — but on-device compromise is out of scope (such an app could screen-record by other means), and even then it can only DoS or spoof the local display, never read the Mac's screen or decrypt the WiFi session. The USB video channel stays plaintext by design: the cable + Apple's "Trust This Computer" is the physical trust boundary.

## Compatibility & rollout

- **USB unaffected**: still plaintext over a loopback-bound port (physical channel); the `:9000` listener just stops advertising on the LAN. A version-mismatched (pre-TLS) peer still streams over USB — only WiFi requires the newer protocol.
- **Discovery reuses the existing `_opensidecar._tcp` Bonjour type** — no new service type is declared, so **upgrading installs never need to re-grant Local Network permission** (macOS snapshots declared Bonjour types at grant time). The TLS listener advertises on that type; the Mac dials the discovered endpoint (which resolves to the TLS port).
- **WiFi is TLS-only**: pre-TLS peers can't establish a WiFi session (they can't pair or complete the pinned handshake), so they're USB-only by construction rather than by a hard version gate.
- Deployment targets unchanged (macOS 14 / iOS 17).

## Dependencies

Adds `apple/swift-certificates` and `apple/swift-asn1` (both targets) for minting/serializing the self-signed identities.

## New files

- `Shared/TrustStore.swift` — identity generation, Keychain-backed pins, in-memory pin snapshot, fingerprint.
- `Shared/TLSConfigurator.swift` — pinned mutual-TLS 1.3 `NWProtocolTLS.Options`.
- `Mac/TrustBootstrapClient.swift` — the USB `:9010` identity exchange.

## Testing

- Both schemes build (macOS + iOS, deployment targets 14/17).
- Verified on device (macOS 26.2 + iPadOS 26.5): first pairing shows the fingerprint sheet and connects; a packet capture on `:9001` confirms TLS application-data records (`0x17 0x03 …`) with no plaintext H.264/JSON on the wire; seamless USB ⇄ WiFi transport switching; Forget / Reset identity revoke and re-pair correctly (both sides, connected and disconnected) while routine re-plugs don't re-prompt.

Note: on-device runtime was exercised on macOS 26 / iPadOS 26; the self-signed `SecIdentity` formation path is compile-checked against the 14/17 SDK settings but hasn't been runtime-verified on 14/17 hardware.

## Not included

- The dev-only signing convenience (gitignored `Signing.xcconfig`) and any personal bundle identifier are intentionally kept out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
