### PR TITLE
feat: end the session when the receiver sleeps, reconnect on wake

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -96,6 +96,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // recording indicator all torn down) instead of dialing forever or
     // silently coming back over a different transport.
     @MainActor var onDisconnected: (() -> Void)?
+    // Fired when the receiver announces its screen went dark (lock or app
+    // backgrounded). The controller ends this session — an invisible display
+    // strands the cursor — and starts a fresh one that waits for the wake.
+    @MainActor var onPeerSleeping: (() -> Void)?
     // Fired on every hello — carries the receiver's install id so the
     // controller can deduplicate USB/WiFi sessions to the same device.
     @MainActor var onHello: ((PhoneInfo) -> Void)?
@@ -174,6 +178,12 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // Liveness: both sides ping every 2s; if nothing arrives for 5s the link
     // is half-open (e.g. usbmuxd accepted but the device is gone) — reconnect.
     private var lastReceived = Date()
+
+    // Session created after the receiver went to sleep: it refuses
+    // connections until its screen is back, so dial failures mean "asleep",
+    // not "app closed" — surface that instead of the usual hints. Cleared by
+    // the first successful connection.
+    private var awaitingWake: Bool
     private var dropsTotal: Int { dropsEncTotal + dropsNetTotal }
 
     // Local cursor echo: a cursor baked into the video carries the full
@@ -208,12 +218,14 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private var lastCaptureAt = Date.distantPast
 
     init(transport: SenderTransport, name: String, mode: CaptureMode,
-         quality: StreamQuality = .best, displaySerial: UInt32 = 0x0001) {
+         quality: StreamQuality = .best, displaySerial: UInt32 = 0x0001,
+         awaitingWake: Bool = false) {
         self.transport = transport
         self.endpointName = name
         self.mode = mode
         self.quality = quality
         self.displaySerial = displaySerial
+        self.awaitingWake = awaitingWake
         super.init()
     }
 
@@ -254,7 +266,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
 
         case .extend:
-            await status("Waiting for the device to connect…")
+            await status(awaitingWake
+                ? "\(endpointName) is asleep — reconnects when it wakes…"
+                : "Waiting for the device to connect…")
             let info = try await waitForHello()
             try await setupExtend(info)
 
@@ -544,6 +558,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         Log.info("connection ready to \(endpointName)")
         connectionReady = true
         everConnected = true
+        awaitingWake = false
         disconnectedSince = nil
         needsKeyframe = true   // new peer needs SPS/PPS + IDR
         // A reconnect can recreate the phone's video view with no cursor
@@ -564,6 +579,19 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         let params = NWParameters(tls: nil, tcp: options)
         let conn = NWConnection(to: endpoint, using: params)
         connection = conn
+        // A dial to a withdrawn Bonjour service (receiver asleep or app
+        // closed) sits in .preparing forever — it neither fails nor resolves
+        // when the service later returns, observed on macOS 26. Give every
+        // dial a deadline and redial fresh: a new NWConnection re-runs
+        // Bonjour resolution, so the retry loop reaches the receiver the
+        // moment it advertises again.
+        let generation = dialGeneration
+        queue.asyncAfter(deadline: .now() + 5.0) { [weak self] in
+            guard let self, generation == self.dialGeneration, !self.stopped,
+                  self.connection === conn, conn.state != .ready else { return }
+            Log.info("dial timed out in \(conn.state) — redialing")
+            self.scheduleReconnect()
+        }
         conn.stateUpdateHandler = { [weak self] state in
             guard let self else { return }
             switch state {
@@ -579,7 +607,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 // waiting as failure and poll by reconnecting.
                 Log.info("connection waiting: \(error) — will retry")
                 self.connectionReady = false
-                Task { await self.status("Waiting for receiver at \(self.endpointName)…") }
+                Task { await self.status(self.awaitingWake
+                    ? "\(self.endpointName) is asleep — reconnects when it wakes…"
+                    : "Waiting for receiver at \(self.endpointName)…") }
                 self.scheduleReconnect()
             case .cancelled:
                 self.connectionReady = false
@@ -627,7 +657,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 case .noDevice:
                     hint = "Waiting for a USB device — plug in the iPhone or iPad…"
                 case .refused:
-                    hint = "Device found — open the OpenDisplay app on it…"
+                    hint = self.awaitingWake
+                        ? "\(self.endpointName) is asleep — reconnects when it wakes…"
+                        : "Device found — open the OpenDisplay app on it…"
                 default:
                     Log.info("usb dial failed: \(error)")
                     hint = "USB connection failed: \(error.localizedDescription)"
@@ -702,6 +734,16 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 Log.info("watchdog: nothing from the phone for >5s — reconnecting")
                 Task { await self.status("Connection stale — reconnecting…") }
                 self.scheduleReconnect()
+            }
+            // The disconnect grace is otherwise only evaluated when a dial
+            // changes state — a dial stuck in .preparing (withdrawn Bonjour
+            // service) would keep a dead session's display up forever.
+            // Enforce it from here too, where the clock always ticks.
+            if !self.connectionReady, self.everConnected,
+               let since = self.disconnectedSince,
+               Date().timeIntervalSince(since) > self.disconnectGraceSeconds {
+                Log.info("device gone for >\(Int(self.disconnectGraceSeconds))s — ending session")
+                Task { @MainActor in self.onDisconnected?() }
             }
             // A reconnect on a static screen produces no capture frames, so
             // the receiver would stay black — replay the last frame as IDR.
@@ -893,6 +935,13 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             // periodic keyframes are off) — force an IDR on the next frame.
             Log.info("phone requested keyframe")
             needsKeyframe = true
+        case WireMessage.sleeping:
+            // The device's screen went dark and it is about to close on us.
+            // Hand the session to the controller right away: it tears the
+            // virtual display down (returning the cursor to a visible
+            // screen) and starts a wake-waiting replacement session.
+            Log.info("receiver went to sleep — ending session, reconnect armed for wake")
+            Task { @MainActor in self.onPeerSleeping?() }
         default:
             Log.info("unknown control message type: \(type)")
         }

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -96,10 +96,13 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // recording indicator all torn down) instead of dialing forever or
     // silently coming back over a different transport.
     @MainActor var onDisconnected: (() -> Void)?
