### PR TITLE
Landing page: sharper corners, fixed sticky nudge, platform-aware steps

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,19 @@ const HERO_WORDS = [
 export default function App() {
   const [macVer, setMacVer] = useState<string | null>(null)
   const [starCount, setStarCount] = useState<string | null>(null)
+  // Step 1 should be whichever platform you're reading this on. Default is
+  // Mac-first (what SSR/prerender emits, and what desktop/Windows/Linux see);
+  // on an iPhone/iPad we flip so the receiver you install here comes first.
+  const [iosFirst, setIosFirst] = useState(false)
+
+  useEffect(() => {
+    const ua = navigator.userAgent
+    const isIosDevice =
+      /iPhone|iPad|iPod/.test(ua) ||
+      // iPadOS 13+ reports as "Macintosh"; a touch-capable one is an iPad.
+      (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1)
+    if (isIosDevice) setIosFirst(true)
+  }, [])
   // Show the brand icon in the navbar only once the big hero logo has
   // scrolled up behind the sticky nav — it "hands off" from hero to navbar.
   const heroLogoRef = useRef<HTMLImageElement>(null)
@@ -191,62 +204,71 @@ export default function App() {
             OpenDisplay is <strong>two apps that work together</strong> — install both to get going.
           </p>
           <div className="downloads">
-            <div>
-              <div className="dl-head">
-                <span className="step">Step 1</span> On your Mac{" "}
-                <span className="ver">{macVer}</span>
-              </div>
-              <p className="dl-sub">The sender — captures a virtual display and streams it.</p>
-              <a
-                className="btn primary"
-                href="https://github.com/peetzweg/opendisplay/releases/latest/download/OpenDisplay.dmg"
-              >
-                Download for Mac
-              </a>
-              <p className="note">
-                Signed &amp; notarized — opens normally on macOS&nbsp;14+. Prefer to compile it yourself?{" "}
-                <a href="https://github.com/peetzweg/opendisplay#quick-start">Build from source ↗</a>
-              </p>
-              <p className="note">
-                Looking for an older version?{" "}
-                <a href="https://github.com/peetzweg/opendisplay/releases">Browse all releases ↗</a>
-              </p>
-            </div>
-            <div>
-              <div className="dl-head">
-                <span className="step">Step 2</span> On your iPhone &amp; iPad
-              </div>
-              <p className="dl-sub">The receiver — displays the stream and sends touch back.</p>
-              {/* TODO: On desktop only, show a QR code next to the App Store
-                  badge that encodes the App Store link, so visitors on a
-                  desktop PC can scan it with their iPhone or iPad to install
-                  the receiver. Hide it on touch/mobile viewports. */}
-              <div className="ios-row">
-                <a
-                  className="badge-wrap"
-                  href="https://apps.apple.com/app/id6780264891"
-                >
-                  <img
-                    className="appstore-badge"
-                    src="app-store-badge.svg"
-                    alt="Download on the App Store"
-                    width="120"
-                    height="40"
-                  />
-                </a>
-              </div>
-              <p className="sub">
-                Want early builds? <a id="testflight" href="https://testflight.apple.com/join/3NYaY11c">
-                  Join the TestFlight beta
-                </a>
-                ,<br />
-                or{" "}
-                <a href="https://github.com/peetzweg/opendisplay#quick-start">
-                  compile it from source ↗
-                </a>
-                .
-              </p>
-            </div>
+            {/* Step 1 is whichever platform you're reading this on — on an
+                iPhone/iPad the receiver comes first (see iosFirst). */}
+            {(() => {
+              const macStep = (
+                <div key="mac">
+                  <div className="dl-head">
+                    <span className="step">Step {iosFirst ? 2 : 1}</span> On your Mac{" "}
+                    <span className="ver">{macVer}</span>
+                  </div>
+                  <p className="dl-sub">The sender — captures a virtual display and streams it.</p>
+                  <a
+                    className="btn primary"
+                    href="https://github.com/peetzweg/opendisplay/releases/latest/download/OpenDisplay.dmg"
+                  >
+                    Download for Mac
+                  </a>
+                  <p className="note">
+                    Signed &amp; notarized — opens normally on macOS&nbsp;14+. Prefer to compile it yourself?{" "}
+                    <a href="https://github.com/peetzweg/opendisplay#quick-start">Build from source ↗</a>
+                  </p>
+                  <p className="note">
+                    Looking for an older version?{" "}
+                    <a href="https://github.com/peetzweg/opendisplay/releases">Browse all releases ↗</a>
+                  </p>
+                </div>
+              )
+              const iosStep = (
+                <div key="ios">
+                  <div className="dl-head">
+                    <span className="step">Step {iosFirst ? 1 : 2}</span> On your iPhone &amp; iPad
+                  </div>
+                  <p className="dl-sub">The receiver — displays the stream and sends touch back.</p>
+                  {/* TODO: On desktop only, show a QR code next to the App Store
+                      badge that encodes the App Store link, so visitors on a
+                      desktop PC can scan it with their iPhone or iPad to install
+                      the receiver. Hide it on touch/mobile viewports. */}
+                  <div className="ios-row">
+                    <a
+                      className="badge-wrap"
+                      href="https://apps.apple.com/app/id6780264891"
+                    >
+                      <img
+                        className="appstore-badge"
+                        src="app-store-badge.svg"
+                        alt="Download on the App Store"
+                        width="120"
+                        height="40"
+                      />
+                    </a>
+                  </div>
+                  <p className="sub">
+                    Want early builds? <a id="testflight" href="https://testflight.apple.com/join/3NYaY11c">
+                      Join the TestFlight beta
+                    </a>
+                    ,<br />
+                    or{" "}
+                    <a href="https://github.com/peetzweg/opendisplay#quick-start">
+                      compile it from source ↗
+                    </a>
+                    .
+                  </p>
+                </div>
+              )
+              return iosFirst ? [iosStep, macStep] : [macStep, iosStep]
+            })()}
           </div>
         </div>
       </section>

--- a/src/components/SupportNudge.tsx
+++ b/src/components/SupportNudge.tsx
@@ -1,11 +1,37 @@
+import { useEffect, useRef, useState } from "react"
+
 // Ko-fi nudge pill that jumps to #support. Sits in flow between the hero and the
 // downloads and pins under the sticky nav once you scroll past it (position:
 // sticky). It lives inside <div class="nudge-scope"> in App — that box ends
 // where #support begins, so the pill stops sticking once the real support
 // section is reached. A centered, bordered pill (blurb + CTA), not a full bar.
+//
+// Once pinned it drops its own top border (the .is-stuck class) so it doesn't
+// double up against the nav's bottom border. "Stuck" can't be detected in pure
+// CSS, so an IntersectionObserver watches the pill against the 60px nav line:
+// the -61px top root margin makes it clip by 1px exactly when it pins, dropping
+// intersectionRatio below 1.
 export default function SupportNudge() {
+  const ref = useRef<HTMLAnchorElement>(null)
+  const [stuck, setStuck] = useState(false)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el || typeof IntersectionObserver === "undefined") return
+    const io = new IntersectionObserver(
+      ([entry]) => setStuck(entry.intersectionRatio < 1),
+      { threshold: [1], rootMargin: "-61px 0px 0px 0px" }
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [])
+
   return (
-    <a className="support-nudge" href="#support">
+    <a
+      ref={ref}
+      className={stuck ? "support-nudge is-stuck" : "support-nudge"}
+      href="#support"
+    >
       <span className="kofi-banner-left">
         <img className="kofi-mark" src="kofi-mark.webp" alt="" width="24" height="24" />
         <span className="kofi-banner-text">Free, and built by one person.</span>

--- a/src/index.css
+++ b/src/index.css
@@ -124,13 +124,13 @@ h2 { font-size: clamp(1.5rem, 3vw, 2rem); line-height: 1.1; letter-spacing: -0.0
 .dl-head { font-family: var(--mono); font-size: 0.72rem; letter-spacing: 0.1em;
   text-transform: uppercase; color: var(--faint); margin-bottom: 6px;
   display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
-.dl-head .step { color: var(--fg); border: 1px solid var(--line-strong); border-radius: 3px;
+.dl-head .step { color: var(--fg); border: 1px solid var(--line-strong);
   padding: 2px 7px; letter-spacing: 0.06em; }
 .dl-head .ver { color: var(--fg); text-transform: none; letter-spacing: 0; }
 .dl-sub { color: var(--muted); font-size: 0.86rem; margin-bottom: 18px; }
 
 .btn { display: inline-flex; align-items: center; gap: 8px; font: inherit;
-  font-weight: 600; font-size: 0.95rem; padding: 12px 22px; border-radius: 3px;
+  font-weight: 600; font-size: 0.95rem; padding: 12px 22px;
   text-decoration: none; border: 1px solid var(--line-strong); cursor: pointer; }
 .btn.primary { background: var(--fg); color: var(--bg); }
 .btn.primary:hover { background: #000; }
@@ -168,7 +168,7 @@ h2 { font-size: clamp(1.5rem, 3vw, 2rem); line-height: 1.1; letter-spacing: -0.0
 /* Post cards: self-contained, self-hosted renditions of community posts.
    The whole card is one link to the post on X. */
 a.showcase-item.is-post { display: block; border: 1px solid var(--line);
-  border-radius: 12px; padding: 18px 20px; text-decoration: none;
+  padding: 18px 20px; text-decoration: none;
   color: var(--fg); background: var(--bg); }
 a.showcase-item.is-post:hover { border-color: var(--line-strong); }
 .post-head { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
@@ -183,7 +183,7 @@ a.showcase-item.is-post:hover { border-color: var(--line-strong); }
 .post-trans { font-size: 0.9rem; line-height: 1.45; margin: 12px 0 0;
   color: var(--muted); font-style: italic; }
 .post-trans + .post-trans { margin-top: 0.5em; }
-.post-photo { display: block; width: 100%; height: auto; border-radius: 8px;
+.post-photo { display: block; width: 100%; height: auto;
   margin: 14px 0 12px; border: 1px solid var(--line); }
 .post-date { font-family: var(--mono); font-size: 0.72rem; letter-spacing: 0.04em;
   color: var(--faint); }
@@ -193,7 +193,7 @@ a.showcase-item.is-post:hover { border-color: var(--line-strong); }
 .showcase-nav button { font-family: var(--mono); font-size: 1rem; line-height: 1;
   width: 40px; height: 40px; display: inline-flex; align-items: center; justify-content: center;
   background: transparent; color: var(--fg); border: 1px solid var(--line-strong);
-  border-radius: 3px; cursor: pointer; }
+  cursor: pointer; }
 .showcase-nav button:hover:not(:disabled) { background: var(--fg); color: var(--bg); }
 .showcase-nav button:disabled { color: var(--faint); border-color: var(--line); cursor: default; }
 
@@ -227,17 +227,17 @@ a.showcase-item.is-post:hover { border-color: var(--line-strong); }
   padding: 22px 24px; border-bottom: 1px solid var(--line); align-items: start; }
 .compare .row p { color: var(--muted); max-width: 80ch; }
 .compare .row .name { font-weight: 600; color: var(--fg); }
-.compare .row.highlight { border: 2px solid var(--accent); border-radius: 4px;
+.compare .row.highlight { border: 2px solid var(--accent);
   background: #fafafa; padding: 22px; margin-top: 10px; }
 @media (max-width: 560px) { .compare .row { grid-template-columns: 1fr; gap: 6px; } }
 .tbl-head { margin: 48px 0 16px; font-size: 1.05rem; font-weight: 600; letter-spacing: -0.01em; }
 
 /* ---- code ---- */
-pre { border: 1px solid var(--line); border-radius: 3px; padding: 20px;
+pre { border: 1px solid var(--line); padding: 20px;
   overflow-x: auto; font-size: 0.84rem; line-height: 1.55; background: #fafafa;
   margin-top: 8px; }
 code { font-family: var(--mono); }
-p code { font-size: 0.88em; background: #f2f2f2; padding: 1px 5px; border-radius: 3px; }
+p code { font-size: 0.88em; background: #f2f2f2; padding: 1px 5px; }
 
 /* ---- comparison table ---- */
 /* no outer frame — keep only the inner row lines (and the boxed OpenDisplay column) */
@@ -293,9 +293,13 @@ details p { color: var(--muted); padding: 0 0 24px; max-width: 78ch; }
 .support-nudge { position: sticky; top: 60px; z-index: 9;
   display: flex; width: fit-content; margin: 0 auto;
   align-items: center; gap: 14px; padding: 10px 18px;
-  border: 1px solid var(--line); border-radius: 3px;
+  border: 1px solid var(--line);
   background: var(--bg); text-decoration: none; color: var(--fg); }
 .support-nudge:hover { background: #fafafa; }
+/* Pinned under the nav: drop the top border so it doesn't double up against the
+   nav's bottom rule. Border stays 1px but transparent — no layout shift, and
+   the nav's opaque border paints over that row anyway. */
+.support-nudge.is-stuck { border-top-color: transparent; }
 .kofi-banner-left { display: inline-flex; align-items: center; gap: 10px; min-width: 0; }
 .support-nudge .kofi-mark { height: 24px; width: auto; display: block; flex: none; }
 .kofi-banner-text { font-size: 0.9rem; color: var(--muted); }
@@ -304,10 +308,9 @@ details p { color: var(--muted); padding: 0 0 24px; max-width: 78ch; }
   transition: transform 0.15s ease; }
 .support-nudge:hover .kofi-banner-arrow { transform: translateY(3px); }
 @media (max-width: 560px) {
-  /* Full-width band: drop the side borders (and now-orphaned corner radius) so
-     only the top/bottom rules remain. */
+  /* Full-width band: drop the side borders so only the top/bottom rules remain. */
   .support-nudge { width: auto; flex-direction: column; gap: 6px; text-align: center;
-    border-left: 0; border-right: 0; border-radius: 0; }
+    border-left: 0; border-right: 0; }
 }
 
 /* ---- footer ---- */


### PR DESCRIPTION
A few landing-page tweaks to the Ko-fi nudge and download steps.

**Why:** The nudge doubled the nav's border once it pinned, corner radii were used inconsistently (rounded buttons next to sharp info boxes), and the download steps always led with Mac even when you're reading on an iPhone or iPad.

**How:** An IntersectionObserver toggles an `is-stuck` class that drops the nudge's top border while pinned. Radii are removed everywhere except the rotating headline pill and the circular post avatars, so the sharp look is uniform. The download section now detects iOS/iPadOS on the client and renders the receiver as Step 1 (Mac stays Step 1 for the prerendered HTML and every other platform).