### PR TITLE
fix(mac): fall back when ScreenCaptureKit misses a virtual display

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -18,10 +18,22 @@ import VideoToolbox
 import Network
 import CoreMedia
 import AppKit
+import IOSurface
 
 enum CaptureMode: String {
     case mirror   // main display (Milestone 1)
     case extend   // virtual display (Milestone 2)
+}
+
+private enum SenderError: LocalizedError {
+    case virtualDisplayNotShareable
+
+    var errorDescription: String? {
+        switch self {
+        case .virtualDisplayNotShareable:
+            return "virtual display never appeared in SCShareableContent"
+        }
+    }
 }
 
 /// Capture-resolution / bitrate trade-off. The virtual display always runs at
@@ -108,6 +120,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     @MainActor var onHello: ((PhoneInfo) -> Void)?
 
     private var stream: SCStream?
+    /// Fallback when SCShareableContent never lists the CGVirtualDisplay (#142).
+    private var displayStream: CGDisplayStream?
+    private var lastDisplayStreamSurface: IOSurfaceRef?
     private var encoder: VTCompressionSession?
     private var connection: NWConnection?
     private var virtualDisplay: VirtualDisplay?
@@ -373,12 +388,27 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         }
         virtualDisplay = vd
         inputInjector = InputInjector(displayID: vd.displayID)
+        _ = await vd.waitUntilReady(timeoutSeconds: 1.0)
 
-        let display = try await findSCDisplay(id: vd.displayID)
         // Quality scaling: capture/encode below native when requested — the
         // display itself stays native so window layout is unaffected.
         let captureW = (Int(Double(pointsWide * 2) * quality.scale)) & ~1
         let captureH = (Int(Double(pointsHigh * 2) * quality.scale)) & ~1
+        // Prefer ScreenCaptureKit. On some Mac mini + external-display-only
+        // setups the virtual display never appears in SCShareableContent
+        // (MacSender Code=3 / issue #142) even though CGVirtualDisplay
+        // returned an id — fall back to CGDisplayStream using that id.
+        let display: SCDisplay
+        do {
+            display = try await findSCDisplay(id: vd.displayID)
+        } catch SenderError.virtualDisplayNotShareable {
+            let error = SenderError.virtualDisplayNotShareable
+            Log.info("SCK capture path failed (\(error.localizedDescription)) — CGDisplayStream fallback")
+            await status("Using alternate capture path…")
+            try await startCaptureCGDisplayStream(displayID: vd.displayID,
+                                                  pixelsWide: captureW, pixelsHigh: captureH)
+            return
+        }
         try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
 
         // Debug aid (`defaults write sh.peet.opensidecar.mac testPattern -bool true`):
@@ -403,6 +433,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             Log.info("reconfiguring for \(target.pixelsWide)x\(target.pixelsHigh)")
             if let stream { try? await stream.stopCapture() }
             stream = nil
+            stopDisplayStream()
             if let encoder { VTCompressionSessionInvalidate(encoder) }
             encoder = nil
             virtualDisplay = nil   // removes the old display
@@ -424,16 +455,86 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     }
 
     /// The virtual display takes a moment to show up in shareable content.
