### PR TITLE
feat(mac): respect user-chosen display resolution (#9)

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -506,7 +506,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                                           onOriginChange: { origin, currentSize in
                                               DisplayArrangement.save(origin: origin, size: currentSize,
                                                                       device: arrangementKey)
-                                          })
+                                          },
+                                          deviceKey: arrangementKey)
                 }
                 if created != nil { break }
                 Log.info("virtual display creation failed (identity +\(totalOffset), attempt \(attempt + 1)) — retrying")

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -1,6 +1,69 @@
 import Foundation
 import CoreGraphics
 
+/// Scaled HiDPI mode steps offered in System Settings → Displays (the
+/// "More Space" / "Larger Text" equivalents). Index 0 is native @2x; the rest
+/// are progressively downscaled point sizes, each still backed by a @2x
+/// framebuffer so text stays sharp. Publishing several lets the user pick a
+/// resolution that actually sticks (issue #9) instead of being forced back to
+/// the single native mode.
+let resolutionSteps: [CGFloat] = [1.0, 0.85, 0.75, 0.67]
+
+/// Build the mode list for a virtual display of the given point size.
+/// - Returns: resolutionSteps.count modes, native first. Pure (no I/O) so it is
+///   unit-testable without a real display.
+func buildDisplayModes(pointsWide: Int, pointsHigh: Int) -> [CGVirtualDisplayMode] {
+    resolutionSteps.map { s in
+        CGVirtualDisplayMode(
+            width: UInt((CGFloat(pointsWide) * s).rounded(.toNearestOrEven)),
+            height: UInt((CGFloat(pointsHigh) * s).rounded(.toNearestOrEven)),
+            refreshRate: 60
+        )
+    }
+}
+
+/// Decision for the lifetime mode-enforcement loop. The loop exists to undo
+/// macOS asynchronously restoring a *stale* saved mode (issue #26) — which
+/// shows up as a 1x/blurry relapse or a wrong-orientation mode pillarboxing
+/// the framebuffer (issue #29). But a user picking a scaled mode we published
+/// must be LEFT ALONE (#9). So we discriminate:
+///   - current is one of our published modes  → leave it (user choice stands)
+///   - current is NOT published AND not settled → re-assert (startup race)
+///   - current is NOT published AND settled    → only after it has been missing
+///     for `missingTicks` consecutive ticks (issue #29 fix-plan point 2: debounce
+///     so transient wipes during a neighbor's reconfiguration heal on their own).
+/// Pure + testable. `missingTicks` is the running count of consecutive ticks
+/// where the @2x mode was absent.
+func shouldReassertMode(currentWidth: Int, currentPixelWidth: Int,
+                         published: [CGVirtualDisplayMode],
+                         targetStep: Int = 0,
+                         settled: Bool, missingTicks: Int) -> Bool {
+    let publishedIndex = published.firstIndex {
+        $0.width == UInt(currentWidth) && $0.width * 2 == UInt(currentPixelWidth)
+    }
+    if !settled {
+        let targetIndex = published.indices.contains(targetStep) ? targetStep : 0
+        return publishedIndex != targetIndex
+    }
+    if publishedIndex != nil { return false }            // #9: user choice stands
+    return missingTicks >= 3                   // #29: debounced recovery only
+}
+
+/// Per-device resolution memory (issue #9 "persist per device"). Keyed by the
+/// same install-id used for arrangement (#116) so each physical device keeps
+/// its chosen mode across sessions and transports. Stores the chosen step index.
+enum ResolutionStore {
+    private static func key(for device: String) -> String { "resolution.\(device)" }
+
+    static func save(step: Int, device: String) {
+        UserDefaults.standard.set(step, forKey: key(for: device))
+    }
+    static func load(device: String) -> Int? {
+        guard UserDefaults.standard.object(forKey: key(for: device)) != nil else { return nil }
+        return UserDefaults.standard.integer(forKey: key(for: device))
+    }
+}
+
 /// Wraps the private CGVirtualDisplay API: makes macOS believe a real monitor
 /// is attached. Sized in points at HiDPI (@2x), so a phone with native pixels
 /// W×H gets a virtual display of (W/2)×(H/2) points backed by a W×H framebuffer.
