### PR TITLE
feat(ios): lower deployment target to iOS 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ opens with a plain double-click on macOS 14+ — no Gatekeeper warning. Open the
 
 ### iPhone app
 
+Needs **iOS / iPadOS 16 or newer** — including the 16.7.x line, which is where
+Apple left the iPad 5 (2017), the iPad Pro 1st gen, the iPhone 8 and the
+iPhone X. If your iPad can't be updated past 16.7, it can still be a second
+display ([#72](https://github.com/peetzweg/opendisplay/issues/72)).
+
 - **TestFlight** (recommended): join the public beta at
   [testflight.apple.com/join/3NYaY11c](https://testflight.apple.com/join/3NYaY11c).
 - **Build from source**: open the project in Xcode, select your free Apple ID

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -91,7 +91,7 @@ struct ReceiverScreen: View {
                 }
             }
             .onAppear { model.receiver.setOrientation(portrait: geo.size.height > geo.size.width) }
-            .onChange(of: geo.size) { _, size in
+            .onChange(of: geo.size) { size in
                 model.receiver.setOrientation(portrait: size.height > size.width)
             }
             .sheet(isPresented: $showOnboarding) {
@@ -126,7 +126,7 @@ struct ReceiverScreen: View {
         .onReceive(NotificationCenter.default.publisher(for: .deviceDidShake)) { _ in
             showSettings = true
         }
-        .onChange(of: scenePhase) { _, phase in
+        .onChange(of: scenePhase) { phase in
             Log.info("scenePhase -> \(String(describing: phase))")
             switch phase {
             case .active: model.sceneDidActivate()
@@ -156,7 +156,7 @@ struct ReceiverScreen: View {
             for: UIApplication.willTerminateNotification)) { _ in
             model.appWillTerminate()
         }
-        .onChange(of: model.receiver.connected) { _, isConnected in
+        .onChange(of: model.receiver.connected) { isConnected in
             // The first valid connection retires the onboarding hint for good.
             if isConnected {
                 hasConnectedBefore = true
@@ -596,7 +596,7 @@ private struct DeviceNameField: View {
             .textInputAutocapitalization(.words)
             .autocorrectionDisabled()
             .focused($focused)
-            .onChange(of: deviceName) { _, name in onChange(name) }
+            .onChange(of: deviceName) { name in onChange(name) }
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     "@type": "SoftwareApplication",
     "name": "OpenDisplay",
     "alternateName": "Open Display",
-    "operatingSystem": "macOS 14+, iPadOS 17+, iOS 17+",
+    "operatingSystem": "macOS 14+, iPadOS 16+, iOS 16+",
     "applicationCategory": "UtilitiesApplication",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
     "description": "Free, open-source alternative to Apple Sidecar, Duet Display and Luna Display: use your iPhone or iPad as a true second monitor (extended display, not a mirror) for your Mac over USB or WiFi — Retina-sharp, low latency, with touch and scroll input. No subscription, no dongle, no account.",

--- a/project.yml
+++ b/project.yml
@@ -87,7 +87,12 @@ targets:
   OpenSidecariOS:
     type: application
     platform: iOS
-    deploymentTarget: "17.0"
+    # iOS 16 revives the iPad 5 (2017) and iPad Pro 1st gen — the large
+    # population stuck on 16.7.x that Apple never offered 17 to (issue #72).
+    # Nothing in the streaming path needs 17: Network.framework is iOS 12,
+    # VideoToolbox/AVSampleBufferDisplayLayer older still. The floor was set
+    # purely by SwiftUI's two-parameter `onChange`, now backported.
+    deploymentTarget: "16.0"
     sources:
       - iOS
       - Shared

--- a/project.yml
+++ b/project.yml
@@ -87,11 +87,7 @@ targets:
   OpenSidecariOS:
     type: application
     platform: iOS
-    # iOS 16 revives the iPad 5 (2017) and iPad Pro 1st gen — the large
-    # population stuck on 16.7.x that Apple never offered 17 to (issue #72).
-    # Nothing in the streaming path needs 17: Network.framework is iOS 12,
-    # VideoToolbox/AVSampleBufferDisplayLayer older still. The floor was set
-    # purely by SwiftUI's two-parameter `onChange`, now backported.
+    # See issue #72 for further details.
     deploymentTarget: "16.0"
     sources:
       - iOS

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -190,7 +190,7 @@ export default function App() {
             A true extended display, not a mirror: USB or WiFi, Retina-sharp, with touch and
             scroll. No subscription. No dongle. No account.
           </p>
-          <p className="meta">macOS 14+ &nbsp;·&nbsp; iPadOS 17+ &nbsp;·&nbsp; iOS 17+ &nbsp;·&nbsp; GPL-3.0</p>
+          <p className="meta">macOS 14+ &nbsp;·&nbsp; iPadOS 16+ &nbsp;·&nbsp; iOS 16+ &nbsp;·&nbsp; GPL-3.0</p>
         </div>
       </section>
 


### PR DESCRIPTION
Closes part of #72 — the iOS 16 step.

## What this does

Lowers `OpenSidecariOS` from `deploymentTarget: 17.0` to `16.0`, which revives the **iPad 5 (2017), iPad Pro 1st gen, iPhone 8 and iPhone X** — the population Apple left on the 16.7.x line. Three people in #72 (@Hugh0306, @Keox35, @doccstat) are on 16.7.16 specifically and have volunteered to test.

## Why it's this small

The research in #72 holds up: **the streaming pipeline was never the constraint.** `Network.framework` is iOS 12, `AVSampleBufferDisplayLayer`/`VideoToolbox` older still, the Metal path 10.3. The entire iOS 17 floor came from four two-parameter `onChange(of:) { old, new in }` closures in `iOS/OpenSidecarPhoneApp.swift` — and all four discarded the old value, so each is a 1:1 rewrite to the single-parameter form (iOS 14+):

| Site | Value observed |
|---|---|
| `:94` | `geo.size` (rotation → `setOrientation`) |
| `:129` | `scenePhase` |
| `:159` | `receiver.connected` (retires the onboarding hint) |
| `:599` | `deviceName` |

**No transport, decoder or renderer changes.**

### No availability shim needed

The single-parameter `onChange` is deprecated on 17+, so I expected to need an `#available`-branching helper to keep the build warning-free. It turns out the compiler only emits that deprecation warning when the deployment target is itself ≥ 17 — at 16.0 it's silent. I verified this both ways before dropping the shim, so this is the whole change rather than the change plus scaffolding.

## Verification

Compiled against the iOS 26.5 SDK (Xcode 26.6):

- Type-check at `arm64-apple-ios16.0` — **0 errors, 0 warnings**
- Optimized whole-module codegen (`-O -wmo`) — **0 errors, 0 warnings**, `minos 16.0` in the resulting object
- No `#available` / `systemVersion` gates exist anywhere in `iOS/` or `Shared/`, so the compiler's availability check is complete coverage rather than partial
- SDK `MinimumDeploymentTarget` is 12.0, so Xcode 26 has no objection to a 16.0 target

**Not yet smoke-tested on a real 16.x device** — I don't have one. This is the thing worth confirming before release; TestFlight's own minimum is iOS 16.0, so the 16.7.16 testers in #72 can be reached directly by a beta build.

## Docs

Corrects the stale `iPadOS 17+` / `iOS 17+` strings in `src/App.tsx` (hero meta line) and `index.html` (schema.org `operatingSystem`), and documents the requirement in the README's iPhone app section, naming the devices it revives.

## On the performance caveat from #72

The A8/A8X worry in that thread applies to the **iOS 15** tier, not this one. The oldest devices unlocked here are A9/A9X (iPad 5, iPad Pro 1), which handle 2048×1536 hardware H.264 decode comfortably. No adaptive quality cap looks necessary for 16.

## What's left for iOS 15 (not in this PR)

For reference, I ran the same type-check at `ios15.0`: **30 errors**, from `NavigationStack`, `ViewThatFits`, `LabeledContent`, `persistentSystemOverlays`, and the `Layout`/`ProposedViewSize` protocol behind `FlowLayout` — matching the manual audit in #72. That's a genuine SwiftUI backport rather than a one-line change, so it's left as a separate step. Note it would not help @bwagner's iPad Air 2 on 15.8.8 reach a build *via TestFlight*, since TestFlight itself requires 16.0 — that tier needs a sideloaded build either way.