-    // Fired when the receiver announces its screen went dark (lock or app
-    // backgrounded). The controller ends this session — an invisible display
-    // strands the cursor — and starts a fresh one that waits for the wake.
+    // Fired when the receiver announces its device locked. The controller
+    // ends this session — an invisible display strands the cursor — and
+    // starts a fresh one that waits for the wake.
     @MainActor var onPeerSleeping: (() -> Void)?
+    // Fired when the receiver announces the app is quitting: deliberate,
+    // so the controller ends the session without arming a reconnect.
+    @MainActor var onPeerClosed: (() -> Void)?
     // Fired on every hello — carries the receiver's install id so the
     // controller can deduplicate USB/WiFi sessions to the same device.
     @MainActor var onHello: ((PhoneInfo) -> Void)?
@@ -731,8 +734,13 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         queue.asyncAfter(deadline: .now() + 2.0) { [weak self] in
             guard let self, !self.stopped else { return }
             if self.connectionReady, Date().timeIntervalSince(self.lastReceived) > 5 {
+                // A suspended receiver app (user switched apps) goes silent
+                // like this while its kernel still accepts redials — the
+                // session and display are kept on purpose so the user's
+                // window arrangement survives until they come back. Genuine
+                // network loss fails the redials and ends via the grace.
                 Log.info("watchdog: nothing from the phone for >5s — reconnecting")
-                Task { await self.status("Connection stale — reconnecting…") }
+                Task { await self.status("\(self.endpointName) app in background — keeping the display") }
                 self.scheduleReconnect()
             }
             // The disconnect grace is otherwise only evaluated when a dial
@@ -936,12 +944,17 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             Log.info("phone requested keyframe")
             needsKeyframe = true
         case WireMessage.sleeping:
-            // The device's screen went dark and it is about to close on us.
-            // Hand the session to the controller right away: it tears the
-            // virtual display down (returning the cursor to a visible
-            // screen) and starts a wake-waiting replacement session.
+            // The device locked and is about to close on us. Hand the
+            // session to the controller right away: it tears the virtual
+            // display down (returning the cursor to a visible screen) and
+            // starts a wake-waiting replacement session.
             Log.info("receiver went to sleep — ending session, reconnect armed for wake")
             Task { @MainActor in self.onPeerSleeping?() }
+        case WireMessage.closing:
+            // The app on the device is quitting for real — end the session
+            // without the silence grace and without waiting for a wake.
+            Log.info("receiver app closed — ending session")
+            Task { @MainActor in self.onPeerClosed?() }
         default:
             Log.info("unknown control message type: \(type)")
         }

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -278,9 +278,14 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
 
         case .extend:
-            await status(awaitingWake
-                ? "\(endpointName) is asleep — reconnects when it wakes…"
-                : "Waiting for the device to connect…")
+            // awaitingWake is queue-confined — read it there before surfacing.
+            queue.async { [weak self] in
+                guard let self else { return }
+                let text = self.awaitingWake
+                    ? "\(self.endpointName) is asleep — reconnects when it wakes…"
+                    : "Waiting for the device to connect…"
+                Task { await self.status(text) }
+            }
             let info = try await waitForHello()
             try await setupExtend(info)
 
@@ -515,15 +520,27 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         }
     }
 
+    // The controller's end() is idempotent, but several detectors (grace,
+    // refusals, service withdrawal) can conclude "gone" repeatedly while the
+    // stop is in flight — report once so the log tells the story once.
+    private var goneReported = false
+
+    /// Declare the device gone and end the session (must be called on `queue`).
+    private func reportGone(_ reason: String) {
+        guard !goneReported, !stopped else { return }
+        goneReported = true
+        Log.info(reason)
+        Task { @MainActor in self.onDisconnected?() }
+    }
+
     /// A dial was actively refused (must be called on `queue`). On a session
     /// that has streamed before, enough refusals in a row prove the receiver
     /// app is gone — end now instead of waiting out the grace.
     private func dialRefused() {
         guard everConnected, !stopped else { return }
         consecutiveRefusals += 1
-        if consecutiveRefusals == refusalsBeforeGivingUp {
-            Log.info("dial refused \(consecutiveRefusals)x — receiver app is gone, ending session")
-            Task { @MainActor in self.onDisconnected?() }
+        if consecutiveRefusals >= refusalsBeforeGivingUp {
+            reportGone("dial refused \(consecutiveRefusals)x — receiver app is gone, ending session")
         }
     }
 
@@ -537,8 +554,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         queue.async { [weak self] in
             guard let self, !self.stopped, self.everConnected,
                   !self.connectionReady else { return }
-            Log.info("service withdrawn and connection down — receiver app is gone, ending session")
-            Task { @MainActor in self.onDisconnected?() }
+            self.reportGone("service withdrawn and connection down — receiver app is gone, ending session")
         }
     }
 
@@ -650,9 +666,12 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 // waiting as failure and poll by reconnecting.
                 Log.info("connection waiting: \(error) — will retry")
                 self.connectionReady = false
-                Task { await self.status(self.awaitingWake
+                // Read the queue-confined flag here (handler runs on queue),
+                // not inside the detached status Task.
+                let text = self.awaitingWake
                     ? "\(self.endpointName) is asleep — reconnects when it wakes…"
-                    : "Waiting for receiver at \(self.endpointName)…") }
+                    : "Waiting for receiver at \(self.endpointName)…"
+                Task { await self.status(text) }
                 self.scheduleReconnect()
             case .cancelled:
                 self.connectionReady = false