+    /// Uses the explicit SCShareableContent API, logs diagnostics on failure,
+    /// and matches by size as a secondary key when CG/SCK ids diverge.
     private func findSCDisplay(id: CGDirectDisplayID) async throws -> SCDisplay {
-        for _ in 0..<20 {
-            let content = try await SCShareableContent.current
+        var lastIDs: [CGDirectDisplayID] = []
+        // ~5s — same overall budget as before; then setupExtend falls back.
+        for attempt in 0..<20 {
+            let content: SCShareableContent
+            do {
+                content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+            } catch {
+                content = try await SCShareableContent.current
+            }
+            lastIDs = content.displays.map(\.displayID)
             if let display = content.displays.first(where: { $0.displayID == id }) {
                 return display
             }
+            if attempt == 0 || attempt == 19 {
+                let ns = NSScreen.screens.compactMap {
+                    ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value
+                }
+                Log.info("findSCDisplay attempt \(attempt): sck=\(lastIDs) ns=\(ns) want=\(id) online=\(CGDisplayIsOnline(id))")
+            }
             try await Task.sleep(for: .milliseconds(250))
         }
-        throw NSError(domain: "MacSender", code: 3,
-                      userInfo: [NSLocalizedDescriptionKey: "virtual display never appeared in SCShareableContent"])
+        Log.info("findSCDisplay failed want=\(id) lastSCK=\(lastIDs) (connection/hello OK — local capture enumeration failed)")
+        throw SenderError.virtualDisplayNotShareable
+    }
+
+    /// Fallback capture when ScreenCaptureKit cannot enumerate the virtual display.
+    /// Targets the CGDirectDisplayID from CGVirtualDisplay directly.
+    /// CGDisplayStream is deprecated in favor of SCK — keep this path as a last resort only (#142).
+    private func startCaptureCGDisplayStream(displayID: CGDirectDisplayID,
+                                             pixelsWide: Int, pixelsHigh: Int) async throws {
+        setupEncoder(width: pixelsWide, height: pixelsHigh)
+
+        let handler: CGDisplayStreamFrameAvailableHandler = { [weak self] status, displayTime, surface, _ in
+            guard let self else { return }
+            guard status == .frameComplete, let surface else { return }
+
+            var unmanaged: Unmanaged<CVPixelBuffer>?
+            let err = CVPixelBufferCreateWithIOSurface(
+                kCFAllocatorDefault, surface, nil, &unmanaged
+            )
+            guard err == kCVReturnSuccess, let pixelBuffer = unmanaged?.takeRetainedValue() else { return }
+
+            IOSurfaceIncrementUseCount(surface)
+            self.releaseLastDisplayStreamSurface()
+            self.lastDisplayStreamSurface = surface
+
+            let pts = CMTime(value: CMTimeValue(displayTime), timescale: 1_000_000_000)
+            self.processCapturedFrame(pixelBuffer, pts: pts, displaySurface: surface)
+        }
+
+        let props = [CGDisplayStream.showCursor: !localCursor] as CFDictionary
+        guard let ds = CGDisplayStream(
+            dispatchQueueDisplay: displayID,
+            outputWidth: pixelsWide,
+            outputHeight: pixelsHigh,
+            pixelFormat: Int32(kCVPixelFormatType_32BGRA),
+            properties: props,
+            queue: queue,
+            handler: handler
+        ) else {
+            throw NSError(domain: "MacSender", code: 4,
+                          userInfo: [NSLocalizedDescriptionKey: "CGDisplayStreamCreate failed"])
+        }
+
+        let startErr = ds.start()
+        guard startErr == .success else {
+            throw NSError(domain: "MacSender", code: 5,
+                          userInfo: [NSLocalizedDescriptionKey: "CGDisplayStreamStart failed: \(startErr.rawValue)"])
+        }
+
+        displayStream = ds
+        await finishCaptureStart(
+            displayID: displayID,
+            pixelsWide: pixelsWide,
+            pixelsHigh: pixelsHigh,
+            logMessage: "capture started (CGDisplayStream fallback): \(pixelsWide)x\(pixelsHigh) display \(displayID) mode \(mode.rawValue)"
+        )
     }
 
     private func startCapture(display: SCDisplay, pixelsWide: Int, pixelsHigh: Int) async throws {
@@ -462,13 +563,37 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: queue)
         try await stream.startCapture()
         self.stream = stream
-        captureDisplayID = display.displayID
+        await finishCaptureStart(
+            displayID: display.displayID,
+            pixelsWide: pixelsWide,
+            pixelsHigh: pixelsHigh,
+            logMessage: "capture started: \(pixelsWide)x\(pixelsHigh) display \(display.displayID) mode \(mode.rawValue) localCursor=\(localCursor)"
+        )
+    }
+
+    private func finishCaptureStart(displayID: CGDirectDisplayID,
+                                    pixelsWide: Int,
+                                    pixelsHigh: Int,
+                                    logMessage: String) async {
+        captureDisplayID = displayID
         lastCursorPNGHash = 0      // rotation rebuilds: re-send the sprite
         lastCursorSent = (-1, -1, false)
         startCursorEcho()
-        Log.info("capture started: \(pixelsWide)x\(pixelsHigh) display \(display.displayID) mode \(mode.rawValue) localCursor=\(localCursor)")
+        Log.info(logMessage)
         let kind = lastHello?.kind ?? "device"
         await status("\(mode == .extend ? "Extending to" : "Mirroring to") \(kind) (\(pixelsWide)×\(pixelsHigh))")
+    }
+
+    private func releaseLastDisplayStreamSurface() {
+        guard let surface = lastDisplayStreamSurface else { return }
+        IOSurfaceDecrementUseCount(surface)
+        lastDisplayStreamSurface = nil
+    }
+
+    private func stopDisplayStream() {
+        if let displayStream { _ = displayStream.stop() }
+        self.displayStream = nil
+        releaseLastDisplayStreamSurface()
     }
 
     func stop() {
@@ -479,6 +604,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         cursorImageTimer = nil
         stream?.stopCapture { _ in }
         stream = nil
+        stopDisplayStream()
         connection?.cancel()
         connection = nil
         if let encoder { VTCompressionSessionInvalidate(encoder) }
@@ -968,7 +1094,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 if let continuation = helloContinuation {
                     helloContinuation = nil
                     continuation.resume(returning: info)
-                } else if mode == .extend, stream != nil, let previous,
+                } else if mode == .extend, (stream != nil || displayStream != nil), let previous,
                           previous.pixelsWide != info.pixelsWide
                           || previous.pixelsHigh != info.pixelsHigh {
                     // Phone rotated — rebuild after a short debounce so a
@@ -1085,6 +1211,13 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
               let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
         else { return }
 
+        processCapturedFrame(pixelBuffer, pts: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
+    }
+
+    /// Shared by ScreenCaptureKit and the CGDisplayStream compatibility path.
+    private func processCapturedFrame(_ pixelBuffer: CVPixelBuffer,
+                                      pts: CMTime,
+                                      displaySurface: IOSurfaceRef? = nil) {
         lastPixelBuffer = pixelBuffer
         lastCaptureAt = Date()
         capFrames += 1
@@ -1094,7 +1227,16 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         if shouldDropFrame(reason: "pending_encode") { return }  // encoder busy
         if shouldDropFrame(reason: "pending_sends") { return }   // TCP send queue full
 
-        encode(pixelBuffer, pts: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
+        if let displaySurface {
+            // CGDisplayStream may recycle a surface as soon as the callback
+            // returns. Keep this encode's surface reserved until VT finishes.
+            IOSurfaceIncrementUseCount(displaySurface)
+            encode(pixelBuffer, pts: pts) {
+                IOSurfaceDecrementUseCount(displaySurface)
+            }
+        } else {
+            encode(pixelBuffer, pts: pts)
+        }
     }
 
     /// Drop when encode or send pipeline is busy.
@@ -1127,8 +1269,13 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         return true
     }
 
-    private func encode(_ pixelBuffer: CVPixelBuffer, pts: CMTime) {
-        guard let encoder else { return }
+    private func encode(_ pixelBuffer: CVPixelBuffer,
+                        pts: CMTime,
+                        completion: (() -> Void)? = nil) {
+        guard let encoder else {
+            completion?()
+            return
+        }
         pipelineLock.lock()
         pendingEncodes += 1
         pipelineLock.unlock()
@@ -1146,6 +1293,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             frameProperties: frameProperties,
             infoFlagsOut: nil
         ) { [weak self] status, _, buffer in
+            defer { completion?() }
             guard let self else { return }
             defer {
                 self.pipelineLock.lock()
@@ -1164,6 +1312,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             pipelineLock.lock()
             pendingEncodes = max(0, pendingEncodes - 1)
             pipelineLock.unlock()
+            completion?()
             Log.info("VTCompressionSessionEncodeFrame failed: \(submitStatus)")
         }
     }

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -36,6 +36,70 @@ private enum SenderError: LocalizedError {
     }
 }
 
+/// Keeps a stopped CGDisplayStream alive until CoreGraphics delivers its
+/// terminal `.stopped` callback, as required by CGDisplayStreamStop.
+private final class DisplayStreamLifetime {
+    var stream: CGDisplayStream?
+    var lastSurface: IOSurfaceRef?
+    private let stateLock = NSLock()
+    private var stopping = false
+    private var loggedStopFailure = false
+
+    func withAcceptedFrame(surface: IOSurfaceRef, _ body: () -> Void) {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard !stopping else { return }
+        IOSurfaceIncrementUseCount(surface)
+        releaseLastSurfaceLocked()
+        lastSurface = surface
+        body()
+    }
+
+    func requestStop(on queue: DispatchQueue) {
+        stateLock.lock()
+        guard !stopping else {
+            stateLock.unlock()
+            return
+        }
+        stopping = true
+        stateLock.unlock()
+
+        attemptStop(on: queue)
+    }
+
+    private func attemptStop(on queue: DispatchQueue) {
+        stateLock.lock()
+        let stream = self.stream
+        stateLock.unlock()
+        guard let stream else { return }
+        let stopError = stream.stop()
+        guard stopError != .success else { return }
+
+        stateLock.lock()
+        if !loggedStopFailure {
+            Log.info("CGDisplayStreamStop failed: \(stopError.rawValue) — retrying")
+            loggedStopFailure = true
+        }
+        stateLock.unlock()
+        queue.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.attemptStop(on: queue)
+        }
+    }
+
+    func finish() {
+        stateLock.lock()
+        releaseLastSurfaceLocked()
+        stream = nil
+        stateLock.unlock()
+    }
+
+    private func releaseLastSurfaceLocked() {
+        guard let lastSurface else { return }
+        IOSurfaceDecrementUseCount(lastSurface)
+        self.lastSurface = nil
+    }
+}
+
 /// Capture-resolution / bitrate trade-off. The virtual display always runs at
 /// native size — only the captured/encoded stream is scaled, so lower presets
 /// cut encode, transmit, and decode time at the cost of sharpness.
