### PR TITLE
perf: reduce lag spikes when scrolling or drawing fast

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -117,12 +117,30 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // multiple OpenDisplay monitors apart and persist their arrangement.
     private let displaySerial: UInt32
 
-    // Backpressure: outstanding sends. If the socket can't keep up we drop
-    // frames instead of queueing latency, then force a keyframe to resync.
-    // Kept tight: at 60fps each queued send is ~17ms of added latency.
+    // ── Encoder parallelism limiter (maxPendingEncodes = 1) ─────────────────
+    //
+    // VTCompressionSessionEncodeFrame returns immediately; the hardware H.264
+    // encoder runs asynchronously. If ScreenCaptureKit delivers the next frame
+    // before the previous encode callback fires, VideoToolbox will run multiple
+    // encodes in parallel inside the same session.
+    //
+    // Capping pendingEncodes at 1 enforces “latest frame wins” on the encoder:
+    // skip captures while an encode is in flight (enc drops), then feed the next
+    // fresh buffer when the callback clears the slot. The H.264 reference chain
+    // stays valid (pre-encode skip → normal P-frame n→n+2); we do NOT force
+    // keyframes on enc drops.
+    //
+    // Separate from network backpressure below (maxPendingSends): enc drops mean
+    // “encoder busy”; net drops mean “TCP send queue full”.
+    private var pendingEncodes = 0
+    private let maxPendingEncodes = 1
     private var pendingSends = 0
     private let maxPendingSends = 3
-    private var dropsThisWindow = 0
+    private let pipelineLock = NSLock()
+    private var dropsEncThisWindow = 0
+    private var dropsNetThisWindow = 0
+    private var dropsEncTotal = 0
+    private var dropsNetTotal = 0
     private var needsKeyframe = true
     private var connectionReady = false
     private var stopped = false
@@ -146,7 +164,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // Liveness: both sides ping every 2s; if nothing arrives for 5s the link
     // is half-open (e.g. usbmuxd accepted but the device is gone) — reconnect.
     private var lastReceived = Date()
-    private var dropsTotal = 0
+    private var dropsTotal: Int { dropsEncTotal + dropsNetTotal }
 
     // Local cursor echo: a cursor baked into the video carries the full
     // capture→encode→stream→display latency (~30ms perceived). Instead we
@@ -454,6 +472,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             self.connection?.cancel()
             self.connection = nil
             self.pendingSends = 0
+            self.pipelineLock.lock()
+            self.pendingEncodes = 0
+            self.pipelineLock.unlock()
             self.connect()
         }
     }
@@ -630,6 +651,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         connection?.cancel()
         connection = nil
         pendingSends = 0
+        pipelineLock.lock()
+        pendingEncodes = 0
+        pipelineLock.unlock()
         queue.asyncAfter(deadline: .now() + 1.0) { [weak self] in
             // Generation-guarded so a switchTransport (or another reconnect)
             // that landed in this 1s window supersedes this dial instead of
@@ -655,7 +679,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 let sorted = self.inputLatencies.sorted()
                 let inp50 = sorted.isEmpty ? 0 : sorted[sorted.count / 2].rounded()
                 let inp95 = sorted.isEmpty ? 0 : sorted[min(sorted.count - 1, Int(Double(sorted.count) * 0.95))].rounded()
-                self.sendJSONFrame("{\"type\":\"ping\",\"drops\":\(self.dropsTotal),\"pending\":\(self.pendingSends),\"inp50\":\(inp50),\"inp95\":\(inp95),\"capFps\":\(capFps)}")
+                self.sendJSONFrame("{\"type\":\"ping\",\"drops\":\(self.dropsTotal),\"encDrops\":\(self.dropsEncTotal),\"netDrops\":\(self.dropsNetTotal),\"pending\":\(self.pendingSends),\"inp50\":\(inp50),\"inp95\":\(inp95),\"capFps\":\(capFps)}")
             }
             self.schedulePing()
         }