@@ -694,23 +713,22 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                     self.becomeReady(conn)
                 }
             } catch {
-                // Distinct guidance per failure: cable missing vs app closed.
-                let hint: String
-                switch error as? Usbmux.Failure {
-                case .noDevice:
-                    hint = "Waiting for a USB device — plug in the iPhone or iPad…"
-                case .refused:
-                    hint = self.awaitingWake
-                        ? "\(self.endpointName) is asleep — reconnects when it wakes…"
-                        : "Device found — open the OpenDisplay app on it…"
-                default:
-                    Log.info("usb dial failed: \(error)")
-                    hint = "USB connection failed: \(error.localizedDescription)"
-                }
                 queue.async {
                     guard generation == self.dialGeneration, !self.stopped else { return }
-                    if case .refused = error as? Usbmux.Failure {
+                    // Distinct guidance per failure: cable missing vs app
+                    // closed. Composed on `queue`: awaitingWake lives there.
+                    let hint: String
+                    switch error as? Usbmux.Failure {
+                    case .noDevice:
+                        hint = "Waiting for a USB device — plug in the iPhone or iPad…"
+                    case .refused:
                         self.dialRefused()
+                        hint = self.awaitingWake
+                            ? "\(self.endpointName) is asleep — reconnects when it wakes…"
+                            : "Device found — open the OpenDisplay app on it…"
+                    default:
+                        Log.info("usb dial failed: \(error)")
+                        hint = "USB connection failed: \(error.localizedDescription)"
                     }
                     Task { await self.status(hint) }
                     self.scheduleReconnect()
@@ -724,8 +742,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         if everConnected {
             if let since = disconnectedSince {
                 if Date().timeIntervalSince(since) > disconnectGraceSeconds {
-                    Log.info("device gone for >\(Int(disconnectGraceSeconds))s — ending session")
-                    Task { @MainActor in self.onDisconnected?() }
+                    reportGone("device gone for >\(Int(disconnectGraceSeconds))s — ending session")
                     return
                 }
             } else {
@@ -783,7 +800,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 // window arrangement survives until they come back. Genuine
                 // network loss fails the redials and ends via the grace.
                 Log.info("watchdog: nothing from the phone for >5s — reconnecting")
-                Task { await self.status("\(self.endpointName) app in background — keeping the display") }
+                // Can't tell a backgrounded receiver from a brief stall here
+                // (both go silent while redials still succeed) — hedge.
+                Task { await self.status("\(self.endpointName) is silent — keeping the display (app in background or brief stall)") }
                 self.scheduleReconnect()
             }
             // The disconnect grace is otherwise only evaluated when a dial
@@ -793,8 +812,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             if !self.connectionReady, self.everConnected,
                let since = self.disconnectedSince,
                Date().timeIntervalSince(since) > self.disconnectGraceSeconds {
-                Log.info("device gone for >\(Int(self.disconnectGraceSeconds))s — ending session")
-                Task { @MainActor in self.onDisconnected?() }
+                self.reportGone("device gone for >\(Int(self.disconnectGraceSeconds))s — ending session")
             }
             // A reconnect on a static screen produces no capture frames, so
             // the receiver would stay black — replay the last frame as IDR.

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -187,6 +187,15 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // not "app closed" — surface that instead of the usual hints. Cleared by
     // the first successful connection.
     private var awaitingWake: Bool
+
+    // Consecutive actively-refused dials on a previously connected session.
+    // Refusal is unambiguous: the device is reachable but nothing listens,
+    // so the app was quit (a suspended app's kernel still accepts, and a
+    // network blip times out instead of refusing). Three in a row (~3s)
+    // ends the session early; the full 10s grace stays reserved for the
+    // ambiguous failure kinds.
+    private var consecutiveRefusals = 0
+    private let refusalsBeforeGivingUp = 3
     private var dropsTotal: Int { dropsEncTotal + dropsNetTotal }
 
     // Local cursor echo: a cursor baked into the video carries the full
@@ -506,6 +515,33 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         }
     }
 
+    /// A dial was actively refused (must be called on `queue`). On a session
+    /// that has streamed before, enough refusals in a row prove the receiver
+    /// app is gone — end now instead of waiting out the grace.
+    private func dialRefused() {
+        guard everConnected, !stopped else { return }
+        consecutiveRefusals += 1
+        if consecutiveRefusals == refusalsBeforeGivingUp {
+            Log.info("dial refused \(consecutiveRefusals)x — receiver app is gone, ending session")
+            Task { @MainActor in self.onDisconnected?() }
+        }
+    }
+
+    /// The receiver's Bonjour advertisement disappeared (the system
+    /// deregisters a dead app's service within ~1s, while a suspended app
+    /// keeps it). Only meaningful once the connection is already down —
+    /// a live connection outranks a flapping mDNS cache. Together they
+    /// prove a WiFi receiver quit, where dials just stall instead of
+    /// being refused.
+    func peerServiceWithdrawn() {
+        queue.async { [weak self] in
+            guard let self, !self.stopped, self.everConnected,
+                  !self.connectionReady else { return }
+            Log.info("service withdrawn and connection down — receiver app is gone, ending session")
+            Task { @MainActor in self.onDisconnected?() }
+        }
+    }
+
     /// Drop the current connection and dial again — fresh TCP through the
     /// tunnel, fresh accept on the phone. Bound to the UI Reconnect button.
     func forceReconnect() {
@@ -562,6 +598,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         connectionReady = true
         everConnected = true
         awaitingWake = false
+        consecutiveRefusals = 0
         disconnectedSince = nil
         needsKeyframe = true   // new peer needs SPS/PPS + IDR
         // A reconnect can recreate the phone's video view with no cursor
@@ -603,6 +640,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             case .failed(let error):
                 Log.info("connection failed: \(error)")
                 self.connectionReady = false
+                if case .posix(let code) = error, code == .ECONNREFUSED {
+                    self.dialRefused()
+                }
                 self.scheduleReconnect()
             case .waiting(let error):
                 // On loopback there is no "path change" to wake us up again
@@ -669,6 +709,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 }
                 queue.async {
                     guard generation == self.dialGeneration, !self.stopped else { return }
+                    if case .refused = error as? Usbmux.Failure {
+                        self.dialRefused()
+                    }
                     Task { await self.status(hint) }
                     self.scheduleReconnect()
                 }

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -526,8 +526,8 @@ final class SenderController: ObservableObject {
             self.end(session)
         }
         sender.onPeerSleeping = { [weak self, weak session] in
-            // The device's screen went dark. Unlike a plain disconnect this
-            // is a known-temporary state announced by the receiver, so ending
+            // The device locked. Unlike a plain disconnect this is a
+            // known-temporary state announced by the receiver, so ending
             // the session (which frees the cursor from the now-invisible
             // display) is paired with a replacement session that dials
             // patiently until the device wakes and accepts again.
@@ -536,6 +536,14 @@ final class SenderController: ObservableObject {
             Log.info("session \(session.id) asleep — display down, waiting for wake")
             self.end(session)
             self.connect(to: target, awaitingWake: true)
+        }
+        sender.onPeerClosed = { [weak self, weak session] in
+            // The receiver app quit — a deliberate goodbye, so no reconnect
+            // waits around. Reopening the app is a fresh start handled by
+            // the normal discovery/auto-connect paths.
+            guard let self, let session else { return }
+            Log.info("session \(session.id) closed by the receiver — ending")
+            self.end(session)
         }
         sessions.append(session)
         Task {

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -254,6 +254,7 @@ final class SenderController: ObservableObject {
             DispatchQueue.main.async {
                 guard let self else { return }
                 self.discovered = Array(results)
+                self.endSessionsWhoseServiceVanished()
                 self.autoConnect()
             }
         }
@@ -377,6 +378,26 @@ final class SenderController: ObservableObject {
             session.onUSB = false
             session.wifiServiceName = serviceName(of: result)
             session.sender.switchTransport(to: .tcp(result.endpoint))
+        }
+    }
+
+    /// A quit receiver app loses its Bonjour advertisement within ~1s, far
+    /// faster than WiFi dial timeouts can notice (dials to a withdrawn
+    /// service stall rather than getting refused). Report the withdrawal to
+    /// each live WiFi session's sender; it only acts if its connection is
+    /// already down too, which together proves the app is gone. Debounced
+    /// 3s: an mDNS record can drop briefly during a WiFi roam — only a
+    /// withdrawal that persists counts. One-shot, guarded re-check, so
+    /// overlapping browse events at worst repeat an idempotent call.
+    private func endSessionsWhoseServiceVanished() {
+        for session in sessions where !session.onUSB {
+            guard wifiService(for: session) == nil else { continue }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self, weak session] in
+                guard let self, let session,
+                      self.sessions.contains(where: { $0 === session }),
+                      self.wifiService(for: session) == nil else { return }
+                session.sender.peerServiceWithdrawn()
+            }
         }
     }
 

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -442,7 +442,8 @@ final class SenderController: ObservableObject {
         return hash == 0 ? 1 : hash
     }
 
-    func connect(to target: ConnectionTarget, userInitiated: Bool = false) {
+    func connect(to target: ConnectionTarget, userInitiated: Bool = false,
+                 awaitingWake: Bool = false) {
         let id = target.sessionID
         guard session(for: id) == nil else { return }
 
@@ -490,7 +491,8 @@ final class SenderController: ObservableObject {
 
         let name = label(for: target)
         let sender = MacSender(transport: transport, name: name, mode: mode,
-                               quality: quality, displaySerial: Self.displaySerial(for: id))
+                               quality: quality, displaySerial: Self.displaySerial(for: id),
+                               awaitingWake: awaitingWake)
         let session = DeviceSession(id: id, target: target, name: name, sender: sender)
         if case .wifi(let result) = target {
             session.wifiServiceName = serviceName(of: result)
@@ -522,6 +524,18 @@ final class SenderController: ObservableObject {
             guard let self, let session else { return }
             Log.info("device disconnected — session \(session.id) stopped")
             self.end(session)
+        }
+        sender.onPeerSleeping = { [weak self, weak session] in
+            // The device's screen went dark. Unlike a plain disconnect this
+            // is a known-temporary state announced by the receiver, so ending
+            // the session (which frees the cursor from the now-invisible
+            // display) is paired with a replacement session that dials
+            // patiently until the device wakes and accepts again.
+            guard let self, let session else { return }
+            let target = session.target
+            Log.info("session \(session.id) asleep — display down, waiting for wake")
+            self.end(session)
+            self.connect(to: target, awaitingWake: true)
         }
         sessions.append(session)
         Task {

--- a/Shared/Protocol.swift
+++ b/Shared/Protocol.swift
@@ -28,4 +28,5 @@ enum WireProtocol {
 enum WireMessage {
     static let welcome = "welcome"                  // Mac -> phone: Mac's pv + min supported
     static let updateRequired = "updateRequired"    // Mac -> phone: peer is below the Mac's floor
+    static let sleeping = "sleeping"                // phone -> Mac: screen locked / app left foreground
 }

--- a/Shared/Protocol.swift
+++ b/Shared/Protocol.swift
@@ -28,5 +28,6 @@ enum WireProtocol {
 enum WireMessage {
     static let welcome = "welcome"                  // Mac -> phone: Mac's pv + min supported
     static let updateRequired = "updateRequired"    // Mac -> phone: peer is below the Mac's floor
-    static let sleeping = "sleeping"                // phone -> Mac: screen locked / app left foreground
+    static let sleeping = "sleeping"                // phone -> Mac: device locked, reconnect on wake
+    static let closing = "closing"                  // phone -> Mac: app quit, end the session for good
 }

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -129,40 +129,24 @@ struct ReceiverScreen: View {
         .onChange(of: scenePhase) { _, phase in
             Log.info("scenePhase -> \(String(describing: phase))")
             switch phase {
-            case .active:
-                // iOS may tear the listener down while suspended — recover.
-                model.receiver.ensureListening()
-            case .background:
-                // Screen locked or the user switched apps — either way the
-                // stream is invisible now, and staying connected strands the
-                // Mac's cursor on a display nobody can see. Tell the Mac and
-                // go silent; it reconnects on its own when we return. The
-                // background assertion keeps iOS from suspending us before
-                // the goodbye flushes.
-                let token = UIApplication.shared.beginBackgroundTask()
-                model.receiver.enterSleep {
-                    DispatchQueue.main.async { UIApplication.shared.endBackgroundTask(token) }
-                }
-            default:
-                break
+            case .active: model.sceneDidActivate()
+            case .background: model.sceneDidBackground()
+            default: break
             }
         }
-        // Belt and braces for the lock case: some sleep paths (e.g. the
-        // power button while the app holds the screen) report the lock via
-        // protected data before/without a scene transition. enterSleep is
-        // idempotent, so reacting to both signals is safe.
+        // The deliberate "screen off" signal: locking the device makes
+        // protected data unavailable (a plain app switch doesn't). This is
+        // what separates "put the iPhone to sleep — end the session now"
+        // from "peeked at a message — keep the session alive".
         .onReceive(NotificationCenter.default.publisher(
             for: UIApplication.protectedDataWillBecomeUnavailableNotification)) { _ in
             Log.info("protected data will become unavailable (device locking)")
-            let token = UIApplication.shared.beginBackgroundTask()
-            model.receiver.enterSleep {
-                DispatchQueue.main.async { UIApplication.shared.endBackgroundTask(token) }
-            }
+            model.deviceWillLock()
         }
         .onReceive(NotificationCenter.default.publisher(
             for: UIApplication.protectedDataDidBecomeAvailableNotification)) { _ in
             Log.info("protected data available again (device unlocked)")
-            model.receiver.ensureListening()
+            model.sceneDidActivate()
         }
         .onChange(of: model.receiver.connected) { _, isConnected in
             // The first valid connection retires the onboarding hint for good.
@@ -635,6 +619,72 @@ final class ReceiverModel: ObservableObject {
         guard !started else { return }
         started = true
         receiver.start(port: 9000)
+    }
+
+    // MARK: - Lock vs app switch
+
+    // A plain app switch keeps the session alive under a background
+    // assertion for this long — enough to answer a message and come back
+    // without a display rebuild, short enough to fit inside the ~30s of
+    // background runtime iOS actually grants. A device lock is the
+    // deliberate "screen off" and skips the linger entirely.
+    private let lingerSeconds: TimeInterval = 20
+    private var lingerTask: DispatchWorkItem?
+    private var backgroundToken: UIBackgroundTaskIdentifier = .invalid
+
+    func sceneDidBackground() {
+        if !UIApplication.shared.isProtectedDataAvailable {
+            // Backgrounded because the device locked, not an app switch.
+            Log.info("backgrounded by device lock — sleeping now")
+            goToSleep()
+            return
+        }
+        Log.info("app switched away — lingering \(Int(lingerSeconds))s before sleeping")
+        beginBackgroundAssertion()
+        receiver.setRenderingPaused(true)
+        // Cancel + replace, never stack self-rescheduling work (#75/#76).
+        lingerTask?.cancel()
+        let task = DispatchWorkItem { [weak self] in self?.goToSleep() }
+        lingerTask = task
+        DispatchQueue.main.asyncAfter(deadline: .now() + lingerSeconds, execute: task)
+    }
+
+    func sceneDidActivate() {
+        lingerTask?.cancel()
+        lingerTask = nil
+        endBackgroundAssertion()
+        receiver.setRenderingPaused(false)
+        receiver.ensureListening()
+    }
+
+    func deviceWillLock() {
+        Log.info("device locking — sleeping now")
+        goToSleep()
+    }
+
+    private func goToSleep() {
+        lingerTask?.cancel()
+        lingerTask = nil
+        receiver.enterSleep { [weak self] in
+            DispatchQueue.main.async { self?.endBackgroundAssertion() }
+        }
+    }
+
+    private func beginBackgroundAssertion() {
+        guard backgroundToken == .invalid else { return }
+        backgroundToken = UIApplication.shared.beginBackgroundTask { [weak self] in
+            // iOS is done waiting — fire the goodbye and release the
+            // assertion before suspension takes us either way.
+            guard let self else { return }
+            self.receiver.enterSleep()
+            self.endBackgroundAssertion()
+        }
+    }
+
+    private func endBackgroundAssertion() {
+        guard backgroundToken != .invalid else { return }
+        UIApplication.shared.endBackgroundTask(backgroundToken)
+        backgroundToken = .invalid
     }
 }
 

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -146,7 +146,7 @@ struct ReceiverScreen: View {
         .onReceive(NotificationCenter.default.publisher(
             for: UIApplication.protectedDataDidBecomeAvailableNotification)) { _ in
             Log.info("protected data available again (device unlocked)")
-            model.sceneDidActivate()
+            model.deviceDidUnlock()
         }
         // Swiping the app away in the switcher (while we're still running)
         // grants a ~5s notice — enough for a clean goodbye so the Mac ends
@@ -643,6 +643,11 @@ final class ReceiverModel: ObservableObject {
     private var backgroundToken: UIBackgroundTaskIdentifier = .invalid
 
     func sceneDidBackground() {
+        // Known limitation: lock detection rides the protected-data signal,
+        // which only fires when a passcode is set AND "Require Passcode" is
+        // Immediately (the Face ID default). Other configurations make a
+        // lock indistinguishable from an app switch, so those keep the
+        // session like a backgrounded app would.
         if !UIApplication.shared.isProtectedDataAvailable {
             // Backgrounded because the device locked, not an app switch.
             Log.info("backgrounded by device lock — sleeping now")
@@ -663,6 +668,18 @@ final class ReceiverModel: ObservableObject {
     func deviceWillLock() {
         Log.info("device locking — sleeping now")
         goToSleep()
+    }
+
+    /// Unlock arrives via the protected-data notification, which also fires
+    /// when the user unlocks into ANOTHER app while we sit in the background
+    /// — don't re-arm the listener or unpause rendering off-screen there;
+    /// the real return still comes through scenePhase.
+    func deviceDidUnlock() {
+        guard UIApplication.shared.applicationState == .active else {
+            Log.info("unlocked while backgrounded — staying dormant")
+            return
+        }
+        sceneDidActivate()
     }
 
     /// User swiped the app away (or iOS terminates us while still running):

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -148,6 +148,14 @@ struct ReceiverScreen: View {
             Log.info("protected data available again (device unlocked)")
             model.sceneDidActivate()
         }
+        // Swiping the app away in the switcher (while we're still running)
+        // grants a ~5s notice — enough for a clean goodbye so the Mac ends
+        // the session at once. A kill without notice is covered Mac-side:
+        // dead apps stop accepting redials, so the silence grace fires.
+        .onReceive(NotificationCenter.default.publisher(
+            for: UIApplication.willTerminateNotification)) { _ in
+            model.appWillTerminate()
+        }
         .onChange(of: model.receiver.connected) { _, isConnected in
             // The first valid connection retires the onboarding hint for good.
             if isConnected {
@@ -621,15 +629,17 @@ final class ReceiverModel: ObservableObject {
         receiver.start(port: 9000)
     }
 
-    // MARK: - Lock vs app switch
+    // MARK: - Lock vs app switch vs app quit
 
-    // A plain app switch keeps the session alive under a background
-    // assertion for this long — enough to answer a message and come back
-    // without a display rebuild, short enough to fit inside the ~30s of
-    // background runtime iOS actually grants. A device lock is the
-    // deliberate "screen off" and skips the linger entirely.
-    private let lingerSeconds: TimeInterval = 20
-    private var lingerTask: DispatchWorkItem?
+    // A plain app switch keeps the session (and the Mac's virtual display,
+    // and therefore the user's window arrangement) alive INDEFINITELY. The
+    // assertion buys ~30s of live pings; after iOS suspends us the kernel
+    // still accepts the Mac's redials, so the session survives untouched
+    // until we return. Only a device lock (deliberate "screen off") or the
+    // app being quit ends the session. Known hole: a lock that happens
+    // after we're already suspended is undetectable — no code runs and the
+    // kernel behaves identically — so the display stays up until the user
+    // returns or the app dies.
     private var backgroundToken: UIBackgroundTaskIdentifier = .invalid
 
     func sceneDidBackground() {
@@ -639,19 +649,12 @@ final class ReceiverModel: ObservableObject {
             goToSleep()
             return
         }
-        Log.info("app switched away — lingering \(Int(lingerSeconds))s before sleeping")
+        Log.info("app switched away — keeping the session, rendering paused")
         beginBackgroundAssertion()
         receiver.setRenderingPaused(true)
-        // Cancel + replace, never stack self-rescheduling work (#75/#76).
-        lingerTask?.cancel()
-        let task = DispatchWorkItem { [weak self] in self?.goToSleep() }
-        lingerTask = task
-        DispatchQueue.main.asyncAfter(deadline: .now() + lingerSeconds, execute: task)
     }
 
     func sceneDidActivate() {
-        lingerTask?.cancel()
-        lingerTask = nil
         endBackgroundAssertion()
         receiver.setRenderingPaused(false)
         receiver.ensureListening()
@@ -662,9 +665,15 @@ final class ReceiverModel: ObservableObject {
         goToSleep()
     }
 
+    /// User swiped the app away (or iOS terminates us while still running):
+    /// ~5s of runtime remain, plenty for the "closing" goodbye that lets the
+    /// Mac end the session immediately instead of after its silence grace.
+    func appWillTerminate() {
+        Log.info("app terminating — closing session")
+        receiver.shutDown()
+    }
+
     private func goToSleep() {
-        lingerTask?.cancel()
-        lingerTask = nil
         receiver.enterSleep { [weak self] in
             DispatchQueue.main.async { self?.endBackgroundAssertion() }
         }
@@ -673,11 +682,9 @@ final class ReceiverModel: ObservableObject {
     private func beginBackgroundAssertion() {
         guard backgroundToken == .invalid else { return }
         backgroundToken = UIApplication.shared.beginBackgroundTask { [weak self] in
-            // iOS is done waiting — fire the goodbye and release the
-            // assertion before suspension takes us either way.
-            guard let self else { return }
-            self.receiver.enterSleep()
-            self.endBackgroundAssertion()
+            // Suspension takes us now; the session stays up by design (the
+            // kernel keeps accepting for us) — just release the assertion.
+            self?.endBackgroundAssertion()
         }
     }
 

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -127,8 +127,42 @@ struct ReceiverScreen: View {
             showSettings = true
         }
         .onChange(of: scenePhase) { _, phase in
-            // iOS may tear the listener down while suspended — recover.
-            if phase == .active { model.receiver.ensureListening() }
+            Log.info("scenePhase -> \(String(describing: phase))")
+            switch phase {
+            case .active:
+                // iOS may tear the listener down while suspended — recover.
+                model.receiver.ensureListening()
+            case .background:
+                // Screen locked or the user switched apps — either way the
+                // stream is invisible now, and staying connected strands the
+                // Mac's cursor on a display nobody can see. Tell the Mac and
+                // go silent; it reconnects on its own when we return. The
+                // background assertion keeps iOS from suspending us before
+                // the goodbye flushes.
+                let token = UIApplication.shared.beginBackgroundTask()
+                model.receiver.enterSleep {
+                    DispatchQueue.main.async { UIApplication.shared.endBackgroundTask(token) }
+                }
+            default:
+                break
+            }
+        }
+        // Belt and braces for the lock case: some sleep paths (e.g. the
+        // power button while the app holds the screen) report the lock via
+        // protected data before/without a scene transition. enterSleep is
+        // idempotent, so reacting to both signals is safe.
+        .onReceive(NotificationCenter.default.publisher(
+            for: UIApplication.protectedDataWillBecomeUnavailableNotification)) { _ in
+            Log.info("protected data will become unavailable (device locking)")
+            let token = UIApplication.shared.beginBackgroundTask()
+            model.receiver.enterSleep {
+                DispatchQueue.main.async { UIApplication.shared.endBackgroundTask(token) }
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(
+            for: UIApplication.protectedDataDidBecomeAvailableNotification)) { _ in
+            Log.info("protected data available again (device unlocked)")
+            model.receiver.ensureListening()
         }
         .onChange(of: model.receiver.connected) { _, isConnected in
             // The first valid connection retires the onboarding hint for good.

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -279,8 +279,8 @@ final class PhoneReceiver: ObservableObject {
                               completion: (() -> Void)?) {
         queue.async {
             var finished = false
-            let finish = {
-                guard !finished else { return }
+            let finish = { [weak self] in
+                guard let self, !finished else { return }
                 finished = true
                 self.connection?.cancel()
                 self.connection = nil

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -255,14 +255,28 @@ final class PhoneReceiver: ObservableObject {
         }
     }
 
-    /// The screen went dark (lock or app backgrounded) — nobody can see the
-    /// stream, so tell the Mac and go silent. Sends "sleeping" (the Mac drops
-    /// its virtual display so the cursor isn't stranded on an invisible
-    /// screen), then closes the connection AND the listener: while asleep we
-    /// must not accept connections, or the Mac's wake retries would rebuild
-    /// the display before anyone can see it. ensureListening() re-arms
+    /// The device locked — nobody can see the stream, so tell the Mac and go
+    /// silent. Sends "sleeping" (the Mac drops its virtual display so the
+    /// cursor isn't stranded on an invisible screen and arms a reconnect),
+    /// then closes the connection AND the listener: while asleep we must not
+    /// accept connections, or the Mac's wake retries would rebuild the
+    /// display before anyone can see it. ensureListening() re-arms
     /// everything when the scene becomes active again.
     func enterSleep(completion: (() -> Void)? = nil) {
+        closeSession(announcing: WireMessage.sleeping,
+                     status: "Asleep — resumes on wake", completion: completion)
+    }
+
+    /// The app is being terminated (user swiped it away). Same close, but
+    /// announced as "closing": quitting the app is deliberate, so the Mac
+    /// ends the session without waiting around for a wake.
+    func shutDown(completion: (() -> Void)? = nil) {
+        closeSession(announcing: WireMessage.closing,
+                     status: "Closed", completion: completion)
+    }
+
+    private func closeSession(announcing type: String, status: String,
+                              completion: (() -> Void)?) {
         queue.async {
             var finished = false
             let finish = {
@@ -274,20 +288,20 @@ final class PhoneReceiver: ObservableObject {
                 self.listener = nil
                 self.listenerHealthy = false
                 self.setConnected(false)
-                self.setStatus("Asleep — resumes on wake")
+                self.setStatus(status)
                 completion?()
             }
             guard let conn = self.connection, conn.state == .ready else {
-                Log.info("entering sleep (no live connection)")
+                Log.info("closing session (\(type)) — no live connection")
                 finish()
                 return
             }
-            Log.info("entering sleep — notifying the Mac and closing")
-            self.sendControl(["type": WireMessage.sleeping], on: conn) {
+            Log.info("closing session — announcing \(type) to the Mac")
+            self.sendControl(["type": type], on: conn) {
                 self.queue.async { finish() }
             }
             // The send completion may never fire on a dying link — don't
-            // let that keep us accepting connections while asleep.
+            // let that keep us accepting connections after going dark.
             self.queue.asyncAfter(deadline: .now() + 1) { finish() }
         }
     }

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -233,6 +233,28 @@ final class PhoneReceiver: ObservableObject {
         }
     }
 
+    // Set while the app lingers in the background with the session alive
+    // (brief app switch): decoding is pointless and hardware decode sessions
+    // fail off-screen, so frames are dropped before the sample stage.
+    private var renderingPaused = false
+
+    /// Pause/resume the video sink around a background linger. Resuming
+    /// flushes the layer and asks the Mac for a keyframe so the picture
+    /// re-syncs immediately (the Mac replays a static screen as IDR too).
+    func setRenderingPaused(_ paused: Bool) {
+        queue.async {
+            guard paused != self.renderingPaused else { return }
+            self.renderingPaused = paused
+            Log.info(paused ? "rendering paused (backgrounded)" : "rendering resumed")
+            if !paused {
+                self.displayLayer.flush()
+                if self.connection?.state == .ready {
+                    self.sendControl(["type": "kf"])
+                }
+            }
+        }
+    }
+
     /// The screen went dark (lock or app backgrounded) — nobody can see the
     /// stream, so tell the Mac and go silent. Sends "sleeping" (the Mac drops
     /// its virtual display so the cursor isn't stranded on an invisible
@@ -636,6 +658,10 @@ final class PhoneReceiver: ObservableObject {
 
     private func enqueueFrame(_ nalus: [Data], captureMs: Double? = nil, sendMs: Double? = nil) {
         guard let formatDesc else { return }
+        // Backgrounded linger: hardware decode is off-limits there, so drop
+        // frames at the door instead of feeding a failing display layer at
+        // frame rate. setRenderingPaused(false) re-syncs with a keyframe.
+        if renderingPaused { return }
 
         // Build one AVCC buffer: each NALU prefixed with 4-byte big-endian length.
         var avcc = Data(capacity: nalus.reduce(0) { $0 + $1.count + 4 })

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -223,12 +223,50 @@ final class PhoneReceiver: ObservableObject {
     }
 
     /// Recreate the listener if it isn't healthy — called when the app
-    /// returns to the foreground (iOS may have torn it down while suspended).
+    /// returns to the foreground (iOS may have torn it down while suspended,
+    /// or enterSleep deliberately took it down on lock).
     func ensureListening() {
         queue.async {
             guard !self.listenerHealthy else { return }
             Log.info("listener not healthy — restarting")
             self.restartListener()
+        }
+    }
+
+    /// The screen went dark (lock or app backgrounded) — nobody can see the
+    /// stream, so tell the Mac and go silent. Sends "sleeping" (the Mac drops
+    /// its virtual display so the cursor isn't stranded on an invisible
+    /// screen), then closes the connection AND the listener: while asleep we
+    /// must not accept connections, or the Mac's wake retries would rebuild
+    /// the display before anyone can see it. ensureListening() re-arms
+    /// everything when the scene becomes active again.
+    func enterSleep(completion: (() -> Void)? = nil) {
+        queue.async {
+            var finished = false
+            let finish = {
+                guard !finished else { return }
+                finished = true
+                self.connection?.cancel()
+                self.connection = nil
+                self.listener?.cancel()
+                self.listener = nil
+                self.listenerHealthy = false
+                self.setConnected(false)
+                self.setStatus("Asleep — resumes on wake")
+                completion?()
+            }
+            guard let conn = self.connection, conn.state == .ready else {
+                Log.info("entering sleep (no live connection)")
+                finish()
+                return
+            }
+            Log.info("entering sleep — notifying the Mac and closing")
+            self.sendControl(["type": WireMessage.sleeping], on: conn) {
+                self.queue.async { finish() }
+            }
+            // The send completion may never fire on a dying link — don't
+            // let that keep us accepting connections while asleep.
+            self.queue.asyncAfter(deadline: .now() + 1) { finish() }
         }
     }
 
@@ -439,14 +477,19 @@ final class PhoneReceiver: ObservableObject {
         sendControl(["type": "scroll", "dx": dx, "dy": dy])
     }
 
-    private func sendControl(_ message: [String: Any], on conn: NWConnection? = nil) {
+    private func sendControl(_ message: [String: Any], on conn: NWConnection? = nil,
+                             completion: (() -> Void)? = nil) {
         guard let conn = conn ?? connection,
-              let payload = try? JSONSerialization.data(withJSONObject: message) else { return }
+              let payload = try? JSONSerialization.data(withJSONObject: message) else {
+            completion?()
+            return
+        }
         var header = UInt32(payload.count).bigEndian
         var frame = Data(bytes: &header, count: 4)
         frame.append(payload)
         conn.send(content: frame, completion: .contentProcessed { error in
             if let error { Log.info("control send error: \(error)") }
+            completion?()
         })
     }
 


### PR DESCRIPTION
Fixes #165. Locking the iPhone/iPad ends the session immediately (the virtual display comes down, so the cursor returns to a visible screen) and the session rebuilds on its own when the device wakes. Backgrounding the app does NOT end the session: the display and the user's window arrangement stay put indefinitely while the receiver sits in another app, and the stream resumes with one keyframe on return.

**Why:** sleeping the phone left the virtual display up forever with the mouse potentially stranded on it. Testing exposed that the existing teardown was also dead over WiFi: a redial to a withdrawn Bonjour service sits in .preparing forever, so dead sessions never cleaned up either.

**How:** the receiver announces its state with two additive control messages. Device lock sends `sleeping` (protected-data signal) and stops listening; the Mac ends the session and starts a wake-waiting replacement that redials until the device listens again. Quitting the app sends `closing` via willTerminate; the Mac ends the session with no reconnect. A plain app switch sends nothing: rendering pauses and the session survives suspension because the kernel keeps accepting the Mac's redials. Two documented limitations: a lock that happens after the app is already suspended is undetectable (no code runs, the kernel accepts identically), and lock detection needs a passcode with Require Passcode set to Immediately (the Face ID default); in both remaining configurations a lock behaves like a backgrounded app and keeps the session. Robustness fixes ride along: every WiFi dial gets a 5s deadline, and the disconnect grace is enforced from the watchdog. A quit app is additionally detected in seconds instead of the grace: over USB three consecutively refused dials (~3s, only a dead app refuses; suspended apps still accept and blips time out), over WiFi a Bonjour advertisement withdrawal persisting 3s while the connection is down (~4s, debounced so an mDNS flap during a roam does not count).

No pv bump (additive messages, old peers ignore them, per COMPATIBILITY.md). Verified live on device over WiFi and USB: real auto-lock plus unlock reconnect, 70s backgrounding with seamless resume, SIGKILL teardown in ~3s (USB) and ~4s via swipe-quit (WiFi), relaunch reconnect, and cable-unplug failover to WiFi mid-session. Still to check: multi-device smoke test (iPad currently offline).
