### PR TITLE
ci: require PR titles to be conventional commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,43 @@
+name: PR title
+
+# The repo squash-merges with the PR title as the commit message, and that
+# title is what release-please parses. A title that is not a conventional
+# commit is silently dropped: #163 shipped Apple Pencil support with no
+# changelog entry and left the release on a patch bump, and nobody noticed
+# until the release PR was read by hand.
+#
+# `pull_request` rather than `pull_request_target` so this also runs on forks
+# with a read-only token, which is where the miss happened.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  conventional:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Scopes stay unrestricted on purpose: contributors should not have
+          # to guess an allowlist, and release-please only cares about the type.
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            test
+            build
+            ci
+            chore
+            style
+            revert


### PR DESCRIPTION
Adds a check that fails when a PR title is not a conventional commit.

**Why:** the repo squash-merges with the PR title as the commit message, and release-please parses exactly that. #163 was titled `Apple Pencil support w/ pressure/tilt/proximity`, so release-please skipped it: the feature never reached the changelog and #185 was cut as a patch instead of a minor. Nothing caught it, it only surfaced when the release PR was read by hand.

**How:** `amannn/action-semantic-pull-request`, the standard action for this. Types are the usual set, scopes are deliberately unrestricted so contributors do not have to guess an allowlist. Runs on `pull_request` rather than `pull_request_target` so it works on forks with a read-only token, which is where the miss happened.

One caveat: `main` currently has no branch protection, so this reports but does not block. Making it actually gate a merge needs it added as a required status check.