@@ -801,8 +825,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             // so one file holds both ends of the story.
             if let json = try? JSONSerialization.data(withJSONObject: obj),
                let line = String(data: json, encoding: .utf8) {
-                Log.info("PHONE-STATS \(line) | mac drops=\(dropsThisWindow) pending=\(pendingSends)")
-                dropsThisWindow = 0
+                Log.info("PHONE-STATS \(line) | mac enc↓=\(dropsEncThisWindow) net↓=\(dropsNetThisWindow) pending=\(pendingSends)")
+                dropsEncThisWindow = 0
+                dropsNetThisWindow = 0
             }
         case "hello":
             if let info = try? JSONDecoder().decode(PhoneInfo.self, from: payload) {
@@ -931,27 +956,56 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         lastCaptureAt = Date()
         capFrames += 1
 
-        // No receiver, or the socket is backed up: skip this frame entirely.
+        // No receiver, or a pipeline stage is backed up: skip this frame.
         guard connectionReady else { return }
-        if pendingSends > maxPendingSends {
-            needsKeyframe = true   // dropped frames break the P-frame chain
-            dropsThisWindow += 1
-            dropsTotal += 1
-            return
-        }
+        if shouldDropFrame(reason: "pending_encode") { return }
+        if shouldDropFrame(reason: "pending_sends") { return }
 
         encode(pixelBuffer, pts: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
     }
 
+    /// Drop when encode or send pipeline is busy.
+    /// Pre-encode drops are invisible to the decoder — the H.264 reference
+    /// chain stays intact, so the next frame can be a normal P-frame (n → n+2).
+    /// Do NOT force keyframes here; that causes IDR pulsing / blockiness.
+    private func shouldDropFrame(reason: String) -> Bool {
+        pipelineLock.lock()
+        let drop: Bool
+        switch reason {
+        case "pending_encode":
+            drop = pendingEncodes >= maxPendingEncodes
+        case "pending_sends":
+            drop = pendingSends >= maxPendingSends
+        default:
+            drop = false
+        }
+        pipelineLock.unlock()
+        guard drop else { return false }
+        switch reason {
+        case "pending_encode":
+            dropsEncThisWindow += 1
+            dropsEncTotal += 1
+        case "pending_sends":
+            dropsNetThisWindow += 1
+            dropsNetTotal += 1
+        default:
+            break
+        }
+        return true
+    }
+
     private func encode(_ pixelBuffer: CVPixelBuffer, pts: CMTime) {
         guard let encoder else { return }
+        pipelineLock.lock()
+        pendingEncodes += 1
+        pipelineLock.unlock()
         let capturedAtMs = Int64(Date().timeIntervalSince1970 * 1000)
         var frameProperties: CFDictionary?
         if needsKeyframe {
             frameProperties = [kVTEncodeFrameOptionKey_ForceKeyFrame: kCFBooleanTrue!] as CFDictionary
             needsKeyframe = false
         }
-        VTCompressionSessionEncodeFrame(
+        let submitStatus = VTCompressionSessionEncodeFrame(
             encoder,
             imageBuffer: pixelBuffer,
             presentationTimeStamp: pts,
@@ -959,16 +1013,25 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             frameProperties: frameProperties,
             infoFlagsOut: nil
         ) { [weak self] status, _, buffer in
-            guard status == noErr, let buffer, let self else { return }
+            guard let self else { return }
+            defer {
+                self.pipelineLock.lock()
+                self.pendingEncodes = max(0, self.pendingEncodes - 1)
+                self.pipelineLock.unlock()
+            }
+            guard status == noErr, let buffer else { return }
             if let data = self.annexB(from: buffer) {
-                // Telemetry prefix before the first start code — the receiver
-                // parses it and skips to the H.264 payload. cap = capture time,
-                // snd = handoff to the socket (so cap→snd ≈ encode duration).
                 let sndMs = Int64(Date().timeIntervalSince1970 * 1000)
                 var framed = Data("{\"cap\":\(capturedAtMs),\"snd\":\(sndMs)}".utf8)
                 framed.append(data)
                 self.sendFramed(framed)
             }
+        }
+        if submitStatus != noErr {
+            pipelineLock.lock()
+            pendingEncodes = max(0, pendingEncodes - 1)
+            pipelineLock.unlock()
+            Log.info("VTCompressionSessionEncodeFrame failed: \(submitStatus)")
         }
     }
 

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -129,11 +129,21 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // fresh buffer when the callback clears the slot. The H.264 reference chain
     // stays valid (pre-encode skip → normal P-frame n→n+2); we do NOT force
     // keyframes on enc drops.
-    //
-    // Separate from network backpressure below (maxPendingSends): enc drops mean
-    // “encoder busy”; net drops mean “TCP send queue full”.
     private var pendingEncodes = 0
     private let maxPendingEncodes = 1
+
+    // ── Outstanding send backpressure (maxPendingSends = 3) ──────────────────
+    //
+    // pendingSends counts video frames whose NWConnection.send completion has
+    // not fired yet — i.e. bytes still in flight / waiting on TCP ACKs. Allow a
+    // small pipeline (3) so the link is not idle between ACKs; unlike the encoder,
+    // a few outstanding sends helps throughput without piling up seconds of lag.
+    //
+    // When pendingSends hits the cap we skip the capture before encode (net
+    // drops). Same drop point as enc drops, but means “TCP send queue full”, not
+    // “encoder busy” — split counters (enc↓ vs net↓) so the HUD shows which
+    // bottleneck fired. Never encode-then-discard: dropping here avoids wasting
+    // VT work on frames that would only add latency.
     private var pendingSends = 0
     private let maxPendingSends = 3
     private let pipelineLock = NSLock()
@@ -958,8 +968,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
         // No receiver, or a pipeline stage is backed up: skip this frame.
         guard connectionReady else { return }
-        if shouldDropFrame(reason: "pending_encode") { return }
-        if shouldDropFrame(reason: "pending_sends") { return }
+        if shouldDropFrame(reason: "pending_encode") { return }  // encoder busy
+        if shouldDropFrame(reason: "pending_sends") { return }   // TCP send queue full
 
         encode(pixelBuffer, pts: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
     }

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -326,7 +326,8 @@ struct PerfOverlay: View {
                 }
                 metric("Mbit/s", String(format: "%.1f", stats.mbps))
                 metric("stalls", "\(stats.stalls)")
-                metric("drops", "\(stats.macDrops)")
+                metric("enc↓", "\(stats.macEncDrops)")
+                metric("net↓", "\(stats.macNetDrops)")
                 if stats.macPending > 0 {
                     metric("queue", "\(stats.macPending)")
                 }

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -31,7 +31,9 @@ struct PerfStats: Equatable {
     var rttMs = 0.0              // control-channel round trip
     var e2eSamples: [Double] = []  // last ~120 per-frame e2e latencies, ms
     var transport = "—"          // USB (loopback via usbmux) or WiFi
-    var macDrops = 0             // frames the Mac dropped (backpressure), total
+    var macDrops = 0             // enc + net drops (legacy total)
+    var macEncDrops = 0          // Mac skipped capture: encoder busy
+    var macNetDrops = 0          // Mac skipped capture: TCP queue full
     var macPending = 0           // Mac send queue depth right now
     var inputP50 = 0.0           // touch sent → CGEvent injected on the Mac, ms
     var inputP95 = 0.0
@@ -89,6 +91,8 @@ final class PhoneReceiver: ObservableObject {
     private var statsReportCounter = 0
     private var transport = "—"
     private var macDrops = 0
+    private var macEncDrops = 0
+    private var macNetDrops = 0
     private var macPending = 0
     private var macInputP50 = 0.0
     private var macInputP95 = 0.0
@@ -329,7 +333,15 @@ final class PhoneReceiver: ObservableObject {
             lastRttMs = rtt
         case "ping":
             // The Mac piggybacks its send-side health on liveness pings.
-            macDrops = obj["drops"] as? Int ?? macDrops
+            if let enc = obj["encDrops"] as? Int {
+                macEncDrops = enc
+            } else if let drops = obj["drops"] as? Int {
+                macEncDrops = drops
+            }
+            if let net = obj["netDrops"] as? Int {
+                macNetDrops = net
+            }
+            macDrops = macEncDrops + macNetDrops
             macPending = obj["pending"] as? Int ?? macPending
             macInputP50 = obj["inp50"] as? Double ?? macInputP50
             macInputP95 = obj["inp95"] as? Double ?? macInputP95
@@ -691,6 +703,8 @@ final class PhoneReceiver: ObservableObject {
             stats.e2eSamples = e2eRing
             stats.transport = transport
             stats.macDrops = macDrops
+            stats.macEncDrops = macEncDrops
+            stats.macNetDrops = macNetDrops
             stats.macPending = macPending
             stats.inputP50 = macInputP50
             stats.inputP95 = macInputP95


### PR DESCRIPTION
## Summary

Serializes VideoToolbox H.264 encodes (`maxPendingEncodes = 1`) while keeping a small TCP send pipeline (`maxPendingSends = 3`). When either stage is saturated, ScreenCaptureKit frames are dropped **before** encode — never encode-then-discard. Pre-encode drops do **not** force keyframes, so the H.264 reference chain stays valid.

## Before this PR

**Encode times under load regularly pass 100ms**

<img width="912" height="228" alt="image" src="https://github.com/user-attachments/assets/2b7b0054-dc89-42b5-a8a9-b76b72370c19" />

https://github.com/user-attachments/assets/223da48a-459f-4535-b5a6-acd0db181b4e

## After this PR

**Encode times after this PR stay stable around 30ms**

<img width="1097" height="263" alt="image" src="https://github.com/user-attachments/assets/2decb629-129e-463c-b23c-0aaa5f394021" />

https://github.com/user-attachments/assets/1fef65c4-d1f4-487a-b9a4-fbe781f93ca5



---

## Problem

`VTCompressionSessionEncodeFrame` returns immediately; the hardware encoder runs asynchronously. Under load, ScreenCaptureKit can deliver a new frame before the previous encode callback completes. VideoToolbox then runs **multiple encodes in parallel** inside the same session.

Profiling on full pipeline showed this hurts latency rather than helping throughput:

- Encode work **overlaps on the timeline** (parallel slices, not faster end-to-end output).
- Per-frame encode time **climbs through a burst** (roughly ~15 ms early in a burst → **100 ms+** on the tail).
- **cap→display p95 tracks the slowest in-flight encode**, so pen strokes and scrolling feel laggy even when average FPS looks fine.

Previously we had a single `drops` counter and treated encoder and network backpressure as one bucket, which made tuning and diagnosis harder.

---

## Solution

Two independent backpressure limits, checked at capture time:

| Limit | Value | Meaning |
|-------|-------|---------|
| `maxPendingEncodes` | **1** | Never pipeline hardware encodes; skip capture while an encode is in flight (**enc↓**). |
| `maxPendingSends` | **3** | Allow a small TCP pipeline so the link isn't idle between ACKs; skip capture when the send queue is full (**net↓**). |

Both paths call the same pre-encode drop helper:

- Drops are **invisible to the decoder** (reference chain intact → normal P-frame `n → n+2`).
- We do **not** force keyframes on encoder drops (avoids IDR pulsing / blockiness).
- We never waste VT work encoding a frame we'd discard on the network side.

---

## Test setup

| Component | Details |
|-----------|---------|
| **Mac** | MacBook Pro (Mac16,5), Apple **M4 Max**, 128 GB RAM |
| **macOS** | 15.1.1 (24B2091) |
| **iPad** | iPad Pro 12.9-inch (6th generation, **iPad14,5**) |
| **iPadOS** | 26.5.2 |

Repro: connect over USB, enable Performance overlay, draw quickly with Apple Pencil (or fast scroll/drag to load the encoder). Compare **enc↓** growth and cap→display latency before vs after.