@@ -122,7 +186,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private var stream: SCStream?
     /// Fallback when SCShareableContent never lists the CGVirtualDisplay (#142).
     private var displayStream: CGDisplayStream?
-    private var lastDisplayStreamSurface: IOSurfaceRef?
+    private var displayStreamLifetime: DisplayStreamLifetime?
     private var encoder: VTCompressionSession?
     private var connection: NWConnection?
     private var virtualDisplay: VirtualDisplay?
@@ -490,7 +554,16 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                                              pixelsWide: Int, pixelsHigh: Int) async throws {
         setupEncoder(width: pixelsWide, height: pixelsHigh)
 
-        let handler: CGDisplayStreamFrameAvailableHandler = { [weak self] status, displayTime, surface, _ in
+        let lifetime = DisplayStreamLifetime()
+        let handler: CGDisplayStreamFrameAvailableHandler = { [weak self, lifetime] status, displayTime, surface, _ in
+            if status == .stopped {
+                lifetime.finish()
+                if let self, self.displayStreamLifetime === lifetime {
+                    self.displayStream = nil
+                    self.displayStreamLifetime = nil
+                }
+                return
+            }
             guard let self else { return }
             guard status == .frameComplete, let surface else { return }
 
@@ -500,12 +573,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             )
             guard err == kCVReturnSuccess, let pixelBuffer = unmanaged?.takeRetainedValue() else { return }
 
-            IOSurfaceIncrementUseCount(surface)
-            self.releaseLastDisplayStreamSurface()
-            self.lastDisplayStreamSurface = surface
-
-            let pts = CMTime(value: CMTimeValue(displayTime), timescale: 1_000_000_000)
-            self.processCapturedFrame(pixelBuffer, pts: pts, displaySurface: surface)
+            let pts = CMClockMakeHostTimeFromSystemUnits(displayTime)
+            lifetime.withAcceptedFrame(surface: surface) {
+                self.processCapturedFrame(pixelBuffer, pts: pts, displaySurface: surface)
+            }
         }
 
         let props = [CGDisplayStream.showCursor: !localCursor] as CFDictionary
@@ -522,13 +593,19 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                           userInfo: [NSLocalizedDescriptionKey: "CGDisplayStreamCreate failed"])
         }
 
