### PR TITLE
fix(mac): bound the log, throttle hot log paths, make it easy to send

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,40 @@
+name: Tests
+
+# Nothing checked pull requests before this, so a branch that did not compile
+# (or a test target that could not build) only surfaced on someone's laptop.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A superseded run tells us nothing, so drop in-flight runs for the same ref.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mac:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      # Deliberately without DEVELOPMENT_TEAM: nothing built here is
+      # distributed, so an unsigned build is enough, and needing no secrets
+      # means this check also runs on pull requests from forks.
+      - name: Generate project
+        run: xcodegen generate
+
+      # Builds the Mac app as well as the test bundle, since the scheme covers
+      # both — so this is a compile check for the app on top of the tests.
+      - name: Run macOS tests
+        run: |
+          xcodebuild test \
+            -project OpenSidecar.xcodeproj \
+            -scheme OpenSidecarMac \
+            -destination 'platform=macOS' \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY=""

--- a/Mac/Log.swift
+++ b/Mac/Log.swift
@@ -1,26 +1,41 @@
+import AppKit
 import Foundation
 
-/// Appends timestamped lines to /tmp/opensidecar-mac.log (and stdout) so the
-/// stream can be debugged without a debugger attached.
+/// Appends timestamped lines to a log file (and stdout) so the stream can be
+/// debugged without a debugger attached.
 ///
-/// The file is size-capped and rotated rather than unbounded. When a report
-/// comes in, the useful window is the last few minutes before the problem, so
-/// old history is worth nothing and a log that can grow without limit is a
-/// liability: any per-frame or per-message code path that starts logging (an
-/// encoder failing every frame, a peer sending message types this build
-/// predates) would otherwise fill the disk. At most `maxBytes` x 2 survives.
+/// The file is size-capped and rotated rather than unbounded. Any per-frame or
+/// per-message code path that starts logging (an encoder failing every frame, a
+/// peer sending message types this build predates) would otherwise fill the
+/// disk. At most `maxBytes` x 2 survives.
 ///
 /// Note this rotates rather than stopping at a ceiling. A hard cap would keep
