### PR TITLE
docs: list community-built compatible apps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,83 @@ pipeline, USB transport, input injection) are already working.
 - 🔒 **Self-hosted & private** — your screen never touches anyone's server.
   Two small apps, one TCP connection, that's it.
 
+## Comparison
+
+| | OpenDisplay | Apple Sidecar | Duet Display | Luna Display |
+|---|---|---|---|---|
+| Price | **Free, open source** | Free | Subscription | $$$ + dongle |
+| iPhone as display | ✅ | ❌ (iPad only) | ✅ | ✅ |
+| Different Apple IDs | ✅ | ❌ | ✅ | ✅ |
+| Wired (USB) | ✅ | ✅ | ✅ | ❌ |
+| True extension | ✅ | ✅ | ✅ | ✅ |
+| Touch input | ✅ | ✅ | ✅ | ✅ |
+| Self-hosted / auditable | ✅ | — | ❌ | ❌ |
+
+## FAQ
+
+**Why do I see the purple screen-recording indicator in the menu bar?**
+That's a macOS privacy indicator shown for *any* app that captures the
+screen — Duet, Luna, OBS, and Zoom trigger it too. Apple Sidecar doesn't,
+only because it's implemented inside the OS rather than on public capture
+APIs. It cannot (and shouldn't) be hidden by an app; it's how macOS tells
+you a capture is running.
+
+**The Mac app doesn't show my iPhone in the Connection menu (WiFi).**
+Both sides need **Local Network** permission, and both fail *silently*
+without it: check Privacy & Security → Local Network on the Mac **and** on
+the iPhone, make sure both are on the same WiFi network, and keep the
+iPhone app open in the foreground. USB mode is unaffected.
+
+**Does it support iPad?** The receiver app is universal (iPhone + iPad);
+iPad is the same codebase. iPad-specific polish (Pencil, pressure) is on the
+roadmap.
+
+**Why H.264 and not HEVC/AV1?** Hardware H.264 encode/decode is universally
+fast and the latency is excellent. HEVC is a planned option for better
+quality-per-bit.
+
+**Is my screen content sent anywhere?** No. One direct TCP connection
+between your Mac and your device, over your cable or your LAN. No servers,
+no accounts, no analytics. Full details — including what the apps store
+locally and the current WiFi-encryption caveat — on the
+[privacy page](https://peetzweg.github.io/opendisplay/privacy.html).
+
+**What's the license? Can I fork it or use it commercially?**
+[GPL-3.0](LICENSE). Use, study, and adapt it freely — commercially too. If
+you distribute a modified version it must stay open source under the same
+license with the original attribution intact, so improvements flow back
+instead of into closed forks. (Releases up to v0.4.x were MIT-licensed and
+remain available under those terms.)
+
+**Will it break on a macOS update?** Possibly — `CGVirtualDisplay` is
+private API. The same risk applies to every virtual-display product.
+The capture/streaming pipeline itself uses only public APIs.
+
+**Audio?** Out of scope for now.
+
+## Compatible apps
+
+The official apps cover a Mac sender and an iPhone/iPad receiver on iOS 17+.
+Other people have built their own clients that speak the same protocol, so
+you can also use an Android device or an older iPad as a display, or drive
+one from Linux. If your hardware is not covered yet, start here:
+
+**Android receivers**
+* [gprot42/android-opendisplay](https://github.com/gprot42/android-opendisplay) - GrapheneOS receiver for de-Googled Pixel phones and tablets, Android 8.0+
+* [josepacelli/opendisplay-android](https://github.com/josepacelli/opendisplay-android) - Android receiver, Android 8.0+, works with an unmodified Mac app
+
+**Older iOS receivers**
+* [cuongpham1/ipad-iphone-second-monitor-ios12-free](https://github.com/cuongpham1/ipad-iphone-second-monitor-ios12-free) - iOS 12 client for iPads and iPhones that cannot run the official app
+
+**Linux senders**
+* [tixwho/opendisplay-linux](https://github.com/tixwho/opendisplay-linux) - drive an iPhone or iPad from a Wayland desktop (KDE Plasma, Hyprland)
+
+These are fan-made projects, not official builds. They are not affiliated
+with OpenDisplay and are not maintained, reviewed, or supported by us, so
+please report issues with them in their own repositories. Listing them here
+also says nothing about our own plans: an official OpenDisplay app may still
+ship for any of these platforms later.
+
 ## How it works
 
 ```
@@ -173,83 +250,6 @@ All live under **Privacy & Security** in System Settings (Mac) / Settings
 (iPhone). The Local Network ones are only needed for WiFi mode — USB works
 without them. If the prompt never appeared, toggle the entry manually or
 force-quit and reopen the app.
-
-## FAQ
-
-**Why do I see the purple screen-recording indicator in the menu bar?**
-That's a macOS privacy indicator shown for *any* app that captures the
-screen — Duet, Luna, OBS, and Zoom trigger it too. Apple Sidecar doesn't,
-only because it's implemented inside the OS rather than on public capture
-APIs. It cannot (and shouldn't) be hidden by an app; it's how macOS tells
-you a capture is running.
-
-**The Mac app doesn't show my iPhone in the Connection menu (WiFi).**
-Both sides need **Local Network** permission, and both fail *silently*
-without it: check Privacy & Security → Local Network on the Mac **and** on
-the iPhone, make sure both are on the same WiFi network, and keep the
-iPhone app open in the foreground. USB mode is unaffected.
-
-**Does it support iPad?** The receiver app is universal (iPhone + iPad);
-iPad is the same codebase. iPad-specific polish (Pencil, pressure) is on the
-roadmap.
-
-**Why H.264 and not HEVC/AV1?** Hardware H.264 encode/decode is universally
-fast and the latency is excellent. HEVC is a planned option for better
-quality-per-bit.
-
-**Is my screen content sent anywhere?** No. One direct TCP connection
-between your Mac and your device, over your cable or your LAN. No servers,
-no accounts, no analytics. Full details — including what the apps store
-locally and the current WiFi-encryption caveat — on the
-[privacy page](https://peetzweg.github.io/opendisplay/privacy.html).
-
-**What's the license? Can I fork it or use it commercially?**
-[GPL-3.0](LICENSE). Use, study, and adapt it freely — commercially too. If
-you distribute a modified version it must stay open source under the same
-license with the original attribution intact, so improvements flow back
-instead of into closed forks. (Releases up to v0.4.x were MIT-licensed and
-remain available under those terms.)
-
-**Will it break on a macOS update?** Possibly — `CGVirtualDisplay` is
-private API. The same risk applies to every virtual-display product.
-The capture/streaming pipeline itself uses only public APIs.
-
-**Audio?** Out of scope for now.
-
-## Comparison
-
-| | OpenDisplay | Apple Sidecar | Duet Display | Luna Display |
-|---|---|---|---|---|
-| Price | **Free, open source** | Free | Subscription | $$$ + dongle |
-| iPhone as display | ✅ | ❌ (iPad only) | ✅ | ✅ |
-| Different Apple IDs | ✅ | ❌ | ✅ | ✅ |
-| Wired (USB) | ✅ | ✅ | ✅ | ❌ |
-| True extension | ✅ | ✅ | ✅ | ✅ |
-| Touch input | ✅ | ✅ | ✅ | ✅ |
-| Self-hosted / auditable | ✅ | — | ❌ | ❌ |
-
-## Compatible apps
-
-The official apps cover a Mac sender and an iPhone/iPad receiver on iOS 17+.
-Other people have built their own clients that speak the same protocol, so
-you can also use an Android device or an older iPad as a display, or drive
-one from Linux. If your hardware is not covered yet, start here:
-
-**Android receivers**
-* [gprot42/android-opendisplay](https://github.com/gprot42/android-opendisplay) - GrapheneOS receiver for de-Googled Pixel phones and tablets, Android 8.0+
-* [josepacelli/opendisplay-android](https://github.com/josepacelli/opendisplay-android) - Android receiver, Android 8.0+, works with an unmodified Mac app
-
-**Older iOS receivers**
-* [cuongpham1/ipad-iphone-second-monitor-ios12-free](https://github.com/cuongpham1/ipad-iphone-second-monitor-ios12-free) - iOS 12 client for iPads and iPhones that cannot run the official app
-
-**Linux senders**
-* [tixwho/opendisplay-linux](https://github.com/tixwho/opendisplay-linux) - drive an iPhone or iPad from a Wayland desktop (KDE Plasma, Hyprland)
-
-These are fan-made projects, not official builds. They are not affiliated
-with OpenDisplay and are not maintained, reviewed, or supported by us, so
-please report issues with them in their own repositories. Listing them here
-also says nothing about our own plans: an official OpenDisplay app may still
-ship for any of these platforms later.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,29 @@ The capture/streaming pipeline itself uses only public APIs.
 | Touch input | ✅ | ✅ | ✅ | ✅ |
 | Self-hosted / auditable | ✅ | — | ❌ | ❌ |
 
+## Compatible apps
+
+The official apps cover a Mac sender and an iPhone/iPad receiver on iOS 17+.
+Other people have built their own clients that speak the same protocol, so
+you can also use an Android device or an older iPad as a display, or drive
+one from Linux. If your hardware is not covered yet, start here:
+
+**Android receivers**
+* [gprot42/android-opendisplay](https://github.com/gprot42/android-opendisplay) - GrapheneOS receiver for de-Googled Pixel phones and tablets, Android 8.0+
+* [josepacelli/opendisplay-android](https://github.com/josepacelli/opendisplay-android) - Android receiver, Android 8.0+, works with an unmodified Mac app
+
+**Older iOS receivers**
+* [cuongpham1/ipad-iphone-second-monitor-ios12-free](https://github.com/cuongpham1/ipad-iphone-second-monitor-ios12-free) - iOS 12 client for iPads and iPhones that cannot run the official app
+
+**Linux senders**
+* [tixwho/opendisplay-linux](https://github.com/tixwho/opendisplay-linux) - drive an iPhone or iPad from a Wayland desktop (KDE Plasma, Hyprland)
+
+These are fan-made projects, not official builds. They are not affiliated
+with OpenDisplay and are not maintained, reviewed, or supported by us, so
+please report issues with them in their own repositories. Listing them here
+also says nothing about our own plans: an official OpenDisplay app may still
+ship for any of these platforms later.
+
 ## Roadmap
 
 Tracked as [roadmap issues](https://github.com/peetzweg/opendisplay/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap) — pick one up if you'd like to contribute!


### PR DESCRIPTION
Adds a **Compatible apps** section to the README, between the comparison table and the roadmap, pointing at community clients for Android, iOS 12, and Linux.

**Why:** People keep forking the project to reach hardware the official apps do not cover (Android devices, iPads stuck on old iOS, Linux desktops). Right now they have to find those forks by accident. Sending them straight there is more useful than leaving the question open in issues.

**How:** Grouped by role rather than platform, because [tixwho/opendisplay-linux](https://github.com/tixwho/opendisplay-linux) is a *sender* (Wayland desktop driving an iPhone) while the rest are receivers. The closing paragraph is the deliberate bit: it labels them fan-made and unsupported, and states explicitly that listing them does not rule out an official app for any of these platforms later.