+        // CGDisplayStream retains the handler, which retains this lifetime
+        // holder. The holder intentionally retains the stream until the
+        // terminal `.stopped` callback breaks the cycle.
+        lifetime.stream = ds
         let startErr = ds.start()
         guard startErr == .success else {
+            lifetime.stream = nil
             throw NSError(domain: "MacSender", code: 5,
                           userInfo: [NSLocalizedDescriptionKey: "CGDisplayStreamStart failed: \(startErr.rawValue)"])
         }
 
         displayStream = ds
+        displayStreamLifetime = lifetime
         await finishCaptureStart(
             displayID: displayID,
             pixelsWide: pixelsWide,
@@ -584,16 +661,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         await status("\(mode == .extend ? "Extending to" : "Mirroring to") \(kind) (\(pixelsWide)×\(pixelsHigh))")
     }
 
-    private func releaseLastDisplayStreamSurface() {
-        guard let surface = lastDisplayStreamSurface else { return }
-        IOSurfaceDecrementUseCount(surface)
-        lastDisplayStreamSurface = nil
-    }
-
     private func stopDisplayStream() {
-        if let displayStream { _ = displayStream.stop() }
+        let lifetime = displayStreamLifetime
         self.displayStream = nil
-        releaseLastDisplayStreamSurface()
+        self.displayStreamLifetime = nil
+        lifetime?.requestStop(on: queue)
     }
 
     func stop() {

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -534,8 +534,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     }
 
     /// The virtual display takes a moment to show up in shareable content.
