### PR TITLE
fix(mac): re-attach capture on stream death instead of full display rebuild (#29)

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -479,11 +479,42 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         scheduleCaptureRecovery()
     }
 
-    /// Retry until capture is back (a rebuild during display sleep can fail).
+    /// Retry until capture is back. Per issue #29 fix-plan point 1: a dead
+    /// stream does NOT mean the display is gone. If our own virtual display
+    /// still exists, just re-attach the capture to it — rebuilding the display
+    /// (destroy+create) is what killed the NEIGHBOR's stream and ping-ponged
+    /// the infinite rebuild loop. Only do a full `reconfigure` when the display
+    /// is actually gone (e.g. display sleep tore it down).
     private func scheduleCaptureRecovery() {
         queue.asyncAfter(deadline: .now() + 3.0) { [weak self] in
             guard let self, !self.stopped, self.stream == nil,
                   let hello = self.lastHello else { return }
+            // Does our virtual display still exist? CGDisplayBounds returns a
+            // zero rect for an unknown id, so a non-zero bounds means it's live.
+            if let vd = self.virtualDisplay,
+               !CGDisplayBounds(vd.displayID).isNull {
+                Log.info("capture died — display still present, re-attaching capture only (#29)")
+                Task {
+                    do {
+                        let display = try await self.findSCDisplay(id: vd.displayID)
+                        // Capture at the display's pixel resolution (points ×2 @2x),
+                        // not SCDisplay.width (logical points) — matches setupExtend.
+                        let captureW = (Int(Double(vd.pointsWide * 2) * self.quality.scale)) & ~1
+                        let captureH = (Int(Double(vd.pointsHigh * 2) * self.quality.scale)) & ~1
+                        try await self.startCapture(display: display,
+                                                    pixelsWide: captureW, pixelsHigh: captureH)
+                        self.needsKeyframe = true
+                    } catch {
+                        Log.info("re-attach failed (\(error)) — falling back to full rebuild")
+                        await self.reconfigure(hello)
+                    }
+                    self.queue.async {
+                        if self.stream == nil { self.scheduleCaptureRecovery() }
+                    }
+                }
+                return
+            }
+            // Display genuinely gone — full rebuild (preserves old behavior).
             Log.info("capture died — rebuilding pipeline")
             Task {
                 await self.reconfigure(hello)

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -490,9 +490,12 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             guard let self, !self.stopped, self.stream == nil,
                   let hello = self.lastHello else { return }
             // Does our virtual display still exist? CGDisplayBounds returns a
-            // zero rect for an unknown id, so a non-zero bounds means it's live.
+            // zero rect for an unknown id, so a non-empty bounds means it's live.
+            // Test isEmpty, not isNull: isNull is only true for the special
+            // CGRect.null, so it reads as "live" for a dead display too and the
+            // rebuild fallback below would become unreachable.
             if let vd = self.virtualDisplay,
-               !CGDisplayBounds(vd.displayID).isNull {
+               !CGDisplayBounds(vd.displayID).isEmpty {
                 Log.info("capture died — display still present, re-attaching capture only (#29)")
                 Task {
                     do {


### PR DESCRIPTION
# fix(mac): re-attach capture on stream death instead of full display rebuild (#29)

Addresses issue #29 (rotation infinite rebuild loop) — fix-plan point 1.

## Root cause
`scheduleCaptureRecovery` responded to a dead `SCStream` with a **full
display destroy+create** (`reconfigure`). With ≥2 devices that rebuild kills
the *neighbor's* stream (OS side effect), whose recovery rebuilds *its*
display, killing the first — an endless ~3s ping-pong. Observed live
2026-06-11 (iPhone USB + iPad USB).

## Fix
A dead stream does NOT mean the display is gone. If our own virtual display
still exists, re-attach the capture to it (no destroy/create) — this alone
breaks the loop. Full `reconfigure` is now only the fallback when the display
is genuinely gone (e.g. display sleep tore it down).

- `scheduleCaptureRecovery`: check `CGDisplayBounds(vd.displayID)`; if live,
  `findSCDisplay` + `startCapture` at pixel res (`points*2 @2x`, matching
  `setupExtend`); on failure fall back to full rebuild.
- #9's `missingTicks` debounce already implements #29 point 2 (enforcement
  recovery no longer amplifies the loop).

## Not in this PR (follow-ups)
- #29 point 3 (serialize rebuilds across sessions with a shared lock) — needs
  a 2-device repro to validate; left separate to keep this PR minimal.
- Point 2's debounce lives in the #9 change.

## Verification
- Logic: the re-attach path is guarded by a non-null display bounds check.
- **Requires 2 devices (iPhone + iPad) to reproduce/verify the loop** — not
  runnable on a single device. Manual: 2 connected, rotate one then the other
  within ~10s, watch `/tmp/opensidecar-mac.log` for alternating
  `reconfiguring` / `-3815` / `capture died` (should be absent after fix).

References #29, #9, #26.
