### PR TITLE
fix(input): stop two-finger scroll from firing a click

### DIFF
--- a/Mac/InputInjector.swift
+++ b/Mac/InputInjector.swift
@@ -36,23 +36,36 @@ final class InputInjector {
         )
 
         let type: CGEventType
+        // Click count on the release. A cancel means "a second finger joined,
+        // this was a scroll, not a tap" — but there is no CGEvent for undoing a
+        // press, and a plain up over the press point is indistinguishable from a
+        // click, so every two-finger scroll opened whatever was under finger one.
+        // Releasing with clickCount 0 keeps the button state honest while telling
+        // AppKit and WebKit not to synthesize a click. Only the cancel path gets
+        // 0: a zero-click *down* is what breaks menu tracking (see above).
+        var clickState = 1
         switch phase {
         case "began":
             type = .leftMouseDown
             isDown = true
         case "moved":
             type = isDown ? .leftMouseDragged : .mouseMoved
-        case "ended", "cancelled":
+        case "ended":
             guard isDown else { return }   // spurious up without a down
             type = .leftMouseUp
             isDown = false
+        case "cancelled":
+            guard isDown else { return }
+            type = .leftMouseUp
+            isDown = false
+            clickState = 0
         default:
             return
         }
 
         guard let event = CGEvent(mouseEventSource: source, mouseType: type,
                                   mouseCursorPosition: point, mouseButton: .left) else { return }
-        event.setIntegerValueField(.mouseEventClickState, value: 1)
+        event.setIntegerValueField(.mouseEventClickState, value: Int64(clickState))
         event.post(tap: .cghidEventTap)
     }
 

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -876,6 +876,16 @@ struct VideoLayerView: UIViewRepresentable {
             case .began:
                 twoFingerActive = true
                 lastPan = .zero
+                // macOS delivers scroll to whatever sits under the cursor, and
+                // the cursor no longer follows the fingers now that a press is
+                // withheld until it commits. Put it on the gesture once, up
+                // front, so the scroll lands on the window being touched. Once
+                // only: a real trackpad does not drag the cursor while
+                // scrolling, and moving it mid-gesture would change the target.
+                if let n = normalized(recognizer.location(in: self)) {
+                    lastNorm = n
+                    receiver?.sendTouch(phase: "moved", x: n.x, y: n.y)
+                }
             case .changed:
                 let t = recognizer.translation(in: self)
                 let scale = min(bounds.width / video.width, bounds.height / video.height)
@@ -888,18 +898,94 @@ struct VideoLayerView: UIViewRepresentable {
             }
         }
 
+        // A press is only a click once we know a second finger is not coming.
+        // Sending `began` on contact posted a mouse-down we then had to take
+        // back, and taking it back only works when UIKit happens to deliver
+        // `cancelled`; when the pan recognizer misses and we get a plain
+        // `ended` instead, that down/up pair *is* a click, which is why every
+        // other two-finger scroll opened whatever sat under the first finger.
+        // So hold the down until the gesture commits to being one.
+        private var pendingDown: (x: Double, y: Double)?
+        private var downSent = false
+        private var holdTimer: DispatchWorkItem?
+
+        /// Movement (in points) that turns a held press into a drag.
+        private let dragSlop: CGFloat = 10
+        /// A press this long with no second finger is a deliberate hold, so
+        /// commit it: press-and-hold menus and drag handles need the button.
+        private let holdDelay: TimeInterval = 0.12
+        private var pendingDownPoint: CGPoint = .zero
+
+        /// Emit the withheld `began`, at the point the finger first landed so a
+        /// drag starts where the user touched rather than where slop was crossed.
+        private func commitPendingDown() {
+            guard let p = pendingDown, !downSent else { return }
+            downSent = true
+            holdTimer?.cancel()
+            holdTimer = nil
+            receiver?.sendTouch(phase: "began", x: p.x, y: p.y)
+        }
+
+        /// Drop the press without a trace. Nothing reached the Mac, so there is
+        /// no button to release and no click to suppress.
+        private func discardPendingDown() {
+            pendingDown = nil
+            downSent = false
+            holdTimer?.cancel()
+            holdTimer = nil
+        }
+
         private func send(_ phase: String, _ touches: Set<UITouch>, _ event: UIEvent?) {
             // Ignore single-finger events while a two-finger gesture runs,
             // and end the click if a second finger joins mid-press.
             if twoFingerActive || (event?.allTouches?.count ?? 1) > 1 {
-                if phase != "began" {
+                if downSent {
                     receiver?.sendTouch(phase: "cancelled", x: lastNorm.x, y: lastNorm.y)
                 }
+                discardPendingDown()
                 return
             }
             guard let touch = touches.first,
                   let norm = normalized(touch.location(in: self)) else { return }
             lastNorm = norm
+
+            switch phase {
+            case "began":
+                let location = touch.location(in: self)
+                pendingDown = norm
+                pendingDownPoint = location
+                downSent = false
+                let work = DispatchWorkItem { [weak self] in self?.commitPendingDown() }
+                holdTimer = work
+                DispatchQueue.main.asyncAfter(deadline: .now() + holdDelay, execute: work)
+                return
+            case "ended":
+                // A tap: nothing was posted yet, so post the whole click now.
+                if pendingDown != nil, !downSent { commitPendingDown() }
+                // No down means the press was already discarded (a second
+                // finger took it), so there is nothing to release.
+                if downSent { receiver?.sendTouch(phase: "ended", x: norm.x, y: norm.y) }
+                discardPendingDown()
+                return
+            case "cancelled":
+                if downSent {
+                    receiver?.sendTouch(phase: "cancelled", x: norm.x, y: norm.y)
+                }
+                discardPendingDown()
+                return
+            case "moved":
+                if pendingDown != nil, !downSent {
+                    let moved = hypot(touch.location(in: self).x - pendingDownPoint.x,
+                                      touch.location(in: self).y - pendingDownPoint.y)
+                    // Below slop the finger is still deciding: track the cursor
+                    // (the Mac turns a move without a down into mouseMoved) but
+                    // keep the button up so a second finger can still cancel.
+                    if moved > dragSlop { commitPendingDown() }
+                }
+            default:
+                break
+            }
+
             if phase == "moved", let event {
                 // The panel samples touches at 120Hz but UIKit delivers at
                 // display refresh — forward every coalesced sample so the Mac


### PR DESCRIPTION
Fixes #187. Two-finger scrolling no longer clicks whatever sits under the first finger.

**Why:** scrolling a Twitter timeline on the iPad opened a post roughly every other gesture, because we posted a `leftMouseDown` as soon as the first finger landed and then had to take it back. The take-back only works when UIKit delivers `cancelled`; when the pan recognizer misses we get a plain `ended` instead, and that down/up pair is a click. See the issue for the log showing the two alternating one for one.

**How:** stop starting a press speculatively. `send()` now withholds the down and commits it once the gesture says what it is: past the slop it is a drag anchored at the original touch point, on lift it is a tap, after 120ms it is a press so hold interactions keep working, and a second finger discards it with nothing ever sent. The Mac side keeps releasing on cancel, since the button would otherwise stick, but with `clickCount` 0 so AppKit and WebKit do not synthesize a click.

The one judgment call: the speculative down was also what dragged the cursor to the touch point, and macOS routes scroll to the window under the cursor. The two-finger pan now places the cursor itself, once at gesture start rather than continuously, which is how a trackpad behaves.

Tested on an iPad over USB: tap, drag, press-and-hold selection, two-finger scroll landing on the touched window, and menus opening and closing cleanly.