-    /// Uses the explicit SCShareableContent API, logs diagnostics on failure,
-    /// and matches by size as a secondary key when CG/SCK ids diverge.
+    /// Uses the explicit SCShareableContent API and logs diagnostics on failure.
     private func findSCDisplay(id: CGDirectDisplayID) async throws -> SCDisplay {
         var lastIDs: [CGDirectDisplayID] = []
         // ~5s — same overall budget as before; then setupExtend falls back.

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -452,7 +452,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         }
         virtualDisplay = vd
         inputInjector = InputInjector(displayID: vd.displayID)
-        _ = await vd.waitUntilReady(timeoutSeconds: 1.0)
+        let virtualDisplayReady = await vd.waitUntilReady(timeoutSeconds: 1.0)
 
         // Quality scaling: capture/encode below native when requested — the
         // display itself stays native so window layout is unaffected.
@@ -462,15 +462,20 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // setups the virtual display never appears in SCShareableContent
         // (MacSender Code=3 / issue #142) even though CGVirtualDisplay
         // returned an id — fall back to CGDisplayStream using that id.
+        if !virtualDisplayReady {
+            try await startFallbackCapture(displayID: vd.displayID,
+                                           pixelsWide: captureW, pixelsHigh: captureH,
+                                           reason: "virtual display missed readiness window")
+            return
+        }
         let display: SCDisplay
         do {
             display = try await findSCDisplay(id: vd.displayID)
         } catch SenderError.virtualDisplayNotShareable {
             let error = SenderError.virtualDisplayNotShareable
-            Log.info("SCK capture path failed (\(error.localizedDescription)) — CGDisplayStream fallback")
-            await status("Using alternate capture path…")
-            try await startCaptureCGDisplayStream(displayID: vd.displayID,
-                                                  pixelsWide: captureW, pixelsHigh: captureH)
+            try await startFallbackCapture(displayID: vd.displayID,
+                                           pixelsWide: captureW, pixelsHigh: captureH,
+                                           reason: "SCK capture path failed (\(error.localizedDescription))")
             return
         }
         try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
@@ -482,6 +487,16 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             let id = vd.displayID
             Task { @MainActor in TestPattern.show(on: id) }
         }
+    }
+
+    private func startFallbackCapture(displayID: CGDirectDisplayID,
+                                      pixelsWide: Int,
+                                      pixelsHigh: Int,
+                                      reason: String) async throws {
+        Log.info("\(reason) — CGDisplayStream fallback")
+        await status("Using alternate capture path…")
+        try await startCaptureCGDisplayStream(displayID: displayID,
+                                              pixelsWide: pixelsWide, pixelsHigh: pixelsHigh)
     }
 
     /// Tear down and rebuild when the phone announces new dimensions. Loops

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AppKit
 import CoreGraphics
 
 /// Wraps the private CGVirtualDisplay API: makes macOS believe a real monitor
@@ -81,6 +82,41 @@ final class VirtualDisplay {
                 try? await Task.sleep(for: .milliseconds(settled ? 2000 : 200))
             }
         }