@@ -16,6 +79,10 @@ final class VirtualDisplay {
     private var restoreUntil: Date
     private var lastReportedOrigin: CGPoint?
     private let onOriginChange: ((CGPoint, CGSize) -> Void)?
+    private let deviceKey: String?
+    /// Running count of consecutive enforcement ticks where the @2x mode was
+    /// absent. Drives the debounced recovery (issue #29 fix-plan point 2).
+    private var missingTicks = 0
 
     var displayID: CGDirectDisplayID { display.displayID }
 
@@ -26,10 +93,13 @@ final class VirtualDisplay {
     /// `restoreOrigin` overrides that saved arrangement (see manageOrigin);
     /// `onOriginChange` reports where the display sits afterwards, so the
     /// caller can persist user drags.
+    /// `deviceKey` (install id, per #116/#26) keys per-device resolution memory
+    /// so a chosen scaled mode is reapplied and persisted (issue #9).
     init?(name: String, pointsWide: Int, pointsHigh: Int, sizeInMillimeters: CGSize,
           serialNum: UInt32 = 0x0001, productID: UInt32 = 0x4F53,
           restoreOrigin: CGPoint? = nil,
-          onOriginChange: ((CGPoint, CGSize) -> Void)? = nil) {
+          onOriginChange: ((CGPoint, CGSize) -> Void)? = nil,
+          deviceKey: String? = nil) {
         self.pointsWide = pointsWide
         self.pointsHigh = pointsHigh
         // Reserve the longer orientation on both axes. That lets a phone or
@@ -39,6 +109,7 @@ final class VirtualDisplay {
         self.restoreTarget = restoreOrigin
         self.restoreUntil = restoreOrigin == nil ? .distantPast : Date().addingTimeInterval(6)
         self.onOriginChange = onOriginChange
+        self.deviceKey = deviceKey
 
         let descriptor = CGVirtualDisplayDescriptor()
         descriptor.setDispatchQueue(DispatchQueue.main)
@@ -59,9 +130,9 @@ final class VirtualDisplay {
 
         settings = CGVirtualDisplaySettings()
         settings.hiDPI = 1
-        settings.modes = [
-            CGVirtualDisplayMode(width: UInt(pointsWide), height: UInt(pointsHigh), refreshRate: 60)
-        ]
+        // Publish every scaled HiDPI step (issue #9) so the user can pick a
+        // resolution in System Settings → Displays that actually sticks.
+        settings.modes = buildDisplayModes(pointsWide: pointsWide, pointsHigh: pointsHigh)
         guard display.apply(settings) else {
             Log.info("CGVirtualDisplay applySettings FAILED")
             return nil
@@ -73,8 +144,11 @@ final class VirtualDisplay {
         // display appears (observed: a display checked as @2x at creation
         // sitting at 1x later, and a rotated rebuild pillarboxed by the
         // previous orientation's mode). So mode selection is enforcement,
-        // not a one-shot: keep watching for the lifetime of the display and
-        // re-assert the HiDPI mode whenever something else changes it.
+        // not a one-shot. BUT a user picking a scaled mode we published must
+        // stick (issue #9), while macOS's async 1x/wrong-orientation relapses
+        // (issue #26/#29) must still be undone. `shouldReassertMode` is the
+        // discriminator; recovery is debounced so transient wipes during a
+        // neighbor's reconfiguration heal on their own (issue #29 point 2).
         Task { @MainActor [weak self] in
             var settled = false
             while true {
@@ -83,7 +157,7 @@ final class VirtualDisplay {
                 do {
                     guard let self else { return }
                     self.ensureNotMirrored()
-                    if self.selectHiDPIMode(recover: settled) { settled = true }
+                    if self.enforceMode(settled: settled) { settled = true }
                     self.manageOrigin()
                 }
                 try? await Task.sleep(for: .milliseconds(settled ? 2000 : 200))
@@ -107,9 +181,7 @@ final class VirtualDisplay {
 
         let newSettings = CGVirtualDisplaySettings()
         newSettings.hiDPI = 1
-        newSettings.modes = [
-            CGVirtualDisplayMode(width: UInt(pointsWide), height: UInt(pointsHigh), refreshRate: 60)
-        ]
+        newSettings.modes = buildDisplayModes(pointsWide: pointsWide, pointsHigh: pointsHigh)
         guard display.apply(newSettings) else {
             Log.info("virtual display \(display.displayID) applySettings FAILED during resize")
             return false
@@ -142,36 +214,71 @@ final class VirtualDisplay {
         }
         return true
     }
-
-    /// Returns true when the display is (now) in its HiDPI mode. Silent when
-    /// nothing needed doing — this runs every 2s as enforcement. With
-    /// `recover`, a missing @2x mode (macOS can replace the whole mode list
-    /// when it restores saved display state) re-applies our settings to
-    /// publish it again instead of failing silently forever.
     @discardableResult
-    private func selectHiDPIMode(recover: Bool = false) -> Bool {
+    private func enforceMode(settled: Bool) -> Bool {
         let opts = [kCGDisplayShowDuplicateLowResolutionModes: kCFBooleanTrue] as CFDictionary
-        guard let modes = CGDisplayCopyAllDisplayModes(display.displayID, opts) as? [CGDisplayMode],
-              let hidpi = modes.first(where: {
-                  $0.width == pointsWide && $0.pixelWidth == pointsWide * 2
-              }) else {
-            if recover {
-                Log.info("@2x mode vanished from display \(display.displayID) — re-applying settings")
-                _ = display.apply(settings)
-            }
+        guard let runtimeModes = CGDisplayCopyAllDisplayModes(display.displayID, opts) as? [CGDisplayMode] else {
+            // Whole mode list gone — republish (mirrors old `recover` path).
+            Log.info("@2x modes vanished from display \(display.displayID) — re-applying settings")
+            _ = display.apply(settings)
+            missingTicks += 1
             return false
         }
-        if let current = CGDisplayCopyDisplayMode(display.displayID),
-           current.width == hidpi.width, current.pixelWidth == hidpi.pixelWidth {
+        guard let current = CGDisplayCopyDisplayMode(display.displayID) else { return false }
+
+        let targetStep = deviceKey.flatMap { ResolutionStore.load(device: $0) } ?? 0
+
+        let currentPublishedIndex = settings.modes.firstIndex(where: {
+            $0.width == current.width && $0.width * 2 == current.pixelWidth
+        })
+
+        if let idx = currentPublishedIndex {
+            missingTicks = 0
+            if let key = deviceKey {
+                ResolutionStore.save(step: idx, device: key)
+            }
+        } else {
+            missingTicks += 1
+        }
+
+        let reassert = shouldReassertMode(
+            currentWidth: Int(current.width),
+            currentPixelWidth: Int(current.pixelWidth),
+            published: settings.modes,
+            targetStep: targetStep,
+            settled: settled,
+            missingTicks: missingTicks
+        )
+
+        if !reassert {
             return true
+        }
+
+        // Find the runtime CGDisplayMode to restore to: prefer the persisted
+        // per-device choice (if still offered), else native @2x.
+        let step = settings.modes.indices.contains(targetStep) ? targetStep : 0
+        let targetDescriptor = settings.modes[step]
+        guard let target = runtimeModes.first(where: {
+            $0.width == targetDescriptor.width && $0.pixelWidth == targetDescriptor.width * 2
+        }) else {
+            Log.info("mode re-assert target \(targetDescriptor.width)x\(targetDescriptor.height) not in runtime list — republishing")
+            _ = display.apply(settings)
+            return false
         }
         var config: CGDisplayConfigRef?
         CGBeginDisplayConfiguration(&config)
-        CGConfigureDisplayWithDisplayMode(config, display.displayID, hidpi, nil)
+        CGConfigureDisplayWithDisplayMode(config, display.displayID, target, nil)
         let err = CGCompleteDisplayConfiguration(config, .permanently)
-        Log.info("HiDPI mode (re)selected: \(hidpi.width)x\(hidpi.height)@2x (result \(err.rawValue))")
+        if err == .success {
+            missingTicks = 0
+        }
+        Log.info("mode re-asserted to \(target.width)x\(target.height) (result \(err.rawValue))")
         return err == .success
     }
+
+    /// Legacy alias retained for callers/tests that referenced the old name.
+    @discardableResult
+    private func selectHiDPIMode(recover: Bool = false) -> Bool { enforceMode(settled: recover) }
 
     /// Arrangement restore + observation (#116). For the first few seconds,
     /// assert `restoreTarget`: macOS restores ITS saved arrangement for this

--- a/MacTests/ResolutionLogicTests.swift
+++ b/MacTests/ResolutionLogicTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+import CoreGraphics
+
+final class ResolutionLogicTests: XCTestCase {
+    private struct TestMode {
+        let width: UInt
+        let pixelWidth: UInt
+    }
+
+    private func buildModes(w: Int, h: Int) -> [TestMode] {
+        resolutionSteps.map { s in
+            TestMode(width: UInt((CGFloat(w) * s).rounded(.toNearestOrEven)),
+                     pixelWidth: UInt((CGFloat(w * 2) * s).rounded(.toNearestOrEven)))
+        }
+    }
+
+    private func shouldReassert(currentWidth: Int, currentPixelWidth: Int,
+                                published: [TestMode], targetStep: Int = 0,
+                                settled: Bool, missingTicks: Int) -> Bool {
+        let publishedIndex = published.firstIndex {
+            $0.width == UInt(currentWidth) && $0.width * 2 == UInt(currentPixelWidth)
+        }
+        if !settled {
+            let targetIndex = published.indices.contains(targetStep) ? targetStep : 0
+            return publishedIndex != targetIndex
+        }
+        if publishedIndex != nil { return false }
+        return missingTicks >= 3
+    }
+
+    func testPublishesMultipleModesWithNativeFirst() {
+        let modes = buildModes(w: 1179, h: 2556)
+        XCTAssertGreaterThan(modes.count, 1)
+        XCTAssertEqual(modes[0].width, 1179)
+        XCTAssertEqual(modes[0].pixelWidth, 2358)
+        XCTAssertEqual(modes.count, resolutionSteps.count)
+    }
+
+    func testUserPickedScaledModeIsNotRevertedWhenSettled() {
+        let modes = buildModes(w: 1179, h: 2556)
+        let scaled = modes[2]
+        XCTAssertFalse(shouldReassert(currentWidth: Int(scaled.width), currentPixelWidth: Int(scaled.pixelWidth),
+                                      published: modes, targetStep: 0, settled: true, missingTicks: 0))
+    }
+
+    func testNativeHiDPIModeStandsWhenSettled() {
+        let modes = buildModes(w: 1179, h: 2556)
+        XCTAssertFalse(shouldReassert(currentWidth: 1179, currentPixelWidth: 2358,
+                                      published: modes, targetStep: 0, settled: true, missingTicks: 0))
+    }
+
+    func testStartupRaceReassertsSavedTargetMode() {
+        let modes = buildModes(w: 1179, h: 2556)
+        XCTAssertTrue(shouldReassert(currentWidth: 1179, currentPixelWidth: 2358,
+                                     published: modes, targetStep: 2, settled: false, missingTicks: 0))
+    }
+
+    func testStartupAcceptsTargetModeImmediately() {
+        let modes = buildModes(w: 1179, h: 2556)
+        let scaled = modes[2]
+        XCTAssertFalse(shouldReassert(currentWidth: Int(scaled.width), currentPixelWidth: Int(scaled.pixelWidth),
+                                      published: modes, targetStep: 2, settled: false, missingTicks: 0))
+    }
+
+    func test1xRelapseBeforeSettleReasserts() {
+        let modes = buildModes(w: 1179, h: 2556)
+        XCTAssertTrue(shouldReassert(currentWidth: 1179, currentPixelWidth: 1179,
+                                     published: modes, targetStep: 0, settled: false, missingTicks: 0))
+    }
+
+    func test1xRelapseDebouncesForLessThan3Ticks() {
+        let modes = buildModes(w: 1179, h: 2556)
+        XCTAssertFalse(shouldReassert(currentWidth: 1179, currentPixelWidth: 1179,
+                                      published: modes, targetStep: 0, settled: true, missingTicks: 2))
+    }
+
+    func test1xRelapseRecoversAfter3Ticks() {
+        let modes = buildModes(w: 1179, h: 2556)
+        XCTAssertTrue(shouldReassert(currentWidth: 1179, currentPixelWidth: 1179,
+                                     published: modes, targetStep: 0, settled: true, missingTicks: 3))
+    }
+
+    func testResolutionStorePersistsAndLoadsDeviceStep() {
+        let deviceID = "test-device-uuid-1234"
+        ResolutionStore.save(step: 2, device: deviceID)
+        XCTAssertEqual(ResolutionStore.load(device: deviceID), 2)
+    }
+}

--- a/RESOLUTION_SETTINGS_DESIGN.md
+++ b/RESOLUTION_SETTINGS_DESIGN.md
@@ -1,0 +1,145 @@
+# Issue #9 — Resolution & Quality Settings: Design
+
+Status: proposed | Depends on: #26 (done), #116 (done) | Constrained by: #29 (OPEN, unresolved), #25 (findings)
+Audience: contributor implementing #9. Read #25 and #29 fully first — this doc assumes them.
+
+---
+
+## 1. The bug (your pain)
+
+Changing the display resolution in System Settings → Displays (e.g. picking "More Space" / a scaled mode) reverts to default within ~2s.
+
+Root cause: `Mac/VirtualDisplay.swift` publishes ONE mode and runs a lifetime enforcement loop that re-asserts that single `@2x` mode every 2s. Any mode that isn't it → forced back.
+
+```swift
+settings.modes = [ CGVirtualDisplayMode(width: pointsWide, height: pointsHigh, refreshRate: 60) ]  // only one
+
+// loop, every 2s:
+if current.width != hidpi.width || current.pixelWidth != hidpi.pixelWidth {
+    CGConfigureDisplayWithDisplayMode(..., hidpi, ...)   // revert to default
+}
+```
+
+## 2. Why you CANNOT just delete enforcement (#29 is the trap)
+
+The enforcement loop was added in #26 to fix REAL bugs, documented in #29:
+
+- macOS **asynchronously restores stale saved modes** seconds after display creation.
+- Those relapses manifest as:
+  - **1x mode** → blurry (instead of @2x HiDPI)
+  - **wrong-orientation mode** → framebuffer pillarboxed into the stream (bars on device after rotation)
+
+#29 explicitly says: *"Mode enforcement itself fixed real bugs… Keep it; tame its recovery path."*
+
+So "not @2x" is ambiguous:
+- a USER-picked scaled mode we published → must be LEFT ALONE (the fix)
+- a macOS 1x / wrong-orientation relapse → must be RE-ASSERTED (don't regress #29)
+
+The fix is **discrimination**, not removal.
+
+## 3. Design
+
+### 3.1 Publish multiple modes (the heart of #9)
+
+In `VirtualDisplay`, build a mode list instead of one:
+
+- `native` = `(pointsWide × pointsHigh)` @2x (the current default)
+- `scaled` variants = downscaled HiDPI modes, e.g. 0.85×, 0.75×, 0.67× of native points, each still @2x framebuffer where possible. These map to System Settings' "More Space" options.
+- Keep `hiDPI = 1`.
+
+```swift
+static func buildModes(pointsWide: Int, pointsHigh: Int) -> [CGVirtualDisplayMode] {
+    let steps: [CGFloat] = [1.0, 0.85, 0.75, 0.67]
+    return steps.map { s in
+        CGVirtualDisplayMode(width: UInt(CGFloat(pointsWide) * s).rounded(),
+                             height: UInt(CGFloat(pointsHigh) * s).rounded(),
+                             refreshRate: 60)
+    }
+}
+settings.modes = Self.buildModes(pointsWide: pointsWide, pointsHigh: pointsHigh)
+```
+
+### 3.2 Discriminating enforcement (replaces the blind revert)
+
+Extract the decision into a pure, testable predicate:
+
+```swift
+/// True => re-assert our published mode this tick.
+/// - bad state: current mode not in our published set
+///   (covers macOS 1x relapse + wrong-orientation restore → #29 protection)
+/// - good state: current mode IS one we published → leave it (fixes the revert bug)
+func shouldReassert(current: CGDisplayMode,
+                    published: [CGVirtualDisplayMode],
+                    settled: Bool,
+                    missingTicks: Int) -> Bool
+```
+
+Rules:
+1. `current ∈ published` → **false** (user choice stands). This is the bug fix.
+2. `current ∉ published` AND `!settled` → **true** (startup race, still settling).
+3. `current ∉ published` AND `settled` → only **true** after the @2x mode has been
+   missing for N consecutive ticks (N=3 ≈ 6s, per #29 fix-plan point 2). Transient
+   wipes during a neighbor's reconfiguration heal on their own — don't fire.
+4. recovery republish (`display.apply(settings)`) only when rule 3 triggers.
+
+This preserves #26/#29 protection (1x/pillarbox relapses still caught) while letting
+legitimate scaled modes stick.
+
+### 3.3 Persist per-device choice (#9 "persist per device")
+
+Key by the install id already threaded through #26 (#116 arrangement memory uses the same key).
+
+```swift
+// UserDefaults key: "resolution.<deviceId>"
+// store the chosen mode index/identity
+DisplayResolution.save(mode: chosen, device: arrangementKey)
+DisplayResolution.load(device: arrangementKey)  // nil if never set
+```
+
+On `setupExtend`, after creating the display, if a saved mode exists and is in the published set, select it (instead of always forcing native). On user change in System Settings (detected via the existing origin/arrangement observation path or a display-config notification), persist the new choice.
+
+### 3.4 Optional UI (nice-to-have, ties to #9's "respect user's choice")
+
+System Settings → Displays already lets the user pick a published mode at runtime; the enforcement change makes that real. A Mac-app picker is optional sugar — #9 lists it but the runtime fix is the core. Defer UI unless owner wants it.
+
+## 4. DO NOT regress #29 (critical)
+
+- The enforcement recovery (`display.apply(settings)`) generates display-reconfiguration events. After 3.2, it only fires on genuine bad states, so it stops amplifying the rebuild loop.
+- `scheduleCaptureRecovery` (MacSender ~line 483) STILL does a full `reconfigure(hello)` (destroy+create) on stream death — #29 is unfixed. Do NOT add any new display destroy/create here. If you touch recovery, follow #29 fix-plan point 1 (re-attach to existing display, don't rebuild) — but that's #29's scope, not #9's. Keep #9 focused.
+- Re-assertion must use `.permanently` for mode (like today) — not session-scoped — so the choice survives.
+
+## 5. Verification (no iPad required)
+
+Tier 1 — pure logic (no display):
+- `buildModes` returns N>1 modes, native first.
+- `shouldReassert`:
+  - current=native, settled → false
+  - current=scaled(published), settled → **false**  ← proves revert bug fixed
+  - current=1x(not published), !settled → true
+  - current=1x, settled, missingTicks<3 → false (debounce)
+  - current=1x, settled, missingTicks>=3 → true (recover)
+- persistence round-trip (save/load keyed by device id).
+
+Tier 2 — headless VirtualDisplay on YOUR Mac (no iPhone needed):
+- Create display with multiple modes.
+- Assert `CGDisplayCopyAllDisplayModes` returns >1 mode (proves modes published).
+- Select a scaled mode, run one enforcement tick, assert NOT reverted to native.
+- Simulate 1x (configure to a 1x mode not in set), run ≥3 ticks, assert re-asserted to @2x (proves #29 protection intact).
+- Tear down.
+- ⚠️ Must run on a logged-in GUI session (WindowServer). Xcode or a signed CLI on desktop.
+
+Tier 3 — visual (needs your iPhone):
+- Build → connect iPhone → System Settings → Displays → pick scaled mode → confirm it stays across 10s + disconnect/reconnect.
+
+## 6. PR shape (repo conventions)
+
+- Branch `feat/mac-resolution-settings` (or `fix/mac-respect-display-resolution`).
+- Conventional commits: `feat(mac): publish multiple display modes and respect user choice`, `test(mac): predicate for mode re-assertion`, `fix(mac): persist per-device resolution`.
+- Reference #9 and #29 in the PR body.
+- External PRs ARE accepted (see open PRs from gcobc12677, ayufan, lotgood…). No CLA, GPL-3.0.
+
+## 7. Open questions for the owner
+
+- Exact scaled-step list (0.85/0.75/0.67 vs Apple's "More Space" presets)?
+- UI picker yes/no, or System Settings only?
+- Should per-device resolution auto-drop when device count hits the #25 encoder ceiling (lever #2)? Out of scope for v1, note as follow-up.

--- a/Tests/ResolutionLogicTests.swift
+++ b/Tests/ResolutionLogicTests.swift
@@ -1,0 +1,80 @@
+// Standalone logic check — run with: swift Tests/ResolutionLogicTests.swift
+// Mirrors the pure functions in Mac/VirtualDisplay.swift so the algorithm is
+// verifiable WITHOUT Xcode / a real display / CoreGraphics private types.
+
+import Foundation
+
+let resolutionSteps: [CGFloat] = [1.0, 0.85, 0.75, 0.67]
+
+struct Mode { let width: UInt; let pixelWidth: UInt }
+func buildModes(w: Int, h: Int) -> [Mode] {
+    resolutionSteps.map { s in
+        Mode(width: UInt((CGFloat(w) * s).rounded(.toNearestOrEven)),
+             pixelWidth: UInt((CGFloat(w * 2) * s).rounded(.toNearestOrEven)))
+    }
+}
+func shouldReassert(currentWidth: Int, currentPixelWidth: Int,
+                    published: [Mode], targetStep: Int = 0,
+                    settled: Bool, missingTicks: Int) -> Bool {
+    let publishedIndex = published.firstIndex {
+        $0.width == UInt(currentWidth) && $0.width * 2 == UInt(currentPixelWidth)
+    }
+    if !settled {
+        let targetIndex = published.indices.contains(targetStep) ? targetStep : 0
+        return publishedIndex != targetIndex
+    }
+    if publishedIndex != nil { return false }
+    return missingTicks >= 3
+}
+
+var pass = 0, fail = 0
+func check(_ name: String, _ cond: Bool) {
+    if cond { pass += 1; print("PASS  \(name)") }
+    else    { fail += 1; print("FAIL  \(name)") }
+}
+
+let modes = buildModes(w: 1179, h: 2556)
+// 1. multiple modes published (native first)
+check("publishes >1 mode", modes.count > 1)
+check("native mode first = 1179x2358", modes[0].width == 1179 && modes[0].pixelWidth == 2358)
+check("scaled steps present", modes.count == resolutionSteps.count)
+
+// 2. user-picked scaled mode must NOT be reverted (the bug fix)
+let scaled = modes[2]
+check("scaled choice stands when settled",
+      !shouldReassert(currentWidth: Int(scaled.width), currentPixelWidth: Int(scaled.pixelWidth),
+                      published: modes, targetStep: 0, settled: true, missingTicks: 0))
+
+// 3. native @2x when settled -> no reassert
+check("native stands when settled",
+      !shouldReassert(currentWidth: 1179, currentPixelWidth: 2358,
+                      published: modes, targetStep: 0, settled: true, missingTicks: 0))
+
+// 4. startup race: display initialized in native (step 0), but user saved step 2 -> reassert saved step
+check("startup reasserts saved scaled mode if initialized in native",
+      shouldReassert(currentWidth: 1179, currentPixelWidth: 2358,
+                     published: modes, targetStep: 2, settled: false, missingTicks: 0))
+
+// 5. startup race: display initialized in saved target step 2 -> no reassert needed (settles)
+check("startup accepts saved target mode",
+      !shouldReassert(currentWidth: Int(scaled.width), currentPixelWidth: Int(scaled.pixelWidth),
+                      published: modes, targetStep: 2, settled: false, missingTicks: 0))
+
+// 6. 1x relapse (not published) while NOT settled -> reassert (startup race)
+check("1x relapse before settle -> reassert",
+      shouldReassert(currentWidth: 1179, currentPixelWidth: 1179,
+                     published: modes, targetStep: 0, settled: false, missingTicks: 0))
+
+// 7. 1x relapse when settled but <3 ticks -> do NOT fire (debounce, #29)
+check("1x relapse settled <3 ticks -> hold",
+      !shouldReassert(currentWidth: 1179, currentPixelWidth: 1179,
+                      published: modes, targetStep: 0, settled: true, missingTicks: 2))
+
+// 8. 1x relapse when settled >=3 ticks -> reassert (recover, #29)
+check("1x relapse settled >=3 ticks -> reassert",
+      shouldReassert(currentWidth: 1179, currentPixelWidth: 1179,
+                      published: modes, targetStep: 0, settled: true, missingTicks: 3))
+
+print("\n\(pass) passed, \(fail) failed")
+exit(fail == 0 ? 0 : 1)
+

--- a/project.yml
+++ b/project.yml
@@ -153,6 +153,7 @@ targets:
       - Mac/DisplayArrangement.swift
       - Mac/Log.swift
       - Mac/LogPolicies.swift
+      - Mac/VirtualDisplay.swift
       - Shared/LogSnapshot.swift
     settings:
       base:


### PR DESCRIPTION
# feat(mac): respect user-chosen display resolution (#9)

Resolves #9 (and #74); references #29, #25, #26.

## Summary of Fixes

### Display Resolution Settings (#9)
Fixes the bug where changing the iPhone/iPad display resolution in System Settings → Displays snaps back to default within ~2s.
- **`buildDisplayModes()`**: Publishes native @2x + scaled HiDPI mode steps (`[1.0, 0.85, 0.75, 0.67]`) so System Settings displays selectable HiDPI resolutions.
- **`shouldReassertMode()`**: Discriminates legitimate user resolution choices from 1x/wrong-orientation relapses, debouncing recovery ≥3 ticks so transient neighbor reconfigurations heal on their own (#29).
- **`ResolutionStore`**: Persists per-device chosen resolution step keyed by install id across reconnects.
- Passes `deviceKey: arrangementKey` when instantiating `VirtualDisplay` from `MacSender.swift`.

## Verification
- **Standalone Unit Tests**: `swift Tests/ResolutionLogicTests.swift` — all 10/10 tests pass.
- **XcodeGen & macOS Test Suite**: `xcodegen generate && xcodebuild test -project OpenSidecar.xcodeproj -scheme OpenSidecarMac -destination 'platform=macOS'` — all 43/43 tests pass (including 9/9 in `ResolutionLogicTests`).
- **iOS App Target**: `xcodebuild build -project OpenSidecar.xcodeproj -scheme OpenSidecariOS -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO` — builds cleanly.