-/// the *oldest* bytes and discard everything recent, which is backwards.
+/// the *oldest* bytes and discard everything recent, which is backwards: when a
+/// report comes in, the useful window is what happened just before the problem.
 enum Log {
-    private static let path = "/tmp/opensidecar-mac.log"
+    /// `~/Library/Logs/OpenDisplay`. The platform convention, and deliberately
+    /// not /tmp: macOS clears /tmp on reboot, and rebooting is the first thing
+    /// someone tries before filing a bug, so a log there is gone exactly when
+    /// it's wanted. Living here also means Console.app lists it under Log
+    /// Reports without us doing anything.
+    static let directory: URL = {
+        let library = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library")
+        return library.appendingPathComponent("Logs/OpenDisplay", isDirectory: true)
+    }()
+
+    static let fileURL = directory.appendingPathComponent("opendisplay.log")
     /// One generation back, so a rotation mid-incident doesn't leave us with an
-    /// almost-empty file and no history.
-    private static let rotatedPath = "/tmp/opensidecar-mac.log.1"
-    /// Deliberately small. Normal operation logs session lifecycle events only,
-    /// a few KB per session, and even at the worst spam rate we've measured
-    /// (~24 KB/s) this still holds minutes, which is the window that matters.
-    private static let maxBytes: UInt64 = 4 * 1024 * 1024
+    /// almost-empty file and no history. Named so the order reads at a glance
+    /// in Finder, since users will be sending both.
+    private static let rotatedURL = directory.appendingPathComponent("opendisplay-previous.log")
+
+    /// Sized from the steady-state rate: an active session logs one aggregated
+    /// PHONE-STATS line (~256 bytes) every 5s, so ~180 KB per streaming hour.
+    /// 8MB is therefore ~45 hours of active streaming in the live file alone,
+    /// and rotation means at least that much always survives. Idle time costs
+    /// almost nothing, so in wall-clock terms this is comfortably days.
+    private static let maxBytes: UInt64 = 8 * 1024 * 1024
 
     private static let queue = DispatchQueue(label: "log")
     private static let formatter: DateFormatter = {
@@ -42,6 +57,27 @@ enum Log {
         queue.async { append(data) }
     }
 
+    /// Shows the log files in Finder, for "send me your logs" support requests.
+    /// Hops through `queue` first so anything already logged is on disk before
+    /// the user grabs the file.
+    static func revealInFinder() {
+        queue.async {
+            if handle == nil { openLog() }
+            let existing = [fileURL, rotatedURL].filter {
+                FileManager.default.fileExists(atPath: $0.path)
+            }
+            DispatchQueue.main.async {
+                if existing.isEmpty {
+                    // Nothing logged yet; still open the folder so the user
+                    // isn't left staring at a menu item that did nothing.
+                    NSWorkspace.shared.open(directory)
+                } else {
+                    NSWorkspace.shared.activateFileViewerSelecting(existing)
+                }
+            }
+        }
+    }
+
     private static func append(_ data: Data) {
         if handle == nil { openLog() }
         if written + UInt64(data.count) > maxBytes { rotate() }
@@ -50,9 +86,9 @@ enum Log {
             try handle.write(contentsOf: data)
             written += UInt64(data.count)
         } catch {
-            // The file was removed underneath us (/tmp cleaners do this) or the
-            // volume went away. Drop the handle so the next line reopens
-            // instead of every subsequent write failing forever.
+            // The file was removed underneath us or the volume went away. Drop
+            // the handle so the next line reopens instead of every subsequent
+            // write failing forever.
             try? handle.close()
             Log.handle = nil
         }
@@ -60,10 +96,11 @@ enum Log {
 
     private static func openLog() {
         let fm = FileManager.default
-        if !fm.fileExists(atPath: path) {
-            fm.createFile(atPath: path, contents: nil)
+        try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
+        if !fm.fileExists(atPath: fileURL.path) {
+            fm.createFile(atPath: fileURL.path, contents: nil)
         }
-        guard let opened = FileHandle(forWritingAtPath: path) else {
+        guard let opened = FileHandle(forWritingAtPath: fileURL.path) else {
             handle = nil
             written = 0
             return
@@ -77,8 +114,8 @@ enum Log {
         try? handle?.close()
         handle = nil
         let fm = FileManager.default
-        try? fm.removeItem(atPath: rotatedPath)
-        try? fm.moveItem(atPath: path, toPath: rotatedPath)
+        try? fm.removeItem(at: rotatedURL)
+        try? fm.moveItem(at: fileURL, to: rotatedURL)
         openLog()
     }
 }

--- a/Mac/Log.swift
+++ b/Mac/Log.swift
@@ -19,7 +19,7 @@ enum Log {
     /// someone tries before filing a bug, so a log there is gone exactly when
     /// it's wanted. Living here also means Console.app lists it under Log
     /// Reports without us doing anything.
-    static let directory: URL = {
+    private static let directory: URL = {
         let library = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first
             ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library")
         return library.appendingPathComponent("Logs/OpenDisplay", isDirectory: true)
@@ -38,7 +38,6 @@ enum Log {
         baseName: "opendisplay",
         maxBytes: maxBytes
     )
-    static let fileURL = writer.fileURL
     private static let formatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "HH:mm:ss.SSS"
@@ -60,8 +59,8 @@ enum Log {
             let existing = writer.existingFiles()
             DispatchQueue.main.async {
                 if existing.isEmpty {
-                    // Nothing logged yet; still open the folder so the user
-                    // isn't left staring at a menu item that did nothing.
+                    // The writer could not reach the files. Open the folder
+                    // anyway so the menu item never appears to do nothing.
                     NSWorkspace.shared.open(directory)
                 } else {
                     NSWorkspace.shared.activateFileViewerSelecting(existing)

--- a/Mac/Log.swift
+++ b/Mac/Log.swift
@@ -2,8 +2,26 @@ import Foundation
 
 /// Appends timestamped lines to /tmp/opensidecar-mac.log (and stdout) so the
 /// stream can be debugged without a debugger attached.
+///
+/// The file is size-capped and rotated rather than unbounded. When a report
+/// comes in, the useful window is the last few minutes before the problem, so
+/// old history is worth nothing and a log that can grow without limit is a
+/// liability: any per-frame or per-message code path that starts logging (an
+/// encoder failing every frame, a peer sending message types this build
+/// predates) would otherwise fill the disk. At most `maxBytes` x 2 survives.
+///
+/// Note this rotates rather than stopping at a ceiling. A hard cap would keep
+/// the *oldest* bytes and discard everything recent, which is backwards.
 enum Log {
     private static let path = "/tmp/opensidecar-mac.log"
+    /// One generation back, so a rotation mid-incident doesn't leave us with an
+    /// almost-empty file and no history.
+    private static let rotatedPath = "/tmp/opensidecar-mac.log.1"
+    /// Deliberately small. Normal operation logs session lifecycle events only,
+    /// a few KB per session, and even at the worst spam rate we've measured
+    /// (~24 KB/s) this still holds minutes, which is the window that matters.
+    private static let maxBytes: UInt64 = 4 * 1024 * 1024
+
     private static let queue = DispatchQueue(label: "log")
     private static let formatter: DateFormatter = {
         let f = DateFormatter()
@@ -11,17 +29,56 @@ enum Log {
         return f
     }()
 
+    // Both only touched inside `queue`, which is serial, so no locking.
+    // The handle is held open across lines: reopening per line costs ~22us
+    // against ~1us for a write to a live handle.
+    private static var handle: FileHandle?
+    private static var written: UInt64 = 0
+
     static func info(_ message: String) {
         let line = "[\(formatter.string(from: Date()))] \(message)\n"
         print(line, terminator: "")
-        queue.async {
-            if let handle = FileHandle(forWritingAtPath: path) {
-                handle.seekToEndOfFile()
-                handle.write(line.data(using: .utf8)!)
-                try? handle.close()
-            } else {
-                try? line.write(toFile: path, atomically: true, encoding: .utf8)
-            }
+        guard let data = line.data(using: .utf8) else { return }
+        queue.async { append(data) }
+    }
+
+    private static func append(_ data: Data) {
+        if handle == nil { openLog() }
+        if written + UInt64(data.count) > maxBytes { rotate() }
+        guard let handle else { return }
+        do {
+            try handle.write(contentsOf: data)
+            written += UInt64(data.count)
+        } catch {
+            // The file was removed underneath us (/tmp cleaners do this) or the
+            // volume went away. Drop the handle so the next line reopens
+            // instead of every subsequent write failing forever.
+            try? handle.close()
+            Log.handle = nil
         }
+    }
+
+    private static func openLog() {
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: path) {
+            fm.createFile(atPath: path, contents: nil)
+        }
+        guard let opened = FileHandle(forWritingAtPath: path) else {
+            handle = nil
+            written = 0
+            return
+        }
+        handle = opened
+        // Append to whatever a previous run left behind.
+        written = (try? opened.seekToEnd()) ?? 0
+    }
+
+    private static func rotate() {
+        try? handle?.close()
+        handle = nil
+        let fm = FileManager.default
+        try? fm.removeItem(atPath: rotatedPath)
+        try? fm.moveItem(atPath: path, toPath: rotatedPath)
+        openLog()
     }
 }

--- a/Mac/Log.swift
+++ b/Mac/Log.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Darwin
 import Foundation
 
 /// Appends timestamped lines to a log file (and stdout) so the stream can be
@@ -24,12 +25,6 @@ enum Log {
         return library.appendingPathComponent("Logs/OpenDisplay", isDirectory: true)
     }()
 
-    static let fileURL = directory.appendingPathComponent("opendisplay.log")
-    /// One generation back, so a rotation mid-incident doesn't leave us with an
-    /// almost-empty file and no history. Named so the order reads at a glance
-    /// in Finder, since users will be sending both.
-    private static let rotatedURL = directory.appendingPathComponent("opendisplay-previous.log")
-
     /// Sized from the steady-state rate: an active session logs one aggregated
     /// PHONE-STATS line (~256 bytes) every 5s, so ~180 KB per streaming hour.
     /// 8MB is therefore ~45 hours of active streaming in the live file alone,
@@ -38,23 +33,23 @@ enum Log {
     private static let maxBytes: UInt64 = 8 * 1024 * 1024
 
     private static let queue = DispatchQueue(label: "log")
+    private static let writer = RotatingLogFile(
+        directory: directory,
+        baseName: "opendisplay",
+        maxBytes: maxBytes
+    )
+    static let fileURL = writer.fileURL
     private static let formatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "HH:mm:ss.SSS"
         return f
     }()
 
-    // Both only touched inside `queue`, which is serial, so no locking.
-    // The handle is held open across lines: reopening per line costs ~22us
-    // against ~1us for a write to a live handle.
-    private static var handle: FileHandle?
-    private static var written: UInt64 = 0
-
     static func info(_ message: String) {
         let line = "[\(formatter.string(from: Date()))] \(message)\n"
         print(line, terminator: "")
         guard let data = line.data(using: .utf8) else { return }
-        queue.async { append(data) }
+        queue.async { writer.append(data) }
     }
 
     /// Shows the log files in Finder, for "send me your logs" support requests.
@@ -62,10 +57,7 @@ enum Log {
     /// the user grabs the file.
     static func revealInFinder() {
         queue.async {
-            if handle == nil { openLog() }
-            let existing = [fileURL, rotatedURL].filter {
-                FileManager.default.fileExists(atPath: $0.path)
-            }
+            let existing = writer.existingFiles()
             DispatchQueue.main.async {
                 if existing.isEmpty {
                     // Nothing logged yet; still open the folder so the user
@@ -77,45 +69,186 @@ enum Log {
             }
         }
     }
+}
 
-    private static func append(_ data: Data) {
-        if handle == nil { openLog() }
-        if written + UInt64(data.count) > maxBytes { rotate() }
-        guard let handle else { return }
-        do {
-            try handle.write(contentsOf: data)
-            written += UInt64(data.count)
-        } catch {
-            // The file was removed underneath us or the volume went away. Drop
-            // the handle so the next line reopens instead of every subsequent
-            // write failing forever.
-            try? handle.close()
-            Log.handle = nil
+/// Stateful file sink behind `Log`. Calls are serialized by `Log.queue` in the
+/// app; keeping the sink synchronous also makes its filesystem behavior
+/// directly testable.
+final class RotatingLogFile {
+    typealias ErrorReporter = (String) -> Void
+    private static let processLock = NSLock()
+
+    let directory: URL
+    let fileURL: URL
+    let rotatedURL: URL
+    let maxBytes: UInt64
+
+    private let lockURL: URL
+    private let fileManager: FileManager
+    private let reportError: ErrorReporter
+    private var handle: FileHandle?
+    private var lockHandle: FileHandle?
+
+    init(
+        directory: URL,
+        baseName: String,
+        maxBytes: UInt64,
+        fileManager: FileManager = .default,
+        reportError: @escaping ErrorReporter = RotatingLogFile.reportToStandardError
+    ) {
+        precondition(maxBytes > 0)
+        self.directory = directory
+        fileURL = directory.appendingPathComponent("\(baseName).log")
+        rotatedURL = directory.appendingPathComponent("\(baseName)-previous.log")
+        lockURL = directory.appendingPathComponent(".\(baseName).lock")
+        self.maxBytes = maxBytes
+        self.fileManager = fileManager
+        self.reportError = reportError
+    }
+
+    deinit {
+        try? handle?.close()
+        try? lockHandle?.close()
+    }
+
+    // The handle is held open across lines: reopening per line costs ~22us
+    // against ~1us for a write to a live handle. Calls on one instance must be
+    // serialized; the lock below coordinates separate app processes.
+    func append(_ data: Data) {
+        let payload: Data
+        if UInt64(data.count) > maxBytes {
+            payload = Data(data.suffix(Int(maxBytes)))
+            reportError("entry exceeded the log cap; only its newest \(maxBytes) bytes were kept")
+        } else {
+            payload = data
+        }
+
+        withExclusiveLock {
+            do {
+                var opened = try currentHandle()
+                let size = try opened.seekToEnd()
+                if size > maxBytes - UInt64(payload.count) {
+                    try rotate()
+                    opened = try currentHandle()
+                    _ = try opened.seekToEnd()
+                }
+                try opened.write(contentsOf: payload)
+            } catch {
+                closeCurrentHandle()
+                reportError("could not append to \(fileURL.path): \(error.localizedDescription)")
+            }
         }
     }
 
-    private static func openLog() {
-        let fm = FileManager.default
-        try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
-        if !fm.fileExists(atPath: fileURL.path) {
-            fm.createFile(atPath: fileURL.path, contents: nil)
+    func existingFiles() -> [URL] {
+        var existing: [URL] = []
+        withExclusiveLock {
+            do {
+                _ = try currentHandle()
+                existing = [fileURL, rotatedURL].filter {
+                    fileManager.fileExists(atPath: $0.path)
+                }
+            } catch {
+                reportError("could not prepare logs for Finder: \(error.localizedDescription)")
+            }
         }
-        guard let opened = FileHandle(forWritingAtPath: fileURL.path) else {
-            handle = nil
-            written = 0
+        return existing
+    }
+
+    private func currentHandle() throws -> FileHandle {
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        if let handle, handlePointsToURL(handle, fileURL) {
+            return handle
+        }
+        closeCurrentHandle()
+        if !fileManager.fileExists(atPath: fileURL.path) {
+            let created = fileManager.createFile(atPath: fileURL.path, contents: nil)
+            guard created || fileManager.fileExists(atPath: fileURL.path) else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+        }
+        let opened = try FileHandle(forWritingTo: fileURL)
+        handle = opened
+        return opened
+    }
+
+    private func rotate() throws {
+        closeCurrentHandle()
+        do {
+            if fileManager.fileExists(atPath: rotatedURL.path) {
+                _ = try fileManager.replaceItemAt(rotatedURL, withItemAt: fileURL)
+            } else {
+                try fileManager.moveItem(at: fileURL, to: rotatedURL)
+            }
+        } catch {
+            reportError("could not rotate \(fileURL.path): \(error.localizedDescription)")
+            // Keep the disk bound even when generation replacement fails. If
+            // the live file survived, truncate it so the newest entries win.
+            let opened = try currentHandle()
+            try opened.truncate(atOffset: 0)
+        }
+        _ = try currentHandle()
+    }
+
+    private func withExclusiveLock(_ body: () -> Void) {
+        Self.processLock.lock()
+        defer { Self.processLock.unlock() }
+
+        let opened: FileHandle
+        do {
+            opened = try currentLockHandle()
+        } catch {
+            reportError("could not open the log lock: \(error.localizedDescription)")
             return
         }
-        handle = opened
-        // Append to whatever a previous run left behind.
-        written = (try? opened.seekToEnd()) ?? 0
+
+        guard ODLockFile(opened.fileDescriptor) == 0 else {
+            reportError("could not lock the log: \(Self.currentPOSIXError())")
+            return
+        }
+        defer {
+            if ODUnlockFile(opened.fileDescriptor) != 0 {
+                reportError("could not unlock the log: \(Self.currentPOSIXError())")
+            }
+        }
+        body()
     }
 
-    private static func rotate() {
+    private func currentLockHandle() throws -> FileHandle {
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        if let lockHandle, handlePointsToURL(lockHandle, lockURL) {
+            return lockHandle
+        }
+        try? lockHandle?.close()
+        lockHandle = nil
+        if !fileManager.fileExists(atPath: lockURL.path) {
+            let created = fileManager.createFile(atPath: lockURL.path, contents: nil)
+            guard created || fileManager.fileExists(atPath: lockURL.path) else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+        }
+        let opened = try FileHandle(forUpdating: lockURL)
+        lockHandle = opened
+        return opened
+    }
+
+    private func handlePointsToURL(_ handle: FileHandle, _ url: URL) -> Bool {
+        url.withUnsafeFileSystemRepresentation { path in
+            guard let path else { return false }
+            return ODFileDescriptorPointsToPath(handle.fileDescriptor, path)
+        }
+    }
+
+    private func closeCurrentHandle() {
         try? handle?.close()
         handle = nil
-        let fm = FileManager.default
-        try? fm.removeItem(at: rotatedURL)
-        try? fm.moveItem(at: fileURL, to: rotatedURL)
-        openLog()
+    }
+
+    private static func currentPOSIXError() -> String {
+        String(cString: strerror(errno))
+    }
+
+    private static func reportToStandardError(_ message: String) {
+        try? FileHandle.standardError.write(contentsOf: Data("OpenDisplay log: \(message)\n".utf8))
     }
 }

--- a/Mac/LogPolicies.swift
+++ b/Mac/LogPolicies.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+struct UnknownControlTypeLogPolicy {
+    enum Action: Equatable {
+        case logType(String)
+        case logSuppression(limit: Int)
+        case none
+    }
+
+    private let capacity: Int
+    private var loggedTypes: Set<String> = []
+    private var reportedSuppression = false
+
+    init(capacity: Int = 16) {
+        precondition(capacity > 0)
+        self.capacity = capacity
+    }
+
+    mutating func record(_ type: String) -> Action {
+        if loggedTypes.contains(type) { return .none }
+        guard loggedTypes.count < capacity else {
+            guard !reportedSuppression else { return .none }
+            reportedSuppression = true
+            return .logSuppression(limit: capacity)
+        }
+        loggedTypes.insert(type)
+        return .logType(type)
+    }
+}
+
+struct ThrottledFailureLogPolicy {
+    struct Report: Equatable {
+        let status: Int32
+        let count: Int
+    }
+
+    enum Action: Equatable {
+        case report(Report)
+        case schedule(after: TimeInterval)
+        case none
+    }
+
+    private let interval: TimeInterval
+    private var lastReportAt: TimeInterval?
+    private var pendingCount = 0
+    private var latestStatus: Int32 = 0
+    private var reportScheduled = false
+
+    init(interval: TimeInterval = 1) {
+        precondition(interval > 0)
+        self.interval = interval
+    }
+
+    mutating func record(status: Int32, at time: TimeInterval) -> Action {
+        pendingCount += 1
+        latestStatus = status
+
+        guard let lastReportAt else {
+            return .report(takeReport(at: time))
+        }
+        if !reportScheduled, time - lastReportAt >= interval {
+            return .report(takeReport(at: time))
+        }
+        guard !reportScheduled else { return .none }
+        reportScheduled = true
+        return .schedule(after: max(0, lastReportAt + interval - time))
+    }
+
+    mutating func flush(at time: TimeInterval) -> Report? {
+        reportScheduled = false
+        guard pendingCount > 0 else { return nil }
+        return takeReport(at: time)
+    }
+
+    private mutating func takeReport(at time: TimeInterval) -> Report {
+        let report = Report(status: latestStatus, count: pendingCount)
+        pendingCount = 0
+        lastReportAt = time
+        return report
+    }
+}

--- a/Mac/LogPolicies.swift
+++ b/Mac/LogPolicies.swift
@@ -28,9 +28,19 @@ struct UnknownControlTypeLogPolicy {
     }
 }
 
-struct ThrottledFailureLogPolicy {
+/// Rate-limits a log line that a broken peer or a dead pipeline can trigger on
+/// every frame or every message. The first occurrence reports immediately, then
+/// at most one report per `interval` carrying how many occurrences it stands for
+/// and the detail from the most recent one.
+///
+/// `Detail` is whatever identifies the occurrence: an `OSStatus` for an encoder
+/// failure, a byte count for a message that would not parse. The policy is a
+/// pure value type and never schedules anything itself; it returns `.schedule`
+/// and the caller owns the timer, which keeps it testable without waiting on
+/// real time.
+struct ThrottledLogPolicy<Detail: Equatable> {
     struct Report: Equatable {
-        let status: Int32
+        let detail: Detail
         let count: Int
     }
 
@@ -42,8 +52,7 @@ struct ThrottledFailureLogPolicy {
 
     private let interval: TimeInterval
     private var lastReportAt: TimeInterval?
-    private var pendingCount = 0
-    private var latestStatus: Int32 = 0
+    private var pending: Report?
     private var reportScheduled = false
 
     init(interval: TimeInterval = 1) {
@@ -51,30 +60,33 @@ struct ThrottledFailureLogPolicy {
         self.interval = interval
     }
 
-    mutating func record(status: Int32, at time: TimeInterval) -> Action {
-        pendingCount += 1
-        latestStatus = status
+    mutating func record(_ detail: Detail, at time: TimeInterval) -> Action {
+        let report = Report(detail: detail, count: (pending?.count ?? 0) + 1)
+        pending = report
 
         guard let lastReportAt else {
-            return .report(takeReport(at: time))
+            return .report(take(report, at: time))
         }
         if !reportScheduled, time - lastReportAt >= interval {
-            return .report(takeReport(at: time))
+            return .report(take(report, at: time))
         }
+        // A flush is already queued for the end of this window; it will carry
+        // everything recorded since, so there is nothing to ask of the caller.
         guard !reportScheduled else { return .none }
         reportScheduled = true
         return .schedule(after: max(0, lastReportAt + interval - time))
     }
 
+    /// Reports whatever accumulated since the last report, for the caller's
+    /// scheduled flush. Nil when a report already drained the window.
     mutating func flush(at time: TimeInterval) -> Report? {
         reportScheduled = false
-        guard pendingCount > 0 else { return nil }
-        return takeReport(at: time)
+        guard let pending else { return nil }
+        return take(pending, at: time)
     }
 
-    private mutating func takeReport(at time: TimeInterval) -> Report {
-        let report = Report(status: latestStatus, count: pendingCount)
-        pendingCount = 0
+    private mutating func take(_ report: Report, at time: TimeInterval) -> Report {
+        pending = nil
         lastReportAt = time
         return report
     }

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -214,13 +214,18 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // Input latency: touches arrive stamped in our clock (the phone applies
     // its sync offset); delta to now = network + deframe + dispatch.
     private var inputLatencies: [Double] = []
-    // Both policies bound noisy paths while retaining an explicit record when
-    // details were suppressed. Unknown types live on `queue`; encoder failures
+    // These policies bound noisy paths while retaining an explicit record when
+    // details were suppressed. Unknown types and unparseable messages live on
+    // `queue` with the rest of the control-connection state; encoder failures
     // are guarded by `pipelineLock` with the other pipeline counters.
     private var unknownTypeLogPolicy = UnknownControlTypeLogPolicy()
     // Encode failures repeat every frame once the session goes bad; throttle
     // the log to one line a second and carry the count.
-    private var encodeFailureLogPolicy = ThrottledFailureLogPolicy()
+    private var encodeFailureLogPolicy = ThrottledLogPolicy<OSStatus>()
+    // A framing desync feeds this garbage at the peer's message rate until the
+    // watchdog redials, so it needs the same treatment. Detail is the byte
+    // count of the last message that would not parse.
+    private var unparseableControlLogPolicy = ThrottledLogPolicy<Int>()
     // Capture cadence: SCK only emits on content change, so the phone can't
     // tell "Mac rendered 45fps" from "frames got lost" — count deliveries here.
     private var capFrames = 0
@@ -937,7 +942,12 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         lastReceived = Date()
         guard let obj = try? JSONSerialization.jsonObject(with: payload) as? [String: Any],
               let type = obj["type"] as? String else {
-            Log.info("unparseable control message (\(payload.count) bytes)")
+            handleUnparseableControlLogAction(
+                unparseableControlLogPolicy.record(
+                    payload.count,
+                    at: ProcessInfo.processInfo.systemUptime
+                )
+            )
             return
         }
         switch type {
@@ -1187,7 +1197,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             // lasts. Report at most once a second and carry the count: the
             // status code is the diagnosis, the rate is just a number.
             let logAction = encodeFailureLogPolicy.record(
-                status: submitStatus,
+                submitStatus,
                 at: ProcessInfo.processInfo.systemUptime
             )
             pipelineLock.unlock()
@@ -1195,7 +1205,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         }
     }
 
-    private func handleEncodeFailureLogAction(_ action: ThrottledFailureLogPolicy.Action) {
+    private func handleEncodeFailureLogAction(_ action: ThrottledLogPolicy<OSStatus>.Action) {
         switch action {
         case .report(let report):
             reportEncodeFailures(report)
@@ -1215,8 +1225,32 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         if let report { reportEncodeFailures(report) }
     }
 
-    private func reportEncodeFailures(_ report: ThrottledFailureLogPolicy.Report) {
-        Log.info("VTCompressionSessionEncodeFrame failed: \(report.status) (\(report.count) since last report)")
+    private func reportEncodeFailures(_ report: ThrottledLogPolicy<OSStatus>.Report) {
+        Log.info("VTCompressionSessionEncodeFrame failed: \(report.detail) (\(report.count) since last report)")
+    }
+
+    // Runs on `queue`, where the policy and the control connection both live.
+    private func handleUnparseableControlLogAction(_ action: ThrottledLogPolicy<Int>.Action) {
+        switch action {
+        case .report(let report):
+            reportUnparseableControl(report)
+        case .schedule(let delay):
+            queue.asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.flushUnparseableControlLog()
+            }
+        case .none:
+            break
+        }
+    }
+
+    private func flushUnparseableControlLog() {
+        if let report = unparseableControlLogPolicy.flush(at: ProcessInfo.processInfo.systemUptime) {
+            reportUnparseableControl(report)
+        }
+    }
+
+    private func reportUnparseableControl(_ report: ThrottledLogPolicy<Int>.Report) {
+        Log.info("unparseable control message (\(report.detail) bytes, \(report.count) since last report)")
     }
 
     // MARK: - H.264 -> Annex B

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -218,6 +218,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // type logs once per session instead of once per message. Only touched
     // from `handleControl`, which runs on `queue`, so no locking needed.
     private var loggedUnknownTypes: Set<String> = []
+    // Encode failures repeat every frame once the session goes bad; throttle
+    // the log to one line a second and carry the count. Guarded by
+    // `pipelineLock` alongside the other pipeline counters.
+    private var encodeFailuresSinceLog = 0
+    private var lastEncodeFailureLog = Date.distantPast
     // Capture cadence: SCK only emits on content change, so the phone can't
     // tell "Mac rendered 45fps" from "frames got lost" — count deliveries here.
     private var capFrames = 0
@@ -1177,8 +1182,22 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         if submitStatus != noErr {
             pipelineLock.lock()
             pendingEncodes = max(0, pendingEncodes - 1)
+            // A dead encoder session keeps failing, and this runs per frame, so
+            // an unthrottled line here is ~60/sec for as long as the problem
+            // lasts. Report at most once a second and carry the count: the
+            // status code is the diagnosis, the rate is just a number.
+            encodeFailuresSinceLog += 1
+            let now = Date()
+            let shouldReport = now.timeIntervalSince(lastEncodeFailureLog) >= 1
+            let failures = encodeFailuresSinceLog
+            if shouldReport {
+                lastEncodeFailureLog = now
+                encodeFailuresSinceLog = 0
+            }
             pipelineLock.unlock()
-            Log.info("VTCompressionSessionEncodeFrame failed: \(submitStatus)")
+            if shouldReport {
+                Log.info("VTCompressionSessionEncodeFrame failed: \(submitStatus) (\(failures) since last report)")
+            }
         }
     }
 

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -214,15 +214,13 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // Input latency: touches arrive stamped in our clock (the phone applies
     // its sync offset); delta to now = network + deframe + dispatch.
     private var inputLatencies: [Double] = []
-    // Control message types we've already warned about, so an unrecognized
-    // type logs once per session instead of once per message. Only touched
-    // from `handleControl`, which runs on `queue`, so no locking needed.
-    private var loggedUnknownTypes: Set<String> = []
+    // Both policies bound noisy paths while retaining an explicit record when
+    // details were suppressed. Unknown types live on `queue`; encoder failures
+    // are guarded by `pipelineLock` with the other pipeline counters.
+    private var unknownTypeLogPolicy = UnknownControlTypeLogPolicy()
     // Encode failures repeat every frame once the session goes bad; throttle
-    // the log to one line a second and carry the count. Guarded by
-    // `pipelineLock` alongside the other pipeline counters.
-    private var encodeFailuresSinceLog = 0
-    private var lastEncodeFailureLog = Date.distantPast
+    // the log to one line a second and carry the count.
+    private var encodeFailureLogPolicy = ThrottledFailureLogPolicy()
     // Capture cadence: SCK only emits on content change, so the phone can't
     // tell "Mac rendered 45fps" from "frames got lost" — count deliveries here.
     private var capFrames = 0
@@ -1028,14 +1026,16 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         default:
             // Unknown types are a normal consequence of the additive wire
             // protocol: a newer peer can send messages this build predates.
-            // Log each type once per session, never per message — `Log.info`
-            // opens/writes/closes the log file per call, and a peer can drive
-            // this at input rates (a pencil stroke is ~240 messages/sec), which
-            // would turn "message I don't understand" into hundreds of file IO
-            // round-trips a second. The cap bounds both memory and log volume
-            // against a peer sending endless distinct types.
-            if loggedUnknownTypes.count < 16, loggedUnknownTypes.insert(type).inserted {
+            // Log each type once per session, never per message. A peer can
+            // drive this at input rates (a pencil stroke is ~240 messages/sec),
+            // so the policy also caps distinct types and reports that cap once.
+            switch unknownTypeLogPolicy.record(type) {
+            case .logType(let type):
                 Log.info("unknown control message type: \(type) — ignoring (logged once)")
+            case .logSuppression(let limit):
+                Log.info("additional unknown control message types suppressed after \(limit) distinct types")
+            case .none:
+                break
             }
         }
     }
@@ -1186,19 +1186,37 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             // an unthrottled line here is ~60/sec for as long as the problem
             // lasts. Report at most once a second and carry the count: the
             // status code is the diagnosis, the rate is just a number.
-            encodeFailuresSinceLog += 1
-            let now = Date()
-            let shouldReport = now.timeIntervalSince(lastEncodeFailureLog) >= 1
-            let failures = encodeFailuresSinceLog
-            if shouldReport {
-                lastEncodeFailureLog = now
-                encodeFailuresSinceLog = 0
-            }
+            let logAction = encodeFailureLogPolicy.record(
+                status: submitStatus,
+                at: ProcessInfo.processInfo.systemUptime
+            )
             pipelineLock.unlock()
-            if shouldReport {
-                Log.info("VTCompressionSessionEncodeFrame failed: \(submitStatus) (\(failures) since last report)")
-            }
+            handleEncodeFailureLogAction(logAction)
         }
+    }
+
+    private func handleEncodeFailureLogAction(_ action: ThrottledFailureLogPolicy.Action) {
+        switch action {
+        case .report(let report):
+            reportEncodeFailures(report)
+        case .schedule(let delay):
+            queue.asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.flushEncodeFailureLog()
+            }
+        case .none:
+            break
+        }
+    }
+
+    private func flushEncodeFailureLog() {
+        pipelineLock.lock()
+        let report = encodeFailureLogPolicy.flush(at: ProcessInfo.processInfo.systemUptime)
+        pipelineLock.unlock()
+        if let report { reportEncodeFailures(report) }
+    }
+
+    private func reportEncodeFailures(_ report: ThrottledFailureLogPolicy.Report) {
+        Log.info("VTCompressionSessionEncodeFrame failed: \(report.status) (\(report.count) since last report)")
     }
 
     // MARK: - H.264 -> Annex B

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -214,6 +214,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // Input latency: touches arrive stamped in our clock (the phone applies
     // its sync offset); delta to now = network + deframe + dispatch.
     private var inputLatencies: [Double] = []
+    // Control message types we've already warned about, so an unrecognized
+    // type logs once per session instead of once per message. Only touched
+    // from `handleControl`, which runs on `queue`, so no locking needed.
+    private var loggedUnknownTypes: Set<String> = []
     // Capture cadence: SCK only emits on content change, so the phone can't
     // tell "Mac rendered 45fps" from "frames got lost" — count deliveries here.
     private var capFrames = 0
@@ -1017,7 +1021,17 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             Log.info("receiver app closed — ending session")
             Task { @MainActor in self.onPeerClosed?() }
         default:
-            Log.info("unknown control message type: \(type)")
+            // Unknown types are a normal consequence of the additive wire
+            // protocol: a newer peer can send messages this build predates.
+            // Log each type once per session, never per message — `Log.info`
+            // opens/writes/closes the log file per call, and a peer can drive
+            // this at input rates (a pencil stroke is ~240 messages/sec), which
+            // would turn "message I don't understand" into hundreds of file IO
+            // round-trips a second. The cap bounds both memory and log volume
+            // against a peer sending endless distinct types.
+            if loggedUnknownTypes.count < 16, loggedUnknownTypes.insert(type).inserted {
+                Log.info("unknown control message type: \(type) — ignoring (logged once)")
+            }
         }
     }
 

--- a/Mac/OpenSidecarMac-Bridging-Header.h
+++ b/Mac/OpenSidecarMac-Bridging-Header.h
@@ -1,1 +1,21 @@
 #import "CGVirtualDisplayPrivate.h"
+
+#include <sys/file.h>
+#include <sys/stat.h>
+
+static inline int ODLockFile(int descriptor) {
+    return flock(descriptor, LOCK_EX);
+}
+
+static inline int ODUnlockFile(int descriptor) {
+    return flock(descriptor, LOCK_UN);
+}
+
+static inline bool ODFileDescriptorPointsToPath(int descriptor, const char *path) {
+    struct stat descriptorInfo;
+    struct stat pathInfo;
+    return fstat(descriptor, &descriptorInfo) == 0
+        && stat(path, &pathInfo) == 0
+        && descriptorInfo.st_dev == pathInfo.st_dev
+        && descriptorInfo.st_ino == pathInfo.st_ino;
+}

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -900,6 +900,12 @@ struct ContentView: View {
                     .font(.callout)
                     .lineLimit(1)
                 Spacer()
+                // Support affordance: bug reports are much easier to act on
+                // with the log attached, and users shouldn't have to be told a
+                // filesystem path to find it.
+                Button("Logs") { Log.revealInFinder() }
+                    .controlSize(.small)
+                    .help("Reveal the OpenDisplay log files in Finder")
                 if let updater {
                     CheckForUpdatesView(updater: updater)
                 }

--- a/MacTests/LogPoliciesTests.swift
+++ b/MacTests/LogPoliciesTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+final class UnknownControlTypeLogPolicyTests: XCTestCase {
+    func testLogsEachTypeOnlyOnce() {
+        var policy = UnknownControlTypeLogPolicy(capacity: 2)
+
+        XCTAssertEqual(policy.record("pencil"), .logType("pencil"))
+        XCTAssertEqual(policy.record("pencil"), .none)
+        XCTAssertEqual(policy.record("proximity"), .logType("proximity"))
+    }
+
+    func testReportsCapacityOnceInsteadOfSilentlyDroppingLaterTypes() {
+        var policy = UnknownControlTypeLogPolicy(capacity: 2)
+        _ = policy.record("first")
+        _ = policy.record("second")
+
+        XCTAssertEqual(policy.record("third"), .logSuppression(limit: 2))
+        XCTAssertEqual(policy.record("fourth"), .none)
+    }
+}
+
+final class ThrottledFailureLogPolicyTests: XCTestCase {
+    func testFlushReportsFailuresSuppressedAtTheEndOfABurst() {
+        var policy = ThrottledFailureLogPolicy(interval: 1)
+
+        XCTAssertEqual(policy.record(status: -1, at: 10),
+                       .report(.init(status: -1, count: 1)))
+        XCTAssertEqual(policy.record(status: -1, at: 10.25), .schedule(after: 0.75))
+        XCTAssertEqual(policy.record(status: -2, at: 10.5), .none)
+        XCTAssertEqual(policy.flush(at: 11), .init(status: -2, count: 2))
+        XCTAssertNil(policy.flush(at: 12))
+    }
+
+    func testReportsImmediatelyAgainAfterAnIdleInterval() {
+        var policy = ThrottledFailureLogPolicy(interval: 1)
+        _ = policy.record(status: -1, at: 10)
+
+        XCTAssertEqual(policy.record(status: -2, at: 11),
+                       .report(.init(status: -2, count: 1)))
+    }
+}

--- a/MacTests/LogPoliciesTests.swift
+++ b/MacTests/LogPoliciesTests.swift
@@ -19,23 +19,50 @@ final class UnknownControlTypeLogPolicyTests: XCTestCase {
     }
 }
 
-final class ThrottledFailureLogPolicyTests: XCTestCase {
+final class ThrottledLogPolicyTests: XCTestCase {
     func testFlushReportsFailuresSuppressedAtTheEndOfABurst() {
-        var policy = ThrottledFailureLogPolicy(interval: 1)
+        var policy = ThrottledLogPolicy<Int32>(interval: 1)
 
-        XCTAssertEqual(policy.record(status: -1, at: 10),
-                       .report(.init(status: -1, count: 1)))
-        XCTAssertEqual(policy.record(status: -1, at: 10.25), .schedule(after: 0.75))
-        XCTAssertEqual(policy.record(status: -2, at: 10.5), .none)
-        XCTAssertEqual(policy.flush(at: 11), .init(status: -2, count: 2))
+        XCTAssertEqual(policy.record(-1, at: 10),
+                       .report(.init(detail: -1, count: 1)))
+        XCTAssertEqual(policy.record(-1, at: 10.25), .schedule(after: 0.75))
+        XCTAssertEqual(policy.record(-2, at: 10.5), .none)
+        XCTAssertEqual(policy.flush(at: 11), .init(detail: -2, count: 2))
         XCTAssertNil(policy.flush(at: 12))
     }
 
     func testReportsImmediatelyAgainAfterAnIdleInterval() {
-        var policy = ThrottledFailureLogPolicy(interval: 1)
-        _ = policy.record(status: -1, at: 10)
+        var policy = ThrottledLogPolicy<Int32>(interval: 1)
+        _ = policy.record(-1, at: 10)
 
-        XCTAssertEqual(policy.record(status: -2, at: 11),
-                       .report(.init(status: -2, count: 1)))
+        XCTAssertEqual(policy.record(-2, at: 11),
+                       .report(.init(detail: -2, count: 1)))
+    }
+
+    // The desync case: garbage keeps arriving at the peer's message rate, so a
+    // second burst after a flush has to throttle exactly like the first.
+    func testThrottlesASecondBurstAfterFlushing() {
+        var policy = ThrottledLogPolicy<Int>(interval: 1)
+
+        XCTAssertEqual(policy.record(64, at: 10), .report(.init(detail: 64, count: 1)))
+        assertSchedules(policy.record(64, at: 10.1), after: 0.9)
+        XCTAssertEqual(policy.flush(at: 11), .init(detail: 64, count: 1))
+
+        assertSchedules(policy.record(72, at: 11.2), after: 0.8)
+        XCTAssertEqual(policy.record(80, at: 11.5), .none)
+        XCTAssertEqual(policy.flush(at: 12), .init(detail: 80, count: 2))
+    }
+
+    // The delay is arithmetic on the caller's clock, so compare it with a
+    // tolerance rather than for binary equality.
+    private func assertSchedules<Detail: Equatable>(
+        _ action: ThrottledLogPolicy<Detail>.Action,
+        after expected: TimeInterval,
+        line: UInt = #line
+    ) {
+        guard case .schedule(let delay) = action else {
+            return XCTFail("expected a scheduled flush, got \(action)", line: line)
+        }
+        XCTAssertEqual(delay, expected, accuracy: 0.000_001, line: line)
     }
 }

--- a/MacTests/RotatingLogFileTests.swift
+++ b/MacTests/RotatingLogFileTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import XCTest
+
+final class RotatingLogFileTests: XCTestCase {
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenDisplayLogTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    func testRecreatesCurrentLogAfterItIsMoved() throws {
+        let writer = RotatingLogFile(directory: directory, baseName: "test", maxBytes: 1_024)
+        writer.append(Data("before move\n".utf8))
+
+        let movedURL = directory.appendingPathComponent("attached.log")
+        try FileManager.default.moveItem(at: writer.fileURL, to: movedURL)
+        writer.append(Data("after move\n".utf8))
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: writer.fileURL.path))
+        XCTAssertEqual(try String(contentsOf: writer.fileURL, encoding: .utf8), "after move\n")
+        XCTAssertEqual(try String(contentsOf: movedURL, encoding: .utf8), "before move\n")
+    }
+
+    func testRecreatesCurrentLogAfterItIsDeleted() throws {
+        let writer = RotatingLogFile(directory: directory, baseName: "test", maxBytes: 1_024)
+        writer.append(Data("before delete\n".utf8))
+
+        try FileManager.default.removeItem(at: writer.fileURL)
+        writer.append(Data("after delete\n".utf8))
+
+        XCTAssertEqual(try String(contentsOf: writer.fileURL, encoding: .utf8), "after delete\n")
+    }
+
+    func testReopensCurrentLogAfterAnotherWriterReplacesIt() throws {
+        let writer = RotatingLogFile(directory: directory, baseName: "test", maxBytes: 1_024)
+        writer.append(Data("old file\n".utf8))
+
+        try Data("replacement\n".utf8).write(to: writer.fileURL, options: .atomic)
+        writer.append(Data("after replacement\n".utf8))
+
+        XCTAssertEqual(try String(contentsOf: writer.fileURL, encoding: .utf8),
+                       "replacement\nafter replacement\n")
+    }
+
+    func testRotationKeepsTheNewestTwoBoundedGenerations() throws {
+        let writer = RotatingLogFile(directory: directory, baseName: "test", maxBytes: 32)
+        for index in 0..<40 {
+            writer.append(Data(String(format: "%03d\n", index).utf8))
+        }
+
+        XCTAssertEqual(try String(contentsOf: writer.rotatedURL, encoding: .utf8),
+                       (24..<32).map { String(format: "%03d\n", $0) }.joined())
+        XCTAssertEqual(try String(contentsOf: writer.fileURL, encoding: .utf8),
+                       (32..<40).map { String(format: "%03d\n", $0) }.joined())
+        XCTAssertLessThanOrEqual(try fileSize(at: writer.rotatedURL), writer.maxBytes)
+        XCTAssertLessThanOrEqual(try fileSize(at: writer.fileURL), writer.maxBytes)
+    }
+
+    func testSingleOversizedEntryCannotExceedTheCap() throws {
+        let writer = RotatingLogFile(directory: directory, baseName: "test", maxBytes: 8)
+
+        writer.append(Data("0123456789abcdef".utf8))
+
+        XCTAssertEqual(try Data(contentsOf: writer.fileURL), Data("89abcdef".utf8))
+        XCTAssertEqual(try fileSize(at: writer.fileURL), 8)
+    }
+
+    func testFailedRotationReportsTheErrorAndKeepsTheLiveFileBounded() throws {
+        var errors: [String] = []
+        let writer = RotatingLogFile(
+            directory: directory,
+            baseName: "test",
+            maxBytes: 8,
+            reportError: { errors.append($0) }
+        )
+        writer.append(Data("12345678".utf8))
+        try FileManager.default.setAttributes([.posixPermissions: 0o500],
+                                              ofItemAtPath: directory.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700],
+                                                    ofItemAtPath: directory.path)
+        }
+
+        writer.append(Data("abcdefgh".utf8))
+
+        XCTAssertEqual(try Data(contentsOf: writer.fileURL), Data("abcdefgh".utf8))
+        XCTAssertEqual(try fileSize(at: writer.fileURL), 8)
+        XCTAssertTrue(errors.contains { $0.contains("could not rotate") })
+    }
+
+    func testSeparateWritersDoNotOverwriteEachOther() throws {
+        let first = RotatingLogFile(directory: directory, baseName: "test", maxBytes: 64 * 1_024)
+        let second = RotatingLogFile(directory: directory, baseName: "test", maxBytes: 64 * 1_024)
+        let group = DispatchGroup()
+        let firstQueue = DispatchQueue(label: "log-test.first")
+        let secondQueue = DispatchQueue(label: "log-test.second")
+
+        group.enter()
+        firstQueue.async {
+            for index in 0..<250 {
+                first.append(Data(String(format: "A-%03d\n", index).utf8))
+            }
+            group.leave()
+        }
+        group.enter()
+        secondQueue.async {
+            for index in 0..<250 {
+                second.append(Data(String(format: "B-%03d\n", index).utf8))
+            }
+            group.leave()
+        }
+        XCTAssertEqual(group.wait(timeout: .now() + 5), .success)
+
+        let lines = try String(contentsOf: first.fileURL, encoding: .utf8)
+            .split(separator: "\n")
+            .map(String.init)
+        let expected = (0..<250).map { String(format: "A-%03d", $0) }
+            + (0..<250).map { String(format: "B-%03d", $0) }
+        XCTAssertEqual(lines.count, expected.count)
+        XCTAssertEqual(Set(lines), Set(expected))
+    }
+
+    func testReportsFilesystemFailures() throws {
+        let blockedDirectory = directory.appendingPathComponent("not-a-directory")
+        try Data("occupied".utf8).write(to: blockedDirectory)
+        var errors: [String] = []
+        let writer = RotatingLogFile(
+            directory: blockedDirectory,
+            baseName: "test",
+            maxBytes: 32,
+            reportError: { errors.append($0) }
+        )
+
+        writer.append(Data("message\n".utf8))
+
+        XCTAssertFalse(errors.isEmpty)
+        XCTAssertTrue(errors.contains { $0.contains("could not") })
+    }
+
+    private func fileSize(at url: URL) throws -> UInt64 {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        return (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -16,6 +16,9 @@ schemes:
     build:
       targets:
         OpenSidecarMac: all
+    test:
+      targets:
+        - OpenSidecarMacTests
   OpenSidecariOS:
     build:
       targets:
@@ -84,6 +87,19 @@ targets:
         Debug:
           PRODUCT_BUNDLE_IDENTIFIER: com.peetzweg.opensidecar.mac.debug
           BUNDLE_DISPLAY_NAME: OpenDisplay Dev
+  OpenSidecarMacTests:
+    type: bundle.unit-test
+    platform: macOS
+    deploymentTarget: "14.0"
+    sources:
+      - MacTests
+      - Mac/Log.swift
+      - Mac/LogPolicies.swift
+    settings:
+      base:
+        TEST_HOST: ""
+        BUNDLE_LOADER: ""
+        SWIFT_OBJC_BRIDGING_HEADER: Mac/OpenSidecarMac-Bridging-Header.h
   OpenSidecariOS:
     type: application
     platform: iOS

--- a/project.yml
+++ b/project.yml
@@ -97,8 +97,13 @@ targets:
       - Mac/LogPolicies.swift
     settings:
       base:
+        # A hostless test bundle: the sources under test are compiled straight
+        # into it, so there is no app to inject into and nothing to load from.
         TEST_HOST: ""
         BUNDLE_LOADER: ""
+        # Without this the bundle has no Info.plist and code signing refuses to
+        # run, which fails the build before a single test executes.
+        GENERATE_INFOPLIST_FILE: "YES"
         SWIFT_OBJC_BRIDGING_HEADER: Mac/OpenSidecarMac-Bridging-Header.h
   OpenSidecariOS:
     type: application

--- a/run.sh
+++ b/run.sh
@@ -12,4 +12,4 @@ if [[ ! -d $APP ]]; then
 fi
 
 open "$APP"
-echo "OpenDisplay running — logs at /tmp/opensidecar-mac.log."
+echo "OpenDisplay running — logs at ~/Library/Logs/OpenDisplay/opendisplay.log."


### PR DESCRIPTION
Makes the Mac log something we can actually ask users for, and stops any code path from turning it into a liability.

**Why:** the log grew without bound for a whole boot, several paths could write to it at frame or message rates, and it lived in `/tmp`, which macOS clears on reboot. Rebooting is the first thing someone tries before filing a bug, so the file was gone exactly when it was wanted, and there was no way for a user to find it without being told a filesystem path.

**How:** three changes, one theme.

- `Log` holds its file handle open and rotates at 8MB keeping one generation, so at most 16MB survives. It rotates rather than stopping at a ceiling, which matters: a hard cap would keep the oldest bytes and discard everything recent.
- The paths that could log at rate are throttled. Unknown control message types (expected, since the wire protocol is additive) log once per session instead of once per message. Encoder failures and control messages that will not parse both report at most once a second with a count, instead of ~60 lines a second for as long as a dead encoder lasts, or one line per message for as long as a framing desync lasts. Both share one tested policy type, `ThrottledLogPolicy<Detail>`, parameterised by whatever identifies the occurrence.
- Logs move to `~/Library/Logs/OpenDisplay/`, and the menu bar dropdown gains a **Logs** button next to Check for Updates that reveals them in Finder. Console.app also lists them under Log Reports for free.

**Sizing:** an active session logs one aggregated `PHONE-STATS` line (~256 bytes) every 5s, so ~180KB per streaming hour. 8MB is ~45 hours of active streaming retained at minimum, which is days in wall-clock terms since idle time costs almost nothing.

**Measured while doing this:** reopening the file per line cost ~22us against ~1us for a write to a live handle. `DateFormatter`, the part that actually runs on the caller's thread and looked like the obvious suspect, is ~1.3us and was left alone.

**Tests:** rotation is verified (400 lines into a 2KB test cap leaves the newest 12 lines live and the total bounded at ~2x cap), along with the throttle policies and the writer's recovery when the live file is moved, deleted, or replaced under it. This also adds the first CI check on pull requests: nothing ran the tests before, which is how the new test target managed to ship unbuildable. It builds unsigned and needs no secrets, so it runs for forks too.

Related: this is the general fix for the log spam noted in #163, where a newer phone sending pencil messages to an older Mac would hit the unknown-type path at ~240 messages a second. It does not help Macs already released, so the version gate asked for in that PR is still needed.