+    }
+
+    /// `applySettings` can succeed before WindowServer attaches the display.
+    /// Poll until the id appears in the online list / NSScreen, or time out.
+    /// Returns whether the display looked attached (capture may still work
+    /// via CGDisplayStream even when this returns false on some systems).
+    @discardableResult
+    func waitUntilReady(timeoutSeconds: Double = 5.0) async -> Bool {
+        let id = display.displayID
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        var attempt = 0
+        while Date() < deadline {
+            var count: UInt32 = 0
+            CGGetOnlineDisplayList(0, nil, &count)
+            var ids = [CGDirectDisplayID](repeating: 0, count: Int(max(count, 1)))
+            CGGetOnlineDisplayList(count, &ids, &count)
+            let list = Array(ids.prefix(Int(count)))
+            let ns = NSScreen.screens.compactMap {
+                ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value
+            }
+            if list.contains(id) || CGDisplayIsActive(id) != 0 || ns.contains(id) {
+                Log.info("virtual display ready: id=\(id) attempt=\(attempt) cg=\(list) ns=\(ns)")
+                return true
+            }
+            if attempt == 0 || attempt % 10 == 9 {
+                Log.info("virtual display waiting: id=\(id) attempt=\(attempt) cg=\(list) ns=\(ns) online=\(CGDisplayIsOnline(id))")
+            }
+            attempt += 1
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+        Log.info("virtual display not listed as online within timeout: id=\(id) — continuing anyway")
+        // One re-apply can help when WindowServer dropped the first attach.
+        _ = display.apply(settings)
+        try? await Task.sleep(for: .milliseconds(300))
+        return CGDisplayIsActive(id) != 0 || CGDisplayIsOnline(id) != 0
     }
 
     /// Returns true when the display is (now) in its HiDPI mode. Silent when

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -86,28 +86,21 @@ final class VirtualDisplay {
 
     /// `applySettings` can succeed before WindowServer attaches the display.
     /// Poll until the id appears in the online list / NSScreen, or time out.
-    /// Returns whether the display looked attached (capture may still work
-    /// via CGDisplayStream even when this returns false on some systems).
+    /// Returns whether the display became ready within the polling window.
+    /// A late attach still returns false so the caller uses CGDisplayStream.
     @discardableResult
     func waitUntilReady(timeoutSeconds: Double = 5.0) async -> Bool {
         let id = display.displayID
         let deadline = Date().addingTimeInterval(timeoutSeconds)
         var attempt = 0
         while Date() < deadline {
-            var count: UInt32 = 0
-            CGGetOnlineDisplayList(0, nil, &count)
-            var ids = [CGDirectDisplayID](repeating: 0, count: Int(max(count, 1)))
-            CGGetOnlineDisplayList(count, &ids, &count)
-            let list = Array(ids.prefix(Int(count)))
-            let ns = NSScreen.screens.compactMap {
-                ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value
-            }
-            if list.contains(id) || CGDisplayIsActive(id) != 0 || ns.contains(id) {
-                Log.info("virtual display ready: id=\(id) attempt=\(attempt) cg=\(list) ns=\(ns)")
+            let visibility = captureVisibility(for: id)
+            if visibility.ready {
+                Log.info("virtual display ready: id=\(id) attempt=\(attempt) cg=\(visibility.cg) ns=\(visibility.ns)")
                 return true
             }
             if attempt == 0 || attempt % 10 == 9 {
-                Log.info("virtual display waiting: id=\(id) attempt=\(attempt) cg=\(list) ns=\(ns) online=\(CGDisplayIsOnline(id))")
+                Log.info("virtual display waiting: id=\(id) attempt=\(attempt) cg=\(visibility.cg) ns=\(visibility.ns) online=\(CGDisplayIsOnline(id))")
             }
             attempt += 1
             try? await Task.sleep(for: .milliseconds(100))
@@ -116,7 +109,25 @@ final class VirtualDisplay {
         // One re-apply can help when WindowServer dropped the first attach.
         _ = display.apply(settings)
         try? await Task.sleep(for: .milliseconds(300))
-        return CGDisplayIsActive(id) != 0 || CGDisplayIsOnline(id) != 0
+        let finalVisibility = captureVisibility(for: id)
+        Log.info("virtual display readiness after re-apply: id=\(id) ready=\(finalVisibility.ready) cg=\(finalVisibility.cg) ns=\(finalVisibility.ns)")
+        // A display that missed the full readiness window is not a stable SCK
+        // target even if the re-apply makes it appear momentarily. Let the
+        // caller use CGDisplayStream for this session.
+        return false
+    }
+
+    private func captureVisibility(for id: CGDirectDisplayID)
+        -> (ready: Bool, cg: [CGDirectDisplayID], ns: [CGDirectDisplayID]) {
+        var count: UInt32 = 0
+        CGGetOnlineDisplayList(0, nil, &count)
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(max(count, 1)))
+        CGGetOnlineDisplayList(count, &ids, &count)
+        let cg = Array(ids.prefix(Int(count)))
+        let ns = NSScreen.screens.compactMap {
+            ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value
+        }
+        return (cg.contains(id) || ns.contains(id), cg, ns)
     }
 
     /// Returns true when the display is (now) in its HiDPI mode. Silent when

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -86,8 +86,7 @@ final class VirtualDisplay {
 
     /// `applySettings` can succeed before WindowServer attaches the display.
     /// Poll until the id appears in the online list / NSScreen, or time out.
-    /// Returns whether the display became ready within the polling window.
-    /// A late attach still returns false so the caller uses CGDisplayStream.
+    /// Returns whether the display became ready, including after one re-apply.
     @discardableResult
     func waitUntilReady(timeoutSeconds: Double = 5.0) async -> Bool {
         let id = display.displayID
@@ -111,10 +110,7 @@ final class VirtualDisplay {
         try? await Task.sleep(for: .milliseconds(300))
         let finalVisibility = captureVisibility(for: id)
         Log.info("virtual display readiness after re-apply: id=\(id) ready=\(finalVisibility.ready) cg=\(finalVisibility.cg) ns=\(finalVisibility.ns)")
-        // A display that missed the full readiness window is not a stable SCK
-        // target even if the re-apply makes it appear momentarily. Let the
-        // caller use CGDisplayStream for this session.
-        return false
+        return finalVisibility.ready
     }
 
     private func captureVisibility(for id: CGDirectDisplayID)


### PR DESCRIPTION
## What changed

- fall back to `CGDisplayStream` when a newly created `CGVirtualDisplay` never appears in `SCShareableContent`
- re-check readiness after one settings re-apply and return to ScreenCaptureKit when the display becomes online
- keep the fallback limited to the typed virtual-display enumeration failure
- reuse the existing frame processing, encoder backpressure, cursor, rotation, and status paths
- isolate IOSurface ownership per display stream and retain the stream until CoreGraphics delivers `.stopped`
- convert `CGDisplayStream` host timestamps with `CMClockMakeHostTimeFromSystemUnits`
- make stream shutdown idempotent and prevent stopped streams from submitting late frames

## Why

On some macOS configurations, the virtual display is created successfully but needs one settings re-apply before WindowServer brings it online. ScreenCaptureKit can fail to enumerate a display that remains offline, while forcing a late-online display through `CGDisplayStream` can produce black frames. The sender can otherwise fail with:

```text
virtual display never appeared in SCShareableContent
```

This leaves the receiver connected but without an extended desktop. The deprecated CoreGraphics stream remains available for displays that are still offline after re-apply; displays that become online use ScreenCaptureKit.

Addresses #142.

## User impact

Users affected by the ScreenCaptureKit enumeration failure or the late-online black screen can extend their desktop to an iPad or iPhone. The normal ScreenCaptureKit path is used whenever the display is online after the readiness retry.

## Validation

- macOS Release build with Xcode succeeded
- strict deep code-signature verification passed
- live Wi-Fi test extended an iPad at `2224×1668`
- pixel probe reproduced fully black `CGDisplayStream` output on a late-online virtual display (`avg=0`)
- live regression confirmed the late-online display selects ScreenCaptureKit and delivers frames
- black-screen route check passed (`GREEN: online virtual display uses ScreenCaptureKit`)
- Screen Recording, Accessibility, and Local Network permissions verified
- fallback lifecycle and timestamp handling reviewed separately for spec and code quality
