### PR TITLE
feat(mac): add Mac-to-Mac receiver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ DerivedData/
 OpenSidecar.xcodeproj/
 Mac/Info.plist
 iOS/Info.plist
+MacReceiver/Info.plist
 
 # Xcode user state
 xcuserdata/

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -73,15 +73,44 @@ struct PhoneInfo: Decodable {
                           // across USB and WiFi
     let pv: Int?          // receiver protocol version (issue #132); absent on
                           // every pre-handshake install → treat as protocol 1
+    let hevc: Bool?       // receiver decodes HEVC (Mac receivers); absent on
+                          // iOS receivers → stay on H.264
+    let prores4444: Bool? // paired Mac receiver accepts framed ProRes 4444
+    let prores4444XQ: Bool? // paired Mac receiver accepts ProRes 4444 XQ
+    let receiverVersion: String?
+    let receiverBuild: String?
+    let renderPath: String?
+    let colorSpace: WireColorSpace? // stream working gamut; absent = sRGB
+    // Exact active display profile from a Mac receiver. A gamut enum alone
+    // loses the factory calibration/TRCs that distinguish an iMac profile
+    // from generic Display P3.
+    let iccProfile: String?
+    // Some receivers deliberately use the system video presentation layer
+    // for its native ColorSync path. Those receivers ask ScreenCaptureKit to
+    // bake the cursor into the video so no independent overlay can force the
+    // display compositor to switch planes (observed as black flashes/trails).
+    let cursorInVideo: Bool?
+    // Optional low-latency side channel advertised by Mac receivers. Cursor
+    // position datagrams bypass the ordered multi-megabyte video stream.
+    let cursorHost: String?
+    let cursorPort: Int?
 
     var kind: String { device ?? "device" }
     var protocolVersion: Int { pv ?? WireProtocol.assumedWhenAbsent }
+    var iccProfileData: Data? {
+        guard let iccProfile, iccProfile.count <= 1_500_000 else { return nil }
+        return Data(base64Encoded: iccProfile)
+    }
 }
 
 /// How the sender reaches the receiver. Reconnects re-dial from scratch, so
 /// a USB device that was replugged (new usbmuxd DeviceID) is found again.
 enum SenderTransport {
-    case tcp(NWEndpoint)                   // WiFi (Bonjour) or -host/-port override
+    // Bonjour bridge endpoints resolve afresh for every NWConnection, so a
+    // receiver's link-local IP may change without invalidating the session.
+    // Binding the endpoint to its discovered interface also prevents a
+    // bridge-selected service from silently resolving over en0/WiFi.
+    case tcp(NWEndpoint, requiredInterface: NWInterface?)
     case usb(udid: String?, port: UInt16)  // native usbmuxd dial; nil = first device
 }
 
@@ -106,10 +135,17 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // Fired on every hello — carries the receiver's install id so the
     // controller can deduplicate USB/WiFi sessions to the same device.
     @MainActor var onHello: ((PhoneInfo) -> Void)?
+    // Called when a TCP connection is ready, reporting the detected local
+    // interface type ("bridge" for Thunderbolt, "wifi" otherwise).
+    @MainActor var onTransportDetected: ((String) -> Void)?
 
     private var stream: SCStream?
     private var encoder: VTCompressionSession?
     private var connection: NWConnection?
+    private var cursorConnection: NWConnection?
+    private var cursorConnectionReady = false
+    private var cursorEndpointKey = ""
+    private var cursorSequence: UInt64 = 0
     private var virtualDisplay: VirtualDisplay?
     private let queue = DispatchQueue(label: "sender.video")
     private let startCode: [UInt8] = [0, 0, 0, 1]
@@ -120,6 +156,22 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private let endpointName: String
     private let mode: CaptureMode
     private let quality: StreamQuality
+    private var shouldUseHEVC: Bool {
+        (lastHello?.hevc ?? false)
+            && !UserDefaults.standard.bool(forKey: "forceH264")
+    }
+    private var shouldUseProRes4444: Bool {
+        (lastHello?.prores4444 ?? false)
+            && !UserDefaults.standard.bool(forKey: "disableProRes4444")
+    }
+    private var shouldUseProRes4444XQ: Bool {
+        shouldUseProRes4444 && (lastHello?.prores4444XQ ?? false)
+            && !UserDefaults.standard.bool(forKey: "disableProRes4444XQ")
+    }
+    private var workingColorSpace: WireColorSpace {
+        lastHello?.colorSpace ?? .sRGB
+    }
+    private var workingICCProfile: Data? { lastHello?.iccProfileData }
     // Stable per-device serial for the virtual display, so macOS can tell
     // multiple OpenDisplay monitors apart and persist their arrangement.
     private let displaySerial: UInt32
@@ -137,7 +189,66 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // stays valid (pre-encode skip → normal P-frame n→n+2); we do NOT force
     // keyframes on enc drops.
     private var pendingEncodes = 0
-    private let maxPendingEncodes = 1
+    // 1 for phone-class panels (latest-frame-wins, minimum latency). At 4K
+    // a single encode takes ~20ms — longer than a 60fps interval — so one
+    // slot halves the frame rate; two slots pipeline the hardware encoder
+    // back to full throughput for ~17ms extra latency. Set by setupEncoder.
+    private var maxPendingEncodes = 1
+    // Low-latency native streams can use a fixed low HEVC QP. The 4.5K path
+    // instead constrains the normal hardware rate controller with a maximum
+    // QP because per-frame BaseFrameQP is ignored outside low-latency mode.
+    // Set during setupEncoder and read on `queue`.
+    private var fixedDesktopQP: Int?
+
+    // ── Static-screen refresh ────────────────────────────────────────────
+    //
+    // When motion stops, the receiver keeps showing the LAST frame — encoded
+    // mid-motion on a starved bit budget, so flat fills around the moved
+    // content freeze with visible quantization splotches ("colored noise on
+    // solid backgrounds"). Re-encoding the same frame does not heal them:
+    // HEVC codes unchanged flat blocks as skip, so the ghost noise survives
+    // every subsequent P-frame. Measured on the 4480x2520 Main10 pipeline:
+    // 4x4-block chroma deviation of ~37/1024 after a window drag, unchanged
+    // by refinement P-frames, and only ~27 after a forced main-session IDR
+    // (the rate controller still owes debt from the motion burst).
+    //
+    // Fix: once the screen has been still for a moment, re-encode the frozen
+    // frame ONCE as a true high-quality IDR through a separate low-latency
+    // HEVC session. kVTEncodeFrameOptionKey_BaseFrameQP is honored only
+    // under low-latency rate control (the main session's fixed-QP request is
+    // silently ignored outside it), and a low-QP IDR reconstructs flat fills
+    // exactly (measured zero luma error). The refresh IDR is ~1.4MB — a
+    // one-off burst the idle link absorbs. The main session never saw this
+    // frame, so its next real frame must resync the reference chain with a
+    // forced keyframe (cheap; it happens while content is moving again).
+    // All state lives on `queue`.
+    private var refreshEncoder: VTCompressionSession?
+    private var refreshEncoderFailed = false
+    private var staticRefreshDone = false      // one refresh per still period
+    private var refreshInFlight = false
+    private var resyncMainOnNextFrame = false  // next main-session frame = IDR
+    private var lastRefreshAt = Date.distantPast
+    private var refreshMotionBurstFrames = 0
+    private var lastRefreshMotionFrameAt = Date.distantPast
+    private var encoderIsHEVC = false
+    private var encoderIsProRes4444 = false
+    private var encoderIsProRes4444XQ = false
+    private var encoderWidth = 0
+    private var encoderHeight = 0
+    private var encoderInputPixelFormat: OSType = 0
+    // Still-screen detection threshold + a floor between refreshes so
+    // periodic tiny redraws (a blinking terminal cursor) can't turn into a
+    // refresh/resync loop.
+    private let staticRefreshDelay: TimeInterval = 0.5
+    private let staticRefreshMinInterval: TimeInterval = 2.0
+    private var staticRefreshEnabled: Bool {
+        UserDefaults.standard.object(forKey: "staticRefresh") == nil
+            || UserDefaults.standard.bool(forKey: "staticRefresh")
+    }
+    private var staticRefreshQP: Int {
+        let override = UserDefaults.standard.integer(forKey: "refreshQP")
+        return (1...51).contains(override) ? override : 8
+    }
 
     // ── Outstanding send backpressure (maxPendingSends = 3) ──────────────────
     //
@@ -203,13 +314,42 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // hide it from capture and stream its position on the control channel —
     // the phone draws it locally on the ~2ms path the touches use.
     // Escape hatch: `defaults write sh.peet.opensidecar.mac localCursor -bool false`.
-    private let localCursor = UserDefaults.standard.object(forKey: "localCursor") == nil
+    private let localCursorPreference = UserDefaults.standard.object(forKey: "localCursor") == nil
         || UserDefaults.standard.bool(forKey: "localCursor")
+    private var localCursor: Bool {
+        localCursorPreference && !(lastHello?.cursorInVideo ?? false)
+    }
     private var cursorTimer: DispatchSourceTimer?
     private var cursorImageTimer: DispatchSourceTimer?
     private var lastCursorSent: (x: Double, y: Double, visible: Bool) = (-1, -1, false)
     private var lastCursorPNGHash = 0
     private var captureDisplayID: CGDirectDisplayID = 0
+    // Static quality refreshes are large IDRs on the same ordered TCP stream
+    // as cursor messages. Do not start one while either pointer is active.
+    private var lastCursorActivityAt = Date.distantPast
+    private var cursorOwnsReceiver: Bool {
+        lastCursorSent.visible || remotePointerInsideReceiver
+    }
+    // The echoed visibility flag can briefly be cleared when receiver-side
+    // and sender-side pointer ownership change at nearly the same time. For
+    // expensive refresh decisions, also sample the real CG cursor so a stale
+    // ownership message can never let a large IDR jump ahead of the pointer.
+    private var cursorBlocksStaticRefresh: Bool {
+        cursorOwnsReceiver || isCursorCurrentlyOnCaptureDisplay()
+    }
+    // ScreenCaptureKit can emit a black buffer while the pointer crosses onto
+    // a virtual display. Filter only content that is actually black: pausing
+    // every frame here makes AVSampleBufferDisplayLayer clear to black while
+    // the independent cursor layer keeps moving (visible as cursor trails).
+    private var suppressCursorEntryBlackFramesUntil = Date.distantPast
+    private var remotePointerInsideReceiver = false
+
+    // A Mac receiver sends hover moves only while its cursor is over the video
+    // view. The sender's synthetic cursor itself remains parked on the virtual
+    // display after the local cursor leaves that view, so `lastCursorSent`
+    // alone cannot detect a later re-entry. A resumed move at the video edge
+    // is the missing transition signal and re-arms the capture guard.
+    private var lastRemotePointerInputAt = Date.distantPast
 
     // Input latency: touches arrive stamped in our clock (the phone applies
     // its sync offset); delta to now = network + deframe + dispatch.
@@ -244,6 +384,17 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private var lastPixelBuffer: CVPixelBuffer?
     private var lastCaptureAt = Date.distantPast
 
+    // The FIRST frame has the same problem, worse: a fresh virtual display
+    // whose wallpaper finished drawing before capture started is fully
+    // static, so SCK delivers nothing at all and the receiver stays dark
+    // with no buffer to replay. A screenshot seeds the pipeline (observed
+    // with Mac receivers, whose displays take seconds to set up).
+    private var captureFilter: SCContentFilter?
+    private var captureConfig: SCStreamConfiguration?
+    private var captureStartedAt = Date.distantFuture
+    private var seedingFirstFrame = false
+    private var firstFrameLogged = false
+
     init(transport: SenderTransport, name: String, mode: CaptureMode,
          quality: StreamQuality = .best, displaySerial: UInt32 = 0x0001,
          awaitingWake: Bool = false) {
@@ -265,6 +416,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             monitorsStarted = true
             schedulePing()
             scheduleWatchdog()
+            scheduleStaticRefresh()
         }
 
         // Screen Recording permission: poll until granted. No auto-prompt at
@@ -324,7 +476,12 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     /// phone dimensions. Called at startup and again whenever the phone
     /// rotates (it re-sends hello with swapped dimensions).
     private func setupExtend(_ info: PhoneInfo) async throws {
-        Log.info("phone hello: \(info.pixelsWide)x\(info.pixelsHigh) @\(info.scale)x")
+        Log.info("phone hello: \(info.pixelsWide)x\(info.pixelsHigh) @\(info.scale)x "
+            + "color=\((info.colorSpace ?? .sRGB).rawValue) "
+            + "ICC=\(info.iccProfileData?.count ?? 0)B "
+            + "receiver=\(info.receiverVersion ?? "legacy")"
+            + "(\(info.receiverBuild ?? "unknown")) "
+            + "render=\(info.renderPath ?? "unspecified")")
 
         // Phone panel is @3x; the virtual display runs @2x HiDPI, so points
         // = native pixels / 2 (rounded down to even for the encoder).
@@ -371,6 +528,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 VirtualDisplay(name: displayName,
                                pointsWide: pointsWide, pointsHigh: pointsHigh,
                                sizeInMillimeters: mm, serialNum: serial,
+                               workingColorSpace: info.colorSpace ?? .sRGB,
+                               targetICCProfile: info.iccProfileData,
                                restoreOrigin: DisplayArrangement.origin(for: sizeInPoints,
                                                                         device: arrangementKey),
                                onOriginChange: { origin in
@@ -388,6 +547,20 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         }
         virtualDisplay = vd
         inputInjector = InputInjector(displayID: vd.displayID)
+
+        // ColorSync registers a new virtual display asynchronously. Wait for
+        // its working profile before ScreenCaptureKit observes the display;
+        // otherwise WindowServer first composites the desktop into sRGB and
+        // clips P3 colors before capture can preserve them.
+        var colorProfileReady = false
+        for _ in 0..<20 {
+            colorProfileReady = await MainActor.run { vd.ensureWorkingColorProfile() }
+            if colorProfileReady { break }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        if !colorProfileReady {
+            Log.info("virtual display color profile did not settle before capture")
+        }
 
         let display = try await findSCDisplay(id: vd.displayID)
         // Quality scaling: capture/encode below native when requested — the
@@ -420,6 +593,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             stream = nil
             if let encoder { VTCompressionSessionInvalidate(encoder) }
             encoder = nil
+            if let refreshEncoder { VTCompressionSessionInvalidate(refreshEncoder) }
+            refreshEncoder = nil
             virtualDisplay = nil   // removes the old display
             needsKeyframe = true
             do {
@@ -430,7 +605,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 return
             }
             if let latest = lastHello,
-               latest.pixelsWide != target.pixelsWide || latest.pixelsHigh != target.pixelsHigh {
+               latest.pixelsWide != target.pixelsWide
+                || latest.pixelsHigh != target.pixelsHigh
+                || latest.colorSpace != target.colorSpace
+                || latest.iccProfile != target.iccProfile {
                 target = latest   // rotated again while we were rebuilding
                 continue
             }
@@ -452,38 +630,101 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     }
 
     private func startCapture(display: SCDisplay, pixelsWide: Int, pixelsHigh: Int) async throws {
+        // The low-latency H.264 hardware encoder silently drops EVERY frame
+        // beyond H.264 level 5.2's 60fps ceiling — observed with a Mac
+        // receiver announcing 4096x2304: VTCompressionSession returns noErr
+        // with a nil sample for 100% of frames, indistinguishable from "no
+        // capture" without the callback-error counter. 3840x2160@60 is the
+        // largest size inside the level, so clamp the CAPTURE there — the
+        // virtual display keeps its native size (window layout and UI
+        // density unaffected); only the stream is downscaled, exactly like
+        // the quality presets already do. HEVC's hardware envelope is far
+        // larger (8K-class), so its clamp exists only as a sanity bound —
+        // 5K iMac panels encode at native size.
+        let maxEncode = (shouldUseProRes4444 || shouldUseHEVC)
+            ? (w: 6144.0, h: 3456.0)
+            : (w: 3840.0, h: 2160.0)
+        let clamp = min(1.0, maxEncode.w / Double(pixelsWide), maxEncode.h / Double(pixelsHigh))
+        let captureW = (Int(Double(pixelsWide) * clamp)) & ~1
+        let captureH = (Int(Double(pixelsHigh) * clamp)) & ~1
+        if clamp < 1.0 {
+            Log.info("capture clamped to \(captureW)x\(captureH) (encoder limit; display stays \(pixelsWide)x\(pixelsHigh))")
+        }
+
         let filter = SCContentFilter(display: display, excludingWindows: [])
 
         let config = SCStreamConfiguration()
-        config.width = pixelsWide
-        config.height = pixelsHigh
+        config.width = captureW
+        config.height = captureH
         // Ask for 120 even though the virtual display is 60Hz: requesting
         // exactly 1/60 makes SCK's rate limiter skip frames that arrive a
         // hair early (beat frequency) — measured ~51fps instead of 60.
         config.minimumFrameInterval = CMTime(value: 1, timescale: 120)
-        // 420v matches the encoder's native input — skips a BGRA→YUV conversion
-        // inside VideoToolbox. (`-pixfmt bgra` reverts for A/B testing.)
-        config.pixelFormat = UserDefaults.standard.string(forKey: "pixfmt") == "bgra"
-            ? kCVPixelFormatType_32BGRA
-            : kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+        // Preserve the desktop at 10-bit 4:4:4 through capture. The HEVC
+        // Main10 hardware encoder performs the final 4:2:0 conversion once;
+        // the previous 8-bit 4:2:0 capture discarded most chroma samples
+        // before encoding and exposed colored noise/banding on flat fills.
+        // Keep the hidden BGRA override for diagnostics and use the legacy
+        // 420f path for H.264/iOS receivers.
+        let pixelFormat: OSType
+        if UserDefaults.standard.string(forKey: "pixfmt") == "bgra" {
+            pixelFormat = kCVPixelFormatType_32BGRA
+        } else if (shouldUseProRes4444 || shouldUseHEVC), quality == .best {
+            // Compressed YCbCr defaults to video range. The former xf44
+            // full-range input left range propagation dependent on the HEVC
+            // encoder and could look washed out in the system display layer.
+            pixelFormat = kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange
+        } else {
+            pixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
+        }
+        config.pixelFormat = pixelFormat
+        // Make the captured desktop's color meaning deterministic. The Mac
+        // receiver advertises Display P3 when its active ICC is wide-gamut;
+        // old peers and ordinary panels remain in device-independent sRGB.
+        // The encoder writes the same negotiated space into its VUI.
+        // With the receiver's exact ICC installed on the virtual display,
+        // leaving this unset makes ScreenCaptureKit preserve that display
+        // profile. Legacy receivers continue using a standard named space.
+        if workingICCProfile == nil {
+            config.colorSpaceName = workingColorSpace == .displayP3
+                ? CGColorSpace.displayP3
+                : CGColorSpace.sRGB
+        }
+        // ScreenCaptureKit only accepts colorMatrix for 420v/420f. The
+        // 10-bit 4:4:4 format carries full-resolution chroma and preserves
+        // its meaning through the display color space.
+        if pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+            || pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange {
+            config.colorMatrix = kCVImageBufferYCbCrMatrix_ITU_R_709_2
+        }
         // One buffer is held permanently (keyframe replay) and one sits in
         // the encoder for ~13ms — headroom prevents SCK starvation drops.
         config.queueDepth = 8
         config.showsCursor = !localCursor
 
-        setupEncoder(width: pixelsWide, height: pixelsHigh)
+        setupEncoder(width: captureW, height: captureH,
+                     inputPixelFormat: pixelFormat)
 
         let stream = SCStream(filter: filter, configuration: config, delegate: self)
         try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: queue)
+        // Set BEFORE capture starts: delegate frames land on `queue` the
+        // moment startCapture returns, racing assignments made after it
+        // (observed as a distantFuture-based first-frame log line).
+        captureStartedAt = Date()
+        firstFrameLogged = false
         try await stream.startCapture()
         self.stream = stream
         captureDisplayID = display.displayID
+        captureFilter = filter
+        captureConfig = config
         lastCursorPNGHash = 0      // rotation rebuilds: re-send the sprite
         lastCursorSent = (-1, -1, false)
         startCursorEcho()
-        Log.info("capture started: \(pixelsWide)x\(pixelsHigh) display \(display.displayID) mode \(mode.rawValue) localCursor=\(localCursor)")
+        Log.info("capture started: \(captureW)x\(captureH) display \(display.displayID) "
+            + "mode \(mode.rawValue) localCursor=\(localCursor) "
+            + "color=\(workingColorSpace.rawValue)")
         let kind = lastHello?.kind ?? "device"
-        await status("\(mode == .extend ? "Extending to" : "Mirroring to") \(kind) (\(pixelsWide)×\(pixelsHigh))")
+        await status("\(mode == .extend ? "Extending to" : "Mirroring to") \(kind) (\(captureW)×\(captureH))")
     }
 
     func stop() {
@@ -496,8 +737,14 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         stream = nil
         connection?.cancel()
         connection = nil
+        cursorConnection?.cancel()
+        cursorConnection = nil
+        cursorConnectionReady = false
+        cursorEndpointKey = ""
         if let encoder { VTCompressionSessionInvalidate(encoder) }
         encoder = nil
+        if let refreshEncoder { VTCompressionSessionInvalidate(refreshEncoder) }
+        refreshEncoder = nil
         virtualDisplay = nil   // releasing it removes the display
         queue.async { [weak self] in
             // Unblock a start() that is still waiting for the hello.
@@ -527,6 +774,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             self.dialGeneration += 1   // a dial still in flight must not adopt
             self.connection?.cancel()
             self.connection = nil
+            self.cursorConnection?.cancel()
+            self.cursorConnection = nil
+            self.cursorConnectionReady = false
+            self.cursorEndpointKey = ""
             self.pendingSends = 0
             self.pipelineLock.lock()
             self.pendingEncodes = 0
@@ -618,7 +869,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private func connect() {
         guard !stopped else { return }
         switch transport {
-        case .tcp(let endpoint): connectTCP(endpoint)
+        case .tcp(let endpoint, let requiredInterface):
+            connectTCP(endpoint, requiredInterface: requiredInterface)
         case .usb(let udid, let port): connectUSB(udid: udid, port: port)
         }
     }
@@ -639,30 +891,46 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // the fresh peer — the cursor analogue of forcing a keyframe.
         lastCursorPNGHash = 0
         lastCursorSent = (-1, -1, false)
+        remotePointerInsideReceiver = false
         lastReceived = Date()  // fresh grace period for the watchdog
         receiveControl(on: conn)
+        // Detect the local interface used for this connection. Thunderbolt
+        // bridge interfaces are named "bridge*"; everything else is WiFi/ETH.
+        if let path = conn.currentPath {
+            let ifaceName = path.availableInterfaces.first?.name ?? ""
+            let isBridge = ifaceName.hasPrefix("bridge")
+            Task { @MainActor in
+                self.onTransportDetected?(isBridge ? "bridge" : "wifi")
+            }
+            Log.info("connection interface: \(ifaceName) (bridge=\(isBridge))")
+        }
         Task { await self.status("Connected to \(self.endpointName)") }
     }
 
-    private func connectTCP(_ endpoint: NWEndpoint) {
-        let options = NWProtocolTCP.Options()
-        options.noDelay = true   // latency matters more than throughput here
-        let params = NWParameters(tls: nil, tcp: options)
-        let conn = NWConnection(to: endpoint, using: params)
-        connection = conn
-        // A dial to a withdrawn Bonjour service (receiver asleep or app
-        // closed) sits in .preparing forever — it neither fails nor resolves
-        // when the service later returns, observed on macOS 26. Give every
-        // dial a deadline and redial fresh: a new NWConnection re-runs
-        // Bonjour resolution, so the retry loop reaches the receiver the
-        // moment it advertises again.
+    private func armDialDeadline(_ conn: NWConnection) {
         let generation = dialGeneration
         queue.asyncAfter(deadline: .now() + 5.0) { [weak self] in
             guard let self, generation == self.dialGeneration, !self.stopped,
                   self.connection === conn, conn.state != .ready else { return }
-            Log.info("dial timed out in \(conn.state) — redialing")
+            Log.info("dial timed out — redialing")
+            conn.cancel()
             self.scheduleReconnect()
         }
+    }
+
+    private func connectTCP(_ endpoint: NWEndpoint,
+                            requiredInterface: NWInterface?) {
+        let options = NWProtocolTCP.Options()
+        options.noDelay = true   // latency matters more than throughput here
+        let params = NWParameters(tls: nil, tcp: options)
+        params.includePeerToPeer = true
+        if let requiredInterface {
+            params.requiredInterface = requiredInterface
+            Log.info("dial constrained to interface \(requiredInterface.name)")
+        }
+        let conn = NWConnection(to: endpoint, using: params)
+        connection = conn
+        armDialDeadline(conn)
         conn.stateUpdateHandler = { [weak self] state in
             guard let self else { return }
             switch state {
@@ -770,6 +1038,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         let generation = dialGeneration
         connection?.cancel()
         connection = nil
+        cursorConnection?.cancel()
+        cursorConnection = nil
+        cursorConnectionReady = false
+        cursorEndpointKey = ""
         pendingSends = 0
         pipelineLock.lock()
         pendingEncodes = 0
@@ -837,7 +1109,219 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 Log.info("static screen after reconnect — replaying last frame as keyframe")
                 self.encode(pixelBuffer, pts: CMClockGetTime(CMClockGetHostTimeClock()))
             }
+            // No frame has EVER arrived (static virtual display since before
+            // capture started) — there is nothing to replay, so seed one.
+            if self.connectionReady, self.needsKeyframe, self.stream != nil,
+               self.lastPixelBuffer == nil, !self.seedingFirstFrame,
+               Date().timeIntervalSince(self.captureStartedAt) > 1 {
+                self.seedFirstFrame()
+            }
             self.scheduleWatchdog()
+        }
+    }
+
+    // MARK: - Static-screen refresh (see the property block for rationale)
+
+    private func scheduleStaticRefresh() {
+        queue.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+            guard let self, !self.stopped else { return }
+            self.maybeSendStaticRefresh()
+            self.scheduleStaticRefresh()
+        }
+    }
+
+    /// Must be called on `queue`. Fires at most once per still period, only
+    /// while the pipeline is idle, and never within staticRefreshMinInterval
+    /// of the previous refresh (a blinking cursor must not loop refreshes).
+    private func maybeSendStaticRefresh() {
+        guard connectionReady, encoderIsHEVC, staticRefreshEnabled,
+              !staticRefreshDone, !refreshInFlight, !needsKeyframe,
+              !cursorBlocksStaticRefresh,
+              Date().timeIntervalSince(lastCaptureAt) > staticRefreshDelay,
+              Date().timeIntervalSince(lastCursorActivityAt) > 0.75,
+              Date().timeIntervalSince(lastRefreshAt) > staticRefreshMinInterval,
+              let pixelBuffer = lastPixelBuffer,
+              pendingSends == 0 else { return }
+        pipelineLock.lock()
+        let encoderBusy = pendingEncodes > 0
+        pipelineLock.unlock()
+        guard !encoderBusy else { return }
+        sendStaticRefresh(pixelBuffer)
+    }
+
+    /// Rearm the expensive still-frame cleanup only after real motion. A
+    /// blinking caret or one status redraw is a lone frame every ~500ms and
+    /// must not create the former two-second refresh/keyframe loop.
+    private func noteCaptureForStaticRefresh(at now: Date) {
+        guard staticRefreshDone else {
+            refreshMotionBurstFrames = 0
+            lastRefreshMotionFrameAt = now
+            return
+        }
+        if now.timeIntervalSince(lastRefreshMotionFrameAt) <= 0.25 {
+            refreshMotionBurstFrames += 1
+        } else {
+            refreshMotionBurstFrames = 1
+        }
+        lastRefreshMotionFrameAt = now
+        if refreshMotionBurstFrames >= 3 {
+            staticRefreshDone = false
+            refreshMotionBurstFrames = 0
+            Log.info("static refresh rearmed after sustained motion")
+        }
+    }
+
+    /// The refresh session: low-latency rate control, because that is the
+    /// only mode where BaseFrameQP is honored — the main session cannot be
+    /// low-latency (the mode caps out around 20fps at 4480x2520, and the
+    /// main session needs 60). Lazily created; geometry follows setupEncoder.
+    private func ensureRefreshEncoder() -> VTCompressionSession? {
+        if let refreshEncoder { return refreshEncoder }
+        guard !refreshEncoderFailed, encoderWidth > 0, encoderHeight > 0 else { return nil }
+        let spec = [
+            kVTVideoEncoderSpecification_EnableLowLatencyRateControl: kCFBooleanTrue,
+        ] as CFDictionary
+        let inputAttributes = [
+            kCVPixelBufferPixelFormatTypeKey: encoderInputPixelFormat,
+        ] as CFDictionary
+        var session: VTCompressionSession?
+        VTCompressionSessionCreate(
+            allocator: nil,
+            width: Int32(encoderWidth), height: Int32(encoderHeight),
+            codecType: kCMVideoCodecType_HEVC,
+            encoderSpecification: spec,
+            imageBufferAttributes: inputAttributes,
+            compressedDataAllocator: nil,
+            outputCallback: nil,
+            refcon: nil,
+            compressionSessionOut: &session)
+        guard let session else {
+            // E.g. hardware without a low-latency HEVC engine. The stream
+            // stays correct without refreshes — just less pretty when still.
+            refreshEncoderFailed = true
+            Log.info("static refresh disabled: low-latency HEVC session unavailable")
+            return nil
+        }
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_RealTime, value: kCFBooleanTrue)
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_AllowFrameReordering, value: kCFBooleanFalse)
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_ProfileLevel,
+                             value: encoderInputPixelFormat == kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange
+                                ? kVTProfileLevel_HEVC_Main10_AutoLevel
+                                : kVTProfileLevel_HEVC_Main_AutoLevel)
+        if let workingICCProfile {
+            VTSessionSetProperty(session, key: kVTCompressionPropertyKey_ICCProfile,
+                                 value: workingICCProfile as CFData)
+        }
+        // Keep the named colour metadata explicit even when an exact ICC is
+        // present. VideoToolbox does not reliably serialize ICC into ProRes
+        // and otherwise guesses Rec.709 primaries/transfer on decode, which
+        // conflicts with the receiver's Display P3 panel profile.
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_ColorPrimaries,
+                             value: workingColorSpace == .displayP3
+                                ? kCMFormatDescriptionColorPrimaries_P3_D65
+                                : kCMFormatDescriptionColorPrimaries_ITU_R_709_2)
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_TransferFunction,
+                             value: kCMFormatDescriptionTransferFunction_sRGB)
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_YCbCrMatrix,
+                             value: kCMFormatDescriptionYCbCrMatrix_ITU_R_709_2)
+        VTCompressionSessionPrepareToEncodeFrames(session)
+        refreshEncoder = session
+        Log.info("static refresh encoder ready (\(encoderWidth)x\(encoderHeight) QP\(staticRefreshQP))")
+        return session
+    }
+
+    /// Encode `pixelBuffer` as a fixed-QP IDR on the refresh session and send
+    /// it. Must be called on `queue`.
+    private func sendStaticRefresh(_ pixelBuffer: CVPixelBuffer) {
+        guard let refresher = ensureRefreshEncoder() else { return }
+        staticRefreshDone = true
+        refreshMotionBurstFrames = 0
+        lastRefreshMotionFrameAt = Date.distantPast
+        refreshInFlight = true
+        lastRefreshAt = Date()
+        let stillMark = lastCaptureAt
+        let capturedAtMs = Int64(Date().timeIntervalSince1970 * 1000)
+        let qp = staticRefreshQP
+        let frameProperties: [CFString: Any] = [
+            kVTEncodeFrameOptionKey_ForceKeyFrame: kCFBooleanTrue,
+            kVTEncodeFrameOptionKey_BaseFrameQP: qp as CFNumber,
+        ]
+        let status = VTCompressionSessionEncodeFrame(
+            refresher,
+            imageBuffer: pixelBuffer,
+            presentationTimeStamp: CMClockGetTime(CMClockGetHostTimeClock()),
+            duration: .invalid,
+            frameProperties: frameProperties as CFDictionary,
+            infoFlagsOut: nil
+        ) { [weak self] status, _, buffer in
+            guard let self else { return }
+            self.queue.async {
+                self.refreshInFlight = false
+                guard status == noErr, let buffer else {
+                    Log.info("static refresh encode failed: \(status)")
+                    return
+                }
+                // A real frame arrived while the refresh encoded — the
+                // refresh content is stale now; sending it would step the
+                // picture backwards for a frame. The same applies when a
+                // pointer entered meanwhile: this large IDR shares TCP with
+                // cursor messages, so it must never be allowed to get ahead
+                // of an active pointer.
+                guard self.lastCaptureAt == stillMark, self.connectionReady else { return }
+                guard !self.cursorBlocksStaticRefresh,
+                      Date().timeIntervalSince(self.lastCursorActivityAt) > 0.75 else {
+                    // Retry once the pointer leaves and the cooldown expires.
+                    self.staticRefreshDone = false
+                    Log.info("static refresh cancelled: cursor active")
+                    return
+                }
+                guard let data = self.annexB(from: buffer) else { return }
+                // The foreign refresh IDR resets the receiver's reference
+                // chain. Force the next main-session frame to be an IDR too,
+                // but only when the refresh is actually going onto the wire.
+                self.resyncMainOnNextFrame = true
+                let sndMs = Int64(Date().timeIntervalSince1970 * 1000)
+                var framed = Data("{\"cap\":\(capturedAtMs),\"snd\":\(sndMs)}".utf8)
+                framed.append(data)
+                self.sendFramed(framed)
+                Log.info("static refresh sent: \(data.count / 1024)KB QP\(qp)")
+            }
+        }
+        if status != noErr {
+            refreshInFlight = false
+            Log.info("static refresh submit failed: \(status)")
+        }
+    }
+
+    /// Grab one screenshot of the captured display and push it through the
+    /// normal encode path as the first (key)frame. Runs at most once at a
+    /// time; must be called on `queue`.
+    private func seedFirstFrame() {
+        guard let filter = captureFilter, let config = captureConfig else { return }
+        seedingFirstFrame = true
+        Log.info("no capture frames since start — seeding one via screenshot")
+        Task { [weak self] in
+            do {
+                let sample = try await SCScreenshotManager.captureSampleBuffer(
+                    contentFilter: filter, configuration: config)
+                self?.queue.async {
+                    guard let self else { return }
+                    self.seedingFirstFrame = false
+                    guard !self.stopped, self.connectionReady,
+                          self.lastPixelBuffer == nil,
+                          let pixelBuffer = CMSampleBufferGetImageBuffer(sample)
+                    else { return }
+                    // Keep it for the reconnect replay too; lastCaptureAt
+                    // stays untouched so that replay path can still fire.
+                    self.lastPixelBuffer = pixelBuffer
+                    self.encode(pixelBuffer, pts: CMClockGetTime(CMClockGetHostTimeClock()))
+                }
+            } catch {
+                self?.queue.async {
+                    self?.seedingFirstFrame = false
+                    Log.info("screenshot seed failed: \(error)")
+                }
+            }
         }
     }
 
@@ -847,7 +1331,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         guard localCursor else { return }
         cursorTimer?.cancel()
         let timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(deadline: .now(), repeating: .milliseconds(8))   // 120Hz
+        // Oversample the 60Hz receiver so a busy 4.5K ProRes encode cannot
+        // turn one delayed timer firing into a visibly missing pointer step.
+        timer.schedule(deadline: .now(), repeating: .milliseconds(4),
+                       leeway: .milliseconds(1))   // up to 240Hz
         timer.setEventHandler { [weak self] in self?.pollCursorPosition() }
         timer.resume()
         cursorTimer = timer
@@ -876,6 +1363,18 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     }
 
     private func pollCursorPosition() {
+        // A Mac receiver renders its own hardware pointer position while the
+        // pointer is over the video. Sampling the synthetic CG cursor here
+        // would send an older coordinate back and make diagonal movement
+        // visibly oscillate. iOS/older receivers do not send this state and
+        // continue using the existing sampled echo path.
+        // Suppress only the round-trip echo that overlaps fresh receiver-side
+        // input. Once that input pauses, a genuinely different coordinate
+        // from the sending Mac's physical mouse may take ownership again.
+        if remotePointerInsideReceiver,
+           Date().timeIntervalSince(lastRemotePointerInputAt) < 0.08 {
+            return
+        }
         guard connectionReady, captureDisplayID != 0,
               let loc = CGEvent(source: nil)?.location else { return }
         let bounds = CGDisplayBounds(captureDisplayID)
@@ -883,14 +1382,31 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         if bounds.contains(loc) {
             let x = (loc.x - bounds.minX) / bounds.width
             let y = (loc.y - bounds.minY) / bounds.height
+            if !lastCursorSent.visible {
+                armCursorEntryFrameGuard(reason: "cursor became visible")
+            }
             if !lastCursorSent.visible
-                || abs(x - lastCursorSent.x) > 0.0004 || abs(y - lastCursorSent.y) > 0.0004 {
+                || abs(x - lastCursorSent.x) > 0.00005 || abs(y - lastCursorSent.y) > 0.00005 {
                 lastCursorSent = (x, y, true)
-                sendJSONFrame(String(format: "{\"type\":\"cursor\",\"x\":%.4f,\"y\":%.4f,\"v\":1}", x, y))
+                lastCursorActivityAt = Date()
+                cursorSequence &+= 1
+                sendCursorFrame(String(format: "{\"type\":\"cursor\",\"x\":%.6f,\"y\":%.6f,\"v\":1,\"s\":%llu}", x, y, cursorSequence))
             }
         } else if lastCursorSent.visible {
             lastCursorSent.visible = false
-            sendJSONFrame("{\"type\":\"cursor\",\"v\":0}")
+            lastCursorActivityAt = Date()
+            cursorSequence &+= 1
+            sendCursorFrame("{\"type\":\"cursor\",\"v\":0,\"s\":\(cursorSequence)}")
+        }
+    }
+
+    private func armCursorEntryFrameGuard(reason: String) {
+        let now = Date()
+        let wasInactive = now > suppressCursorEntryBlackFramesUntil
+
+        suppressCursorEntryBlackFramesUntil = now.addingTimeInterval(0.40)
+        if wasInactive {
+            Log.info("cursor-entry capture guard armed: \(reason)")
         }
     }
 
@@ -974,6 +1490,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             if let info = try? JSONDecoder().decode(PhoneInfo.self, from: payload) {
                 let previous = lastHello
                 lastHello = info
+                configureCursorChannel(info)
                 Task { @MainActor in self.onHello?(info) }
                 // Version handshake (issue #132). Reply with our identity, and
                 // if the receiver is below the version we support, tell it to
@@ -990,14 +1507,18 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                     continuation.resume(returning: info)
                 } else if mode == .extend, stream != nil, let previous,
                           previous.pixelsWide != info.pixelsWide
-                          || previous.pixelsHigh != info.pixelsHigh {
-                    // Phone rotated — rebuild after a short debounce so a
-                    // flurry of orientation flips settles into one rebuild.
+                          || previous.pixelsHigh != info.pixelsHigh
+                          || previous.colorSpace != info.colorSpace
+                          || previous.iccProfile != info.iccProfile {
+                    // Rotation or target-profile change — rebuild after a
+                    // short debounce so a flurry of changes settles into one.
                     Task {
                         try? await Task.sleep(for: .milliseconds(300))
                         guard let current = self.lastHello,
                               current.pixelsWide == info.pixelsWide,
-                              current.pixelsHigh == info.pixelsHigh else { return }
+                              current.pixelsHigh == info.pixelsHigh,
+                              current.colorSpace == info.colorSpace,
+                              current.iccProfile == info.iccProfile else { return }
                         await self.reconfigure(info)
                     }
                 }
@@ -1006,6 +1527,29 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             if let phase = obj["phase"] as? String,
                let x = obj["x"] as? Double,
                let y = obj["y"] as? Double {
+                if phase == "moved" || phase == "began" {
+                    let now = Date()
+                    lastCursorActivityAt = now
+                    let idle = now.timeIntervalSince(lastRemotePointerInputAt)
+                    let edgeDistance = min(x, 1 - x, y, 1 - y)
+                    // Re-entering the receiver video begins at one of its
+                    // edges. Requiring both an input gap and an edge position
+                    // avoids adding a hold after an ordinary pause in the
+                    // middle of the remote desktop.
+                    if !remotePointerInsideReceiver,
+                       idle > 0.35, edgeDistance <= 0.045 {
+                        armCursorEntryFrameGuard(
+                            reason: String(format: "remote pointer resumed after %.0fms", idle * 1000))
+                    }
+                    lastRemotePointerInputAt = now
+                    // Track the injected position without echoing it back.
+                    // After receiver input pauses, polling sees the same point
+                    // and stays quiet; only a different physical-sender point
+                    // is sent, which cleanly transfers cursor ownership.
+                    if remotePointerInsideReceiver {
+                        lastCursorSent = (x, y, true)
+                    }
+                }
                 inputInjector?.handleTouch(phase: phase, x: x, y: y)
                 if let t = obj["t"] as? Double {
                     let delta = Date().timeIntervalSince1970 * 1000 - t
@@ -1015,8 +1559,20 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                     }
                 }
             }
+        case "pointerPresence":
+            if let inside = obj["inside"] as? Bool {
+                remotePointerInsideReceiver = inside
+                lastCursorActivityAt = Date()
+                if inside {
+                    armCursorEntryFrameGuard(reason: "receiver pointer entered")
+                } else if lastCursorSent.visible {
+                    lastCursorSent.visible = false
+                    sendJSONFrame("{\"type\":\"cursor\",\"v\":0}")
+                }
+            }
         case "scroll":
             if let dx = obj["dx"] as? Double, let dy = obj["dy"] as? Double {
+                lastCursorActivityAt = Date()
                 inputInjector?.handleScroll(dx: dx, dy: dy)
             }
         case "pencil":
@@ -1092,43 +1648,274 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     // MARK: - Encoder setup
 
-    private func setupEncoder(width: Int, height: Int) {
-        // Low-latency rate control: the hardware encoder emits every frame
-        // immediately instead of pipelining. (`-lowlatency NO` for A/B.)
-        let lowLatency = UserDefaults.standard.object(forKey: "lowlatency") == nil
-            || UserDefaults.standard.bool(forKey: "lowlatency")
-        let spec: CFDictionary? = lowLatency
-            ? [kVTVideoEncoderSpecification_EnableLowLatencyRateControl: kCFBooleanTrue] as CFDictionary
-            : nil
+    private func setupEncoder(width: Int, height: Int,
+                              inputPixelFormat: OSType) {
+        // ProRes 4444 is the paired-Mac fidelity experiment. It preserves
+        // 10-bit 4:4:4 and makes every frame independently decodable. If the
+        // hardware session is unavailable, fall through to the established
+        // HEVC/H.264 path so mixed-version installs remain usable.
+        let wantProRes4444 = shouldUseProRes4444
+        let wantProRes4444XQ = shouldUseProRes4444XQ
+        // HEVC when the receiver offered it in its hello (Mac receivers):
+        // better quality per bit, and the hardware encoder sustains 60fps at
+        // sizes where the H.264 engine falls over. iOS receivers don't send
+        // the offer and stay on H.264. Falls back if session creation fails
+        // (e.g. an older Intel machine without an HEVC encoder) — the
+        // receiver auto-detects the codec from the bitstream either way.
+        let wantHEVC = shouldUseHEVC
+        if (lastHello?.prores4444 ?? false), !wantProRes4444 {
+            Log.info("ProRes 4444 offer overridden — using HEVC/H.264")
+        }
+        if (lastHello?.hevc ?? false), !wantHEVC {
+            Log.info("HEVC offer overridden — using H.264")
+        }
+        // Apple's low-latency HEVC rate controller is excellent below 4K,
+        // but throttles a 4480x2520 stream to ~19fps. Let VideoToolbox use its
+        // normal hardware pipeline above 4K (measured 47–48fps with 3 slots).
+        // Keep the hidden override for diagnostics.
+        let pixels = width * height
+        let accurate10Bit = (wantProRes4444 || wantHEVC)
+            && inputPixelFormat == kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange
+        let lowLatency = UserDefaults.standard.object(forKey: "lowlatency") != nil
+            ? UserDefaults.standard.bool(forKey: "lowlatency")
+            : !(wantHEVC && pixels > 3840 * 2160) && !wantProRes4444
+        // Native Mac-receiver best quality is the fidelity path. BaseFrameQP
+        // is only honored by VideoToolbox's low-latency controller; the 4.5K
+        // path uses normal rate control for throughput, so constrain it with
+        // MaxAllowedFrameQP instead of logging a fixed QP that is ignored.
+        let nativeFidelity = accurate10Bit && quality == .best
+        // Asking the hardware encoder to spend extra time on mode decisions
+        // works well through 4K, but measured ~68ms/frame and ~20fps at the
+        // iMac's 4480x2520. At 4.5K, retain the real-time search path and get
+        // fidelity from the tighter QP ceiling, larger bit budget and QP-8
+        // idle refresh instead.
+        let qualityFirstEncoder = nativeFidelity && pixels <= 3840 * 2160
+        fixedDesktopQP = !wantProRes4444 && nativeFidelity && lowLatency ? 12 : nil
+        let maxFrameQP = nativeFidelity ? 16 : 20
+        var proResCodecType = wantProRes4444XQ
+            ? kCMVideoCodecType_AppleProRes4444XQ
+            : kCMVideoCodecType_AppleProRes4444
+        let proResEncoderID = wantProRes4444XQ
+            ? "com.apple.videotoolbox.videoencoder.appleproreshw.4444xq"
+            : "com.apple.videotoolbox.videoencoder.appleproreshw.4444"
+        let spec: CFDictionary? = wantProRes4444
+            ? [kVTVideoEncoderSpecification_EncoderID:
+                proResEncoderID as CFString] as CFDictionary
+            : (lowLatency
+                ? [kVTVideoEncoderSpecification_EnableLowLatencyRateControl: kCFBooleanTrue] as CFDictionary
+                : nil)
+        var usingProRes4444 = wantProRes4444
+        var usingProRes4444XQ = wantProRes4444XQ
+        var usingHEVC = !wantProRes4444 && wantHEVC
+        let inputAttributes = [
+            kCVPixelBufferPixelFormatTypeKey: inputPixelFormat,
+        ] as CFDictionary
         VTCompressionSessionCreate(
             allocator: nil,
             width: Int32(width), height: Int32(height),
-            codecType: kCMVideoCodecType_H264,
+            codecType: wantProRes4444
+                ? proResCodecType
+                : (wantHEVC ? kCMVideoCodecType_HEVC : kCMVideoCodecType_H264),
             encoderSpecification: spec,
-            imageBufferAttributes: nil,
+            imageBufferAttributes: inputAttributes,
             compressedDataAllocator: nil,
             outputCallback: nil,
             refcon: nil,
             compressionSessionOut: &encoder
         )
+        if encoder == nil, wantProRes4444XQ {
+            Log.info("hardware ProRes 4444 XQ session creation failed — falling back to hardware 4444")
+            proResCodecType = kCMVideoCodecType_AppleProRes4444
+            usingProRes4444XQ = false
+            let fallbackSpec = [kVTVideoEncoderSpecification_EncoderID:
+                "com.apple.videotoolbox.videoencoder.appleproreshw.4444" as CFString] as CFDictionary
+            VTCompressionSessionCreate(
+                allocator: nil,
+                width: Int32(width), height: Int32(height),
+                codecType: proResCodecType,
+                encoderSpecification: fallbackSpec,
+                imageBufferAttributes: inputAttributes,
+                compressedDataAllocator: nil,
+                outputCallback: nil,
+                refcon: nil,
+                compressionSessionOut: &encoder
+            )
+        }
+        if encoder == nil, wantProRes4444 {
+            Log.info("hardware ProRes session creation failed — trying generic ProRes 4444")
+            proResCodecType = kCMVideoCodecType_AppleProRes4444
+            usingProRes4444XQ = false
+            VTCompressionSessionCreate(
+                allocator: nil,
+                width: Int32(width), height: Int32(height),
+                codecType: kCMVideoCodecType_AppleProRes4444,
+                encoderSpecification: nil,
+                imageBufferAttributes: inputAttributes,
+                compressedDataAllocator: nil,
+                outputCallback: nil,
+                refcon: nil,
+                compressionSessionOut: &encoder
+            )
+        }
+        if encoder == nil, wantProRes4444 {
+            Log.info("ProRes 4444 session creation failed — falling back to HEVC")
+            usingProRes4444 = false
+            usingProRes4444XQ = false
+            usingHEVC = wantHEVC
+            let fallbackSpec: CFDictionary? = lowLatency
+                ? [kVTVideoEncoderSpecification_EnableLowLatencyRateControl: kCFBooleanTrue] as CFDictionary
+                : nil
+            VTCompressionSessionCreate(
+                allocator: nil,
+                width: Int32(width), height: Int32(height),
+                codecType: wantHEVC ? kCMVideoCodecType_HEVC : kCMVideoCodecType_H264,
+                encoderSpecification: fallbackSpec,
+                imageBufferAttributes: inputAttributes,
+                compressedDataAllocator: nil,
+                outputCallback: nil,
+                refcon: nil,
+                compressionSessionOut: &encoder
+            )
+        }
+        if encoder == nil, wantHEVC {
+            Log.info("HEVC session creation failed — falling back to H.264")
+            usingProRes4444 = false
+            usingProRes4444XQ = false
+            usingHEVC = false
+            VTCompressionSessionCreate(
+                allocator: nil,
+                width: Int32(width), height: Int32(height),
+                codecType: kCMVideoCodecType_H264,
+                encoderSpecification: nil,
+                imageBufferAttributes: inputAttributes,
+                compressedDataAllocator: nil,
+                outputCallback: nil,
+                refcon: nil,
+                compressionSessionOut: &encoder
+            )
+        }
         guard let encoder else {
             Log.info("FATAL: VTCompressionSessionCreate failed")
             return
         }
-        // Low-latency settings: real-time, no B-frames, periodic keyframes.
+        // Real-time, no B-frames. ProRes is intra-only; inter-frame controls
+        // and rate-control/QP properties below are only meaningful to HEVC/H.264.
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_RealTime, value: kCFBooleanTrue)
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_AllowFrameReordering, value: kCFBooleanFalse)
-        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ProfileLevel, value: kVTProfileLevel_H264_High_AutoLevel)
-        // No periodic IDRs: each one is a bitrate spike → transmit-time hiccup.
-        // TCP never loses data, and we force a keyframe on reconnect/drop.
-        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_MaxKeyFrameInterval, value: 3600 as CFNumber)
-        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration, value: 60 as CFNumber)
+        if !usingProRes4444 {
+            VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ProfileLevel,
+                                 value: usingHEVC
+                                    ? (accurate10Bit
+                                        ? kVTProfileLevel_HEVC_Main10_AutoLevel
+                                        : kVTProfileLevel_HEVC_Main_AutoLevel)
+                                    : kVTProfileLevel_H264_High_AutoLevel)
+        }
+        if let workingICCProfile {
+            VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ICCProfile,
+                                 value: workingICCProfile as CFData)
+        }
+        // ICC and named metadata are complementary here. In particular,
+        // Apple's ProRes encoder accepts ICC but does not put it in the
+        // compressed format description; explicit P3/sRGB prevents the
+        // decoder from guessing a contradictory Rec.709 colour space.
+        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ColorPrimaries,
+                             value: workingColorSpace == .displayP3
+                                ? kCMFormatDescriptionColorPrimaries_P3_D65
+                                : kCMFormatDescriptionColorPrimaries_ITU_R_709_2)
+        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_TransferFunction,
+                             value: kCMFormatDescriptionTransferFunction_sRGB)
+        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_YCbCrMatrix,
+                             value: kCMFormatDescriptionYCbCrMatrix_ITU_R_709_2)
+        if !usingProRes4444 {
+            // No periodic IDRs: each one is a bitrate spike → transmit-time hiccup.
+            // TCP never loses data, and we force a keyframe on reconnect/drop.
+            VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_MaxKeyFrameInterval, value: 3600 as CFNumber)
+            VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration, value: 60 as CFNumber)
+        }
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_MaxFrameDelayCount, value: 0 as CFNumber)
-        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_AverageBitRate, value: quality.bitrate as CFNumber)
+        // Preset bitrates were tuned on iPad-class panels (~5.6MP). Scale
+        // with the actual encode size so 4K Mac receivers aren't starved —
+        // 18Mbps at 3840x2160 visibly blurs text. Capped for sanity; WiFi
+        // users pick a lower quality preset, same as before.
+        let referencePixels = 2732.0 * 2048.0
+        let ratio = max(1.0, Double(width * height) / referencePixels)
+        let bitrateScale = nativeFidelity ? 4.0 : (accurate10Bit ? 3.0 : 1.5)
+        let bitrateCap = nativeFidelity ? 180_000_000
+            : (accurate10Bit ? 120_000_000 : 60_000_000)
+        let bitrate = min(Int(Double(quality.bitrate) * ratio * bitrateScale),
+                          bitrateCap)
+        // HEVC benefits from two in-flight frames at smaller sizes. Native
+        // 4480x2520 reaches its best throughput with three: 47–48fps versus
+        // 41–44 with two; four adds ~20ms without increasing throughput.
+        // Beyond iPad-class sizes H.264 also needs a second slot.
+        // `defaults write <bundle-id> encodeSlots -int N` overrides (1-6):
+        // deeper pipelines trade ~16ms queue latency per slot for throughput
+        // on encoders with internal parallel stages. 0/absent = automatic.
+        let slotsOverride = UserDefaults.standard.integer(forKey: "encodeSlots")
+        pipelineLock.lock()
+        maxPendingEncodes = slotsOverride > 0
+            ? min(slotsOverride, 6)
+            : (usingProRes4444
+                ? 6
+                : (usingHEVC
+                ? (pixels > 3840 * 2160 ? 3 : 2)
+                : (Double(pixels) > referencePixels ? 2 : 1)))
+        pipelineLock.unlock()
+        if slotsOverride > 0 {
+            Log.info("encode pipeline depth overridden: \(min(slotsOverride, 6)) slots")
+        }
+        if !usingProRes4444 {
+            VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_AverageBitRate, value: bitrate as CFNumber)
+        }
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ExpectedFrameRate, value: 60 as CFNumber)
-        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_PrioritizeEncodingSpeedOverQuality, value: kCFBooleanTrue)
+        // Extra quality search is too slow at 4.5K. Through 4K the native
+        // preset can use it; above 4K the lower maximum QP and larger bit
+        // budget preserve detail while the encoder remains real-time.
+        VTSessionSetProperty(
+            encoder,
+            key: kVTCompressionPropertyKey_PrioritizeEncodingSpeedOverQuality,
+            value: qualityFirstEncoder ? kCFBooleanFalse : kCFBooleanTrue)
+        if accurate10Bit && !usingProRes4444 {
+            // Prevent the rate controller from turning smooth desktop fills
+            // into coarse, differently quantized coding blocks. Native
+            // fidelity uses 16; lower presets retain the previous ceiling.
+            VTSessionSetProperty(encoder,
+                                 key: kVTCompressionPropertyKey_MaxAllowedFrameQP,
+                                 value: maxFrameQP as CFNumber)
+            VTSessionSetProperty(encoder,
+                                 key: kVTCompressionPropertyKey_Quality,
+                                 value: (nativeFidelity ? 0.95 : 0.9) as CFNumber)
+            if #available(macOS 15.0, *), !lowLatency {
+                VTSessionSetProperty(
+                    encoder,
+                    key: kVTCompressionPropertyKey_SpatialAdaptiveQPLevel,
+                    value: 0 as CFNumber)
+            }
+        }
         VTCompressionSessionPrepareToEncodeFrames(encoder)
-        Log.info("encoder ready: \(width)x\(height) H.264 \(quality.bitrate / 1_000_000)Mbps quality=\(quality.rawValue) lowLatencyRC=\(lowLatency)")
+        // The static-refresh session must match the main session's geometry;
+        // recreate it lazily after any (re)configuration.
+        encoderIsHEVC = usingHEVC
+        encoderIsProRes4444 = usingProRes4444
+        encoderIsProRes4444XQ = usingProRes4444XQ
+        encoderWidth = width
+        encoderHeight = height
+        encoderInputPixelFormat = inputPixelFormat
+        if let refreshEncoder { VTCompressionSessionInvalidate(refreshEncoder) }
+        refreshEncoder = nil
+        refreshEncoderFailed = false
+        let qpMode = fixedDesktopQP != nil ? "fixedQP12" : "maxQP\(maxFrameQP)"
+        let colorMode = (usingProRes4444
+            ? "10-bit 4:4:4 intra"
+            : accurate10Bit
+            ? "Main10 x444-video \(qpMode) \(qualityFirstEncoder ? "quality-search" : "realtime-search")"
+            : "8-bit")
+            + " \(workingColorSpace.rawValue) ICC=\(workingICCProfile?.count ?? 0)B"
+        let codecName = usingProRes4444XQ
+            ? "ProRes 4444 XQ"
+            : (usingProRes4444 ? "ProRes 4444" : (usingHEVC ? "HEVC" : "H.264"))
+        let rateDescription = usingProRes4444 ? "intra VBR" : "\(bitrate / 1_000_000)Mbps"
+        Log.info("encoder ready: \(width)x\(height) \(codecName) \(rateDescription) \(colorMode) quality=\(quality.rawValue) lowLatencyRC=\(lowLatency) staticRefresh=\(usingHEVC && staticRefreshEnabled)")
     }
 
     // MARK: - Capture callback
@@ -1141,9 +1928,45 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
               let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
         else { return }
 
-        lastPixelBuffer = pixelBuffer
-        lastCaptureAt = Date()
+        // Blank/suspended/idle status buffers contain no new display image.
+        // Encoding them can replace the receiver's last good frame with a
+        // transient black one, so only complete/started frames are eligible.
+        if let status = frameStatus(of: sampleBuffer),
+           status != .complete, status != .started {
+            return
+        }
+
+        if !firstFrameLogged {
+            firstFrameLogged = true
+            Log.info(String(format: "first capture frame %.0fms after capture start",
+                            Date().timeIntervalSince(captureStartedAt) * 1000))
+        }
+        let capturedAt = Date()
+        noteCaptureForStaticRefresh(at: capturedAt)
+        lastCaptureAt = capturedAt
         capFrames += 1
+
+        // Some macOS versions label the cursor-entry glitch as a complete
+        // frame. Reject only a truly frame-wide black buffer; withholding all
+        // frames makes the receiver's video layer itself clear to black.
+        // Requiring an existing good frame also keeps startup safe.
+        let capturedNow = Date()
+        // The capture callback can beat the 120Hz cursor timer when the
+        // sending Mac's physical mouse enters the virtual display. Detect
+        // that transition here as well so the very first suspect frame is
+        // held instead of waiting up to 8ms for pollCursorPosition().
+        if lastPixelBuffer != nil,
+           !lastCursorSent.visible,
+           isCursorCurrentlyOnCaptureDisplay() {
+            armCursorEntryFrameGuard(reason: "capture observed cursor entry")
+        }
+        if lastPixelBuffer != nil,
+           capturedNow <= suppressCursorEntryBlackFramesUntil,
+            isNearlyBlackFrame(pixelBuffer) {
+            Log.info("suppressed transient black capture frame on cursor entry")
+            return
+        }
+        lastPixelBuffer = pixelBuffer
 
         // No receiver, or a pipeline stage is backed up: skip this frame.
         guard connectionReady else { return }
@@ -1151,6 +1974,111 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         if shouldDropFrame(reason: "pending_sends") { return }   // TCP send queue full
 
         encode(pixelBuffer, pts: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
+    }
+
+    /// ScreenCaptureKit's per-frame status attachment. Missing status remains
+    /// eligible for compatibility with older systems/alternate producers.
+    private func frameStatus(of sample: CMSampleBuffer) -> SCFrameStatus? {
+        guard let attachments = CMSampleBufferGetSampleAttachmentsArray(
+                sample, createIfNecessary: false) as? [[SCStreamFrameInfo: Any]],
+              let raw = attachments.first?[.status] as? Int else { return nil }
+        return SCFrameStatus(rawValue: raw)
+    }
+
+    private func isCursorCurrentlyOnCaptureDisplay() -> Bool {
+        guard captureDisplayID != 0,
+              let location = CGEvent(source: nil)?.location else { return false }
+        return CGDisplayBounds(captureDisplayID).contains(location)
+    }
+
+    /// Fast whole-frame black check for both capture formats supported by
+    /// startCapture (BGRA and bi-planar YUV). This only runs for ~250 ms on
+    /// cursor entry, not on every frame.
+    private func isNearlyBlackFrame(_ buf: CVPixelBuffer) -> Bool {
+        guard CVPixelBufferLockBaseAddress(buf, .readOnly) == kCVReturnSuccess else { return false }
+        defer { CVPixelBufferUnlockBaseAddress(buf, .readOnly) }
+        let w = CVPixelBufferGetWidth(buf)
+        let h = CVPixelBufferGetHeight(buf)
+        guard w > 0, h > 0 else { return false }
+
+        let format = CVPixelBufferGetPixelFormatType(buf)
+        let samplesPerAxis = 5
+        var darkCount = 0
+        let total = samplesPerAxis * samplesPerAxis
+
+        switch format {
+        case kCVPixelFormatType_32BGRA:
+            guard let base = CVPixelBufferGetBaseAddress(buf) else { return false }
+            let stride = CVPixelBufferGetBytesPerRow(buf)
+            let ptr = base.assumingMemoryBound(to: UInt8.self)
+            for row in 0..<samplesPerAxis {
+                for col in 0..<samplesPerAxis {
+                    let x = (col + 1) * w / (samplesPerAxis + 1)
+                    let y = (row + 1) * h / (samplesPerAxis + 1)
+                    let offset = y * stride + x * 4
+                    if ptr[offset] <= 4, ptr[offset + 1] <= 4, ptr[offset + 2] <= 4 {
+                        darkCount += 1
+                    }
+                }
+            }
+
+        case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+             kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
+            guard CVPixelBufferGetPlaneCount(buf) > 0,
+                  let yBase = CVPixelBufferGetBaseAddressOfPlane(buf, 0) else { return false }
+            let yStride = CVPixelBufferGetBytesPerRowOfPlane(buf, 0)
+            let yPtr = yBase.assumingMemoryBound(to: UInt8.self)
+            // Video-range black is Y=16; full-range black is Y=0.
+            let threshold: UInt8 = format == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange ? 20 : 4
+            for row in 0..<samplesPerAxis {
+                for col in 0..<samplesPerAxis {
+                    let x = (col + 1) * w / (samplesPerAxis + 1)
+                    let y = (row + 1) * h / (samplesPerAxis + 1)
+                    if yPtr[y * yStride + x] <= threshold { darkCount += 1 }
+                }
+            }
+
+        case kCVPixelFormatType_420YpCbCr10BiPlanarFullRange,
+             kCVPixelFormatType_422YpCbCr10BiPlanarFullRange,
+             kCVPixelFormatType_444YpCbCr10BiPlanarFullRange:
+            guard CVPixelBufferGetPlaneCount(buf) > 0,
+                  let yBase = CVPixelBufferGetBaseAddressOfPlane(buf, 0) else { return false }
+            let yStride = CVPixelBufferGetBytesPerRowOfPlane(buf, 0) / 2
+            let yPtr = yBase.assumingMemoryBound(to: UInt16.self)
+            // 10 useful bits live in the MSBs of each UInt16. Allow code
+            // values 0...4, matching the 8-bit full-range black threshold.
+            let threshold = UInt16(4 << 6)
+            for row in 0..<samplesPerAxis {
+                for col in 0..<samplesPerAxis {
+                    let x = (col + 1) * w / (samplesPerAxis + 1)
+                    let y = (row + 1) * h / (samplesPerAxis + 1)
+                    if yPtr[y * yStride + x] <= threshold { darkCount += 1 }
+                }
+            }
+
+        case kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange,
+             kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange,
+             kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange:
+            guard CVPixelBufferGetPlaneCount(buf) > 0,
+                  let yBase = CVPixelBufferGetBaseAddressOfPlane(buf, 0) else { return false }
+            let yStride = CVPixelBufferGetBytesPerRowOfPlane(buf, 0) / 2
+            let yPtr = yBase.assumingMemoryBound(to: UInt16.self)
+            // Video-range 10-bit black is code value 64, stored in the most
+            // significant ten bits. Allow a small capture tolerance.
+            let threshold = UInt16(68 << 6)
+            for row in 0..<samplesPerAxis {
+                for col in 0..<samplesPerAxis {
+                    let x = (col + 1) * w / (samplesPerAxis + 1)
+                    let y = (row + 1) * h / (samplesPerAxis + 1)
+                    if yPtr[y * yStride + x] <= threshold { darkCount += 1 }
+                }
+            }
+
+        default:
+            return false
+        }
+
+        return darkCount >= total - 2
     }
 
     /// Drop when encode or send pipeline is busy.
@@ -1164,7 +2092,12 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         case "pending_encode":
             drop = pendingEncodes >= maxPendingEncodes
         case "pending_sends":
-            drop = pendingSends >= maxPendingSends
+            // While a pointer owns the receiver, keep at most one video frame
+            // in TCP. Cursor JSON then waits behind one frame at worst instead
+            // of a three-frame video burst. Latest-wins capture dropping keeps
+            // latency bounded and recovers immediately when the pointer leaves.
+            let sendLimit = cursorOwnsReceiver ? 1 : maxPendingSends
+            drop = pendingSends >= sendLimit
         default:
             drop = false
         }
@@ -1189,11 +2122,28 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         pendingEncodes += 1
         pipelineLock.unlock()
         let capturedAtMs = Int64(Date().timeIntervalSince1970 * 1000)
-        var frameProperties: CFDictionary?
-        if needsKeyframe {
-            frameProperties = [kVTEncodeFrameOptionKey_ForceKeyFrame: kCFBooleanTrue!] as CFDictionary
+        var properties: [CFString: Any] = [:]
+        if encoderIsProRes4444 {
+            // Every ProRes frame is independently decodable. Clear the
+            // reconnect flags on the first submitted frame so the watchdog
+            // does not keep replaying a static frame as a fictitious IDR.
             needsKeyframe = false
+            resyncMainOnNextFrame = false
+        } else if needsKeyframe || resyncMainOnNextFrame {
+            // resyncMainOnNextFrame: the receiver last displayed a refresh
+            // IDR the main session never encoded — its reference chain is
+            // foreign, so this frame must be an IDR too.
+            properties[kVTEncodeFrameOptionKey_ForceKeyFrame] = kCFBooleanTrue
+            needsKeyframe = false
+            resyncMainOnNextFrame = false
         }
+        if let fixedDesktopQP {
+            // BaseFrameQP disables normal rate control for this frame. It is
+            // intentionally supplied on every frame, as required by VT, so
+            // smooth fills cannot silently fall back to coarse VBR blocks.
+            properties[kVTEncodeFrameOptionKey_BaseFrameQP] = fixedDesktopQP as CFNumber
+        }
+        let frameProperties = properties.isEmpty ? nil : properties as CFDictionary
         let submitStatus = VTCompressionSessionEncodeFrame(
             encoder,
             imageBuffer: pixelBuffer,
@@ -1220,8 +2170,15 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 self.handleEncodeOutputFailureLogAction(logAction)
                 return
             }
-            if let data = self.annexB(from: buffer) {
-                let sndMs = Int64(Date().timeIntervalSince1970 * 1000)
+            let sndMs = Int64(Date().timeIntervalSince1970 * 1000)
+            if self.encoderIsProRes4444,
+               let data = self.sampleData(from: buffer) {
+                let wireCodec = self.encoderIsProRes4444XQ
+                    ? "prores4444xq" : "prores4444"
+                var framed = Data("{\"cap\":\(capturedAtMs),\"snd\":\(sndMs),\"codec\":\"\(wireCodec)\",\"w\":\(self.encoderWidth),\"h\":\(self.encoderHeight)}\n".utf8)
+                framed.append(data)
+                self.sendFramed(framed)
+            } else if let data = self.annexB(from: buffer) {
                 var framed = Data("{\"cap\":\(capturedAtMs),\"snd\":\(sndMs)}".utf8)
                 framed.append(data)
                 self.sendFramed(framed)
@@ -1318,7 +2275,21 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         Log.info("unparseable control message (\(report.detail) bytes, \(report.count) since last report)")
     }
 
-    // MARK: - H.264 -> Annex B
+    /// Copy a self-contained compressed sample (used by ProRes). Unlike the
+    /// Annex-B codecs, ProRes has no out-of-band parameter sets or NAL framing.
+    private func sampleData(from sample: CMSampleBuffer) -> Data? {
+        guard let block = CMSampleBufferGetDataBuffer(sample) else { return nil }
+        let total = CMBlockBufferGetDataLength(block)
+        guard total > 0 else { return nil }
+        var data = Data(count: total)
+        let status = data.withUnsafeMutableBytes { bytes in
+            CMBlockBufferCopyDataBytes(block, atOffset: 0, dataLength: total,
+                                       destination: bytes.baseAddress!)
+        }
+        return status == noErr ? data : nil
+    }
+
+    // MARK: - H.264 / HEVC -> Annex B
 
     private func annexB(from sample: CMSampleBuffer) -> Data? {
         guard let block = CMSampleBufferGetDataBuffer(sample) else { return nil }
@@ -1328,18 +2299,41 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 lengthAtOffsetOut: &len, totalLengthOut: &total,
                 dataPointerOut: &ptr) == noErr, let ptr else { return nil }
 
-        var out = Data(capacity: total + 128)
-        // On keyframes, prepend SPS/PPS (they live in the format description).
+        var out = Data(capacity: total + 256)
+        // On keyframes, prepend the parameter sets (they live in the format
+        // description). Query the REAL count instead of assuming 3 (HEVC) or
+        // 2 (H.264): the low-latency static-refresh session emits 1 VPS +
+        // 1 SPS + FOUR PPS entries whose ids its slices reference — with the
+        // count hardcoded to 3, PPS 1-3 never reached the receiver and every
+        // refresh IDR failed decode (-12909), looping keyframe requests.
         if isKeyframe(sample), let fmt = CMSampleBufferGetFormatDescription(sample) {
-            for i in 0..<2 {           // index 0 = SPS, 1 = PPS
+            let isHEVC = CMFormatDescriptionGetMediaSubType(fmt) == kCMVideoCodecType_HEVC
+            var psCount = 0
+            let countStatus = isHEVC
+                ? CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
+                    fmt, parameterSetIndex: 0,
+                    parameterSetPointerOut: nil, parameterSetSizeOut: nil,
+                    parameterSetCountOut: &psCount, nalUnitHeaderLengthOut: nil)
+                : CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+                    fmt, parameterSetIndex: 0,
+                    parameterSetPointerOut: nil, parameterSetSizeOut: nil,
+                    parameterSetCountOut: &psCount, nalUnitHeaderLengthOut: nil)
+            if countStatus != noErr { psCount = isHEVC ? 3 : 2 }
+            for i in 0..<psCount {
                 var psPtr: UnsafePointer<UInt8>?
                 var psLen = 0
-                if CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+                let status = isHEVC
+                    ? CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
                         fmt, parameterSetIndex: i,
                         parameterSetPointerOut: &psPtr,
                         parameterSetSizeOut: &psLen,
-                        parameterSetCountOut: nil, nalUnitHeaderLengthOut: nil) == noErr,
-                   let psPtr {
+                        parameterSetCountOut: nil, nalUnitHeaderLengthOut: nil)
+                    : CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+                        fmt, parameterSetIndex: i,
+                        parameterSetPointerOut: &psPtr,
+                        parameterSetSizeOut: &psLen,
+                        parameterSetCountOut: nil, nalUnitHeaderLengthOut: nil)
+                if status == noErr, let psPtr {
                     out.append(contentsOf: startCode)
                     out.append(Data(bytes: psPtr, count: psLen))
                 }
@@ -1401,6 +2395,63 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         var frame = Data(bytes: &header, count: 4)
         frame.append(payload)
         connection.send(content: frame, completion: .contentProcessed { _ in })
+    }
+
+    private func configureCursorChannel(_ info: PhoneInfo) {
+        guard let host = info.cursorHost,
+              let rawPort = info.cursorPort,
+              (1...65535).contains(rawPort),
+              let port = NWEndpoint.Port(rawValue: UInt16(rawPort)) else {
+            cursorConnection?.cancel()
+            cursorConnection = nil
+            cursorConnectionReady = false
+            cursorEndpointKey = ""
+            return
+        }
+        let key = "\(host):\(rawPort)"
+        guard key != cursorEndpointKey || cursorConnection?.state != .ready else { return }
+        cursorConnection?.cancel()
+        cursorConnectionReady = false
+        cursorEndpointKey = key
+        let params = NWParameters.udp
+        params.includePeerToPeer = true
+        params.serviceClass = .responsiveData
+        if let requiredInterface = connection?.currentPath?.availableInterfaces.first {
+            params.requiredInterface = requiredInterface
+        }
+        let conn = NWConnection(
+            host: NWEndpoint.Host(host), port: port, using: params)
+        cursorConnection = conn
+        conn.stateUpdateHandler = { [weak self] state in
+            guard let self, self.cursorConnection === conn else { return }
+            switch state {
+            case .ready:
+                self.cursorConnectionReady = true
+                Log.info("cursor UDP channel ready: \(key)")
+            case .failed(let error):
+                self.cursorConnectionReady = false
+                Log.info("cursor UDP channel failed: \(error) — using TCP fallback")
+            case .cancelled:
+                self.cursorConnectionReady = false
+            default:
+                break
+            }
+        }
+        conn.start(queue: queue)
+    }
+
+    private func sendCursorFrame(_ json: String) {
+        if let cursorConnection, cursorConnectionReady {
+            cursorConnection.send(content: Data(json.utf8),
+                                  completion: .contentProcessed { [weak self] error in
+                if let error {
+                    self?.cursorConnectionReady = false
+                    Log.info("cursor UDP send failed: \(error) — using TCP fallback")
+                }
+            })
+        } else {
+            sendJSONFrame(json)
+        }
     }
 
     private func sendFramed(_ payload: Data) {

--- a/Mac/OpenSidecarMac.entitlements
+++ b/Mac/OpenSidecarMac.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<!-- Local/ad-hoc builds embed Sparkle with a separately signed framework.
+	     Without this, hardened runtime rejects Sparkle before app launch. -->
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
 </plist>

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -5,6 +5,26 @@ import Sparkle
 
 /// How the app presents itself. One bundle, switched at runtime via the
 /// activation policy — like Raycast/Hammerspoon style background agents.
+enum TransportPreference: String, CaseIterable {
+    case auto, wifi, bridge
+
+    var label: String {
+        switch self {
+        case .auto: return "Auto"
+        case .wifi: return "WiFi only"
+        case .bridge: return "Thunderbolt Bridge"
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .auto: return "Use the best available path (bridge IP from TXT record, then WiFi)."
+        case .wifi: return "Always connect over WiFi / local network."
+        case .bridge: return "Connect directly to the receiver's Thunderbolt bridge IP."
+        }
+    }
+}
+
 enum AppPresentation: String, CaseIterable {
     case menuBar, dock, background
 
@@ -142,7 +162,15 @@ final class DeviceSession: ObservableObject, Identifiable {
     // and its service row.
     var wifiServiceName: String?
 
-    var transportLabel: String { onUSB ? "USB" : "WiFi" }
+    // Whether the WiFi session is currently going through a Thunderbolt
+    // bridge interface (lower latency than WiFi).
+    @Published var onBridge: Bool = false
+
+    var transportLabel: String {
+        if onUSB { return "USB" }
+        if onBridge { return "TB" }
+        return "WiFi"
+    }
 
     init(id: String, target: ConnectionTarget, name: String, sender: MacSender) {
         self.id = id
@@ -185,10 +213,20 @@ final class SenderController: ObservableObject {
     @Published var quality = StreamQuality(rawValue: UserDefaults.standard.string(forKey: "quality") ?? "") ?? .best {
         didSet { UserDefaults.standard.set(quality.rawValue, forKey: "quality") }
     }
+    @Published var transportPref = TransportPreference(rawValue: UserDefaults.standard.string(forKey: "transportPref") ?? "") ?? .auto {
+        didSet { UserDefaults.standard.set(transportPref.rawValue, forKey: "transportPref") }
+    }
+    @Published var bridgeIP = UserDefaults.standard.string(forKey: "bridgeIP") ?? "" {
+        didSet { UserDefaults.standard.set(bridgeIP, forKey: "bridgeIP") }
+    }
 
     var running: Bool { !sessions.isEmpty }
 
     private var browser: NWBrowser?
+    // IPs belonging to Thunderbolt bridge interfaces (link-local 169.254.x.x
+    // on bridge*). Populated from ifconfig on init and refreshed when browse
+    // results change. Used to prefer the bridge over WiFi when both exist.
+    private var bridgeEndpoints: Set<NWEndpoint> = []
     private var usbWatcher: UsbmuxDeviceWatcher?
 
     // Connection policy — one session per physical device, and the cable
@@ -248,18 +286,106 @@ final class SenderController: ObservableObject {
     }
 
     private func startBrowsing() {
+        refreshBridgeEndpoints()
         // TXT records carry the receiver's install id (new receivers).
-        let browser = NWBrowser(for: .bonjourWithTXTRecord(type: "_opensidecar._tcp", domain: nil), using: .tcp)
+        let params = NWParameters.tcp
+        params.includePeerToPeer = true
+        let browser = NWBrowser(for: .bonjourWithTXTRecord(type: "_opensidecar._tcp", domain: nil), using: params)
         browser.browseResultsChangedHandler = { [weak self] results, _ in
             DispatchQueue.main.async {
                 guard let self else { return }
                 self.discovered = Array(results)
+                self.refreshBridgeEndpoints()
                 self.endSessionsWhoseServiceVanished()
                 self.autoConnect()
             }
         }
         browser.start(queue: .main)
         self.browser = browser
+    }
+
+    // MARK: - Thunderbolt bridge detection
+
+    /// Scan local interfaces for Thunderbolt bridge endpoints. A bridge
+    /// interface has a name like "bridge0" and typically carries a link-local
+    /// address (169.254.x.x). We collect those IPs so we can match them
+    /// against Bonjour-resolved endpoints and prefer the bridge.
+    private func refreshBridgeEndpoints() {
+        var addrs: Set<String> = []
+        var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&ifaddrPtr) == 0, let first = ifaddrPtr else { return }
+        defer { freeifaddrs(first) }
+        var ptr: UnsafeMutablePointer<ifaddrs>? = first
+        while let iface = ptr?.pointee {
+            let name = String(cString: iface.ifa_name)
+            if name.hasPrefix("bridge"), (iface.ifa_flags & UInt32(IFF_UP)) != 0 {
+                if let sa = iface.ifa_addr, sa.pointee.sa_family == sa_family_t(AF_INET) {
+                    var buf = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                    if getnameinfo(sa, socklen_t(sa.pointee.sa_len),
+                                   &buf, socklen_t(buf.count),
+                                   nil, 0, NI_NUMERICHOST) == 0 {
+                        addrs.insert(String(cString: buf))
+                    }
+                }
+            }
+            ptr = iface.ifa_next
+        }
+        guard !addrs.isEmpty else { return }
+        // Match bridge IPs against current browse results. We compare by IP
+        // prefix because the browse result's endpoint is a .service that
+        // hasn't been resolved yet; however once a connection is established
+        // the resolved IP will match.
+        let bridge = discovered.filter { result in
+            if case .service(_, _, _, let interface) = result.endpoint {
+                if let iface = interface, iface.name.hasPrefix("bridge") { return true }
+            }
+            return false
+        }
+        // Also keep results whose resolved IP matches a bridge address.
+        for addr in addrs {
+            for result in discovered {
+                if case .hostPort(let host, _) = result.endpoint {
+                    if String(describing: host) == addr {
+                        bridgeEndpoints.insert(result.endpoint)
+                    }
+                }
+            }
+        }
+        // Store service endpoints that are on bridge interfaces.
+        for result in bridge {
+            bridgeEndpoints.insert(result.endpoint)
+        }
+    }
+
+    /// Whether a browse result is on a Thunderbolt bridge interface.
+    private func isBridgeResult(_ result: NWBrowser.Result) -> Bool {
+        // NWBrowser commonly coalesces one Bonjour service seen on several
+        // interfaces into a single Result. In that form endpoint.interface is
+        // nil and the actual paths live in Result.interfaces.
+        if result.interfaces.contains(where: { $0.name.hasPrefix("bridge") }) {
+            return true
+        }
+        if case .service(_, _, _, let interface) = result.endpoint,
+           let iface = interface, iface.name.hasPrefix("bridge") { return true }
+        return bridgeEndpoints.contains(result.endpoint)
+    }
+
+    /// The best browse result for a device, preferring Thunderbolt bridge.
+    private func bestResult(for results: [NWBrowser.Result]) -> NWBrowser.Result? {
+        if let bridge = results.first(where: { isBridgeResult($0) }) { return bridge }
+        return results.first
+    }
+
+    /// Group discovered services by device name and return unique entries,
+    /// picking the bridge endpoint for each device when available.
+    private func preferredDiscovered() -> [NWBrowser.Result] {
+        var byName: [String: [NWBrowser.Result]] = [:]
+        for result in discovered {
+            if let name = serviceName(of: result) {
+                byName[name, default: []].append(result)
+            }
+        }
+        return byName.compactMap { bestResult(for: $0.value) }
     }
 
     // MARK: - Physical-device identity
@@ -271,6 +397,12 @@ final class SenderController: ObservableObject {
 
     private func txtID(of result: NWBrowser.Result) -> String? {
         if case .bonjour(let txt) = result.metadata { return txt["id"] }
+        return nil
+    }
+
+    /// Thunderbolt bridge IP advertised by the receiver (from TXT record).
+    private func txtBridgeIP(of result: NWBrowser.Result) -> String? {
+        if case .bonjour(let txt) = result.metadata { return txt["ip"] }
         return nil
     }
 
@@ -334,8 +466,15 @@ final class SenderController: ObservableObject {
                 connect(to: .usb(udid: device.udid))
             }
         }
+        // Upgrade WiFi sessions to Thunderbolt bridge when available.
+        // Same principle as USB upgrade: the bridge is lower latency.
+        for session in sessions where !session.onUSB {
+            upgradeToBridge(session)
+        }
         guard wifiAutoConnectArmed, Date() < wifiAutoConnectDeadline else { return }
-        for result in discovered {
+        // Use preferredDiscovered() so bridge results are picked over WiFi
+        // when the same device is visible on multiple interfaces.
+        for result in preferredDiscovered() {
             let target = ConnectionTarget.wifi(result)
             if wifiRemembered.contains(target.sessionID),
                activeSession(coveringWiFi: result) == nil,
@@ -372,13 +511,98 @@ final class SenderController: ObservableObject {
     private func failover(detachedUDIDs: Set<String>) {
         guard autoConnectEnabled, !detachedUDIDs.isEmpty else { return }
         for session in sessions where session.onUSB {
-            guard let udid = session.usbUDID, detachedUDIDs.contains(udid),
-                  let result = wifiService(for: session) else { continue }
-            Log.info("cable detached for \(session.id) — failing over to WiFi")
-            session.onUSB = false
-            session.wifiServiceName = serviceName(of: result)
-            session.sender.switchTransport(to: .tcp(result.endpoint))
+            guard let udid = session.usbUDID, detachedUDIDs.contains(udid) else { continue }
+            // Try Thunderbolt bridge first, then WiFi.
+            if let bridge = bridgeService(for: session) {
+                Log.info("cable detached for \(session.id) — failing over to bridge")
+                session.onUSB = false
+                session.onBridge = true
+                session.wifiServiceName = serviceName(of: bridge)
+                if let transport = bridgeTransport(for: bridge) {
+                    session.sender.switchTransport(to: transport)
+                }
+            } else if let result = wifiService(for: session) {
+                Log.info("cable detached for \(session.id) — failing over to WiFi")
+                session.onUSB = false
+                session.onBridge = false
+                session.wifiServiceName = serviceName(of: result)
+                session.sender.switchTransport(
+                    to: .tcp(result.endpoint, requiredInterface: nil))
+            }
         }
+    }
+
+    /// Migrate a WiFi session to the Thunderbolt bridge when available.
+    /// The bridge is lower-latency and more stable than WiFi, same as USB.
+    private func upgradeToBridge(_ session: DeviceSession) {
+        guard !session.onUSB, !session.onBridge else { return }
+        guard let result = bridgeService(for: session) else { return }
+        Log.info("bridge available for \(session.id) — migrating from WiFi")
+        session.onBridge = true
+        session.wifiServiceName = serviceName(of: result)
+        if let transport = bridgeTransport(for: result) {
+            session.sender.switchTransport(to: transport)
+        }
+    }
+
+    /// The discovered Thunderbolt bridge service belonging to this session's
+    /// device. Returns nil if no bridge result is found, or if the session
+    /// is already on the bridge endpoint.
+    private func bridgeService(for session: DeviceSession) -> NWBrowser.Result? {
+        guard let currentName = session.wifiServiceName ?? session.name as String? else { return nil }
+        return discovered.first { result in
+            guard isBridgeResult(result) else { return false }
+            if let id = txtID(of: result), let deviceID = session.deviceID {
+                return id == deviceID
+            }
+            return serviceName(of: result) == currentName
+        }
+    }
+
+    /// Find the Thunderbolt bridge browse result that matches a WiFi result
+    /// (same device, different interface). Used during connect() to prefer
+    /// the bridge endpoint.
+    private func bridgeResult(for wifiResult: NWBrowser.Result) -> NWBrowser.Result? {
+        guard let wifiName = serviceName(of: wifiResult) else { return nil }
+        return discovered.first { result in
+            guard isBridgeResult(result), result.endpoint != wifiResult.endpoint else { return false }
+            if let wifiID = txtID(of: wifiResult), let resultID = txtID(of: result) {
+                return wifiID == resultID
+            }
+            return serviceName(of: result) == wifiName
+        }
+    }
+
+    /// Build a dynamic Bonjour transport pinned to the bridge interface. The
+    /// endpoint remains a service name, not a 169.254 address, so every fresh
+    /// connection resolves the receiver's current address after cable/IP
+    /// changes. Pinning the NWInterface is what prevents en0 fallback.
+    private func bridgeTransport(for result: NWBrowser.Result) -> SenderTransport? {
+        let candidate = isBridgeResult(result) ? result : bridgeResult(for: result)
+        guard let candidate else { return nil }
+        let endpointInterface: NWInterface? = {
+            guard case .service(_, _, _, let interface) = candidate.endpoint else { return nil }
+            return interface
+        }()
+        guard let interface = candidate.interfaces.first(where: {
+                  $0.name.hasPrefix("bridge")
+              }) ?? endpointInterface,
+              interface.name.hasPrefix("bridge") else { return nil }
+        return .tcp(candidate.endpoint, requiredInterface: interface)
+    }
+
+    /// Optional diagnostic/manual escape hatch. Dynamic Bonjour is always
+    /// preferred; this is used only if the receiver failed to advertise on
+    /// bridge0 and the user explicitly supplied an address.
+    private func manualBridgeTransport(port: UInt16) -> SenderTransport? {
+        guard !bridgeIP.isEmpty,
+              let result = discovered.first(where: { isBridgeResult($0) }),
+              let interface = result.interfaces.first(where: {
+                  $0.name.hasPrefix("bridge")
+              }) else { return nil }
+        return .tcp(.hostPort(host: NWEndpoint.Host(bridgeIP),
+                              port: NWEndpoint.Port(rawValue: port)!),
+                    requiredInterface: interface)
     }
 
     /// A quit receiver app loses its Bonjour advertisement within ~1s, far
@@ -496,18 +720,53 @@ final class SenderController: ObservableObject {
         }
 
         let transport: SenderTransport
+        var usedBridge = false
         switch target {
         case .usb(let udid):
             guard let portNum = UInt16(port) else { return }
             if UserDefaults.standard.object(forKey: "host") != nil, udid == nil {
                 // Manual override: dial a plain TCP endpoint instead of usbmuxd.
                 transport = .tcp(.hostPort(host: NWEndpoint.Host(host),
-                                           port: NWEndpoint.Port(rawValue: portNum)!))
+                                           port: NWEndpoint.Port(rawValue: portNum)!),
+                                 requiredInterface: nil)
             } else {
                 transport = .usb(udid: udid, port: portNum)
             }
         case .wifi(let result):
-            transport = .tcp(result.endpoint)
+            if let portNum = UInt16(port) {
+                switch self.transportPref {
+                case .bridge:
+                    // Dynamic first: connect to the Bonjour service instance
+                    // discovered specifically on bridge0. Its IP is resolved
+                    // again on every reconnect, so no 169.254 address is
+                    // persisted. Never silently downgrade forced Bridge to
+                    // en0; a manual IP remains only as an explicit fallback.
+                    if let dynamic = bridgeTransport(for: result) {
+                        transport = dynamic
+                        usedBridge = true
+                        Log.info("dynamic bridge service selected for \(self.label(for: target))")
+                    } else if let manual = manualBridgeTransport(port: portNum) {
+                        transport = manual
+                        usedBridge = true
+                        Log.info("manual bridge override selected for \(self.label(for: target))")
+                    } else {
+                        Log.info("bridge mode: receiver is not advertised on bridge0 yet — not falling back to WiFi")
+                        return
+                    }
+                case .wifi:
+                    transport = .tcp(result.endpoint, requiredInterface: nil)
+                case .auto:
+                    if let dynamic = bridgeTransport(for: result) {
+                        transport = dynamic
+                        usedBridge = true
+                        Log.info("auto: dynamic bridge service selected for \(self.label(for: target))")
+                    } else {
+                        transport = .tcp(result.endpoint, requiredInterface: nil)
+                    }
+                }
+            } else {
+                transport = .tcp(result.endpoint, requiredInterface: nil)
+            }
         }
 
         let name = label(for: target)
@@ -518,6 +777,7 @@ final class SenderController: ObservableObject {
         if case .wifi(let result) = target {
             session.wifiServiceName = serviceName(of: result)
         }
+        session.onBridge = usedBridge
         sender.onStatus = { [weak session] text in
             session?.status = text
             Log.info("status[\(id)]: \(text)")
@@ -537,6 +797,9 @@ final class SenderController: ObservableObject {
         sender.onStats = { [weak session] frames, mbps in
             session?.framesSent = frames
             session?.mbps = mbps
+        }
+        sender.onTransportDetected = { [weak session] transport in
+            session?.onBridge = (transport == "bridge")
         }
         sender.onDisconnected = { [weak self, weak session] in
             // Device unplugged / left the network and stayed gone: end this
@@ -618,12 +881,15 @@ final class SenderController: ObservableObject {
         let name: String
         let usbTarget: ConnectionTarget?
         let wifiTarget: ConnectionTarget?
+        /// Whether the WiFi target is on a Thunderbolt bridge interface.
+        var hasBridge = false
 
         var transportLabel: String {
+            let tb = hasBridge ? "TB" : "WiFi"
             switch (usbTarget != nil, wifiTarget != nil) {
-            case (true, true): return "USB · WiFi"
+            case (true, true): return "USB · \(tb)"
             case (true, false): return "USB"
-            case (false, true): return "WiFi"
+            case (false, true): return tb
             default: return ""
             }
         }
@@ -649,14 +915,16 @@ final class SenderController: ObservableObject {
             if let covering = activeSession(coveringUSB: device) {
                 coveredSessionIDs.insert(covering.id)
             }
-            entries.append(DeviceEntry(
+            var entry = DeviceEntry(
                 id: "device:\(device.udid)",
                 name: device.name
                     ?? twin.flatMap(serviceName)
                     ?? session(for: usbTarget.sessionID)?.deviceKind
                     ?? "iPhone / iPad",
                 usbTarget: usbTarget,
-                wifiTarget: twin.map { .wifi($0) }))
+                wifiTarget: twin.map { .wifi($0) })
+            if let twin { entry.hasBridge = isBridgeResult(twin) }
+            entries.append(entry)
         }
         if UserDefaults.standard.object(forKey: "host") != nil {
             let target = ConnectionTarget.usb(udid: nil)
@@ -664,9 +932,15 @@ final class SenderController: ObservableObject {
             entries.append(DeviceEntry(id: target.sessionID, name: label(for: target),
                                        usbTarget: target, wifiTarget: nil))
         }
+        // Group WiFi/bridge results by service name so each device appears
+        // once, with the bridge endpoint preferred when both exist.
+        var wifiByName: [String: [NWBrowser.Result]] = [:]
         for result in discovered {
-            guard let name = serviceName(of: result), !mergedServices.contains(name)
-            else { continue }
+            guard let name = serviceName(of: result), !mergedServices.contains(name) else { continue }
+            wifiByName[name, default: []].append(result)
+        }
+        for (name, results) in wifiByName {
+            guard let result = bestResult(for: results) else { continue }
             let target = ConnectionTarget.wifi(result)
             coveredSessionIDs.insert(target.sessionID)
             // A USB-identity session that failed over to WiFi serves this
@@ -675,8 +949,10 @@ final class SenderController: ObservableObject {
             if let covering = activeSession(coveringWiFi: result) {
                 coveredSessionIDs.insert(covering.id)
             }
-            entries.append(DeviceEntry(id: "service:\(name)", name: name,
-                                       usbTarget: nil, wifiTarget: target))
+            var entry = DeviceEntry(id: "service:\(name)", name: name,
+                                       usbTarget: nil, wifiTarget: target)
+            entry.hasBridge = isBridgeResult(result)
+            entries.append(entry)
         }
         // Sessions whose device vanished from discovery (e.g. Bonjour record
         // gone while the stream is still alive) keep a row to disconnect.
@@ -831,6 +1107,28 @@ struct ContentView: View {
                     Text(controller.quality.explanation)
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Picker("Connection", selection: $controller.transportPref) {
+                        ForEach(TransportPreference.allCases, id: \.self) { t in
+                            Text(t.label).tag(t)
+                        }
+                    }
+                    .onChange(of: controller.transportPref) {
+                        if controller.running { controller.restartAll() }
+                    }
+                    Text(controller.transportPref.explanation)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    if controller.transportPref == .bridge {
+                        TextField("Receiver bridge IP (169.254.x.x)", text: $controller.bridgeIP)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.caption)
+                        Text("The receiver's Thunderbolt bridge IP. Leave empty to auto-detect from Bonjour.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
 
                 VStack(alignment: .leading, spacing: 4) {

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreGraphics
+import ColorSync
 
 /// Wraps the private CGVirtualDisplay API: makes macOS believe a real monitor
 /// is attached. Sized in points at HiDPI (@2x), so a phone with native pixels
@@ -10,6 +11,10 @@ final class VirtualDisplay {
     private let settings: CGVirtualDisplaySettings
     let pointsWide: Int
     let pointsHigh: Int
+    private let workingColorSpace: WireColorSpace
+    private let targetICCProfile: Data?
+    private let profileFileID: UInt32
+    private var lastColorProfileLog = ""
 
     private var restoreTarget: CGPoint?
     private let restoreUntil: Date
@@ -26,10 +31,16 @@ final class VirtualDisplay {
     /// `onOriginChange` reports where the display sits afterwards, so the
     /// caller can persist user drags.
     init?(name: String, pointsWide: Int, pointsHigh: Int, sizeInMillimeters: CGSize,
-          serialNum: UInt32 = 0x0001, restoreOrigin: CGPoint? = nil,
+          serialNum: UInt32 = 0x0001,
+          workingColorSpace: WireColorSpace = .sRGB,
+          targetICCProfile: Data? = nil,
+          restoreOrigin: CGPoint? = nil,
           onOriginChange: ((CGPoint) -> Void)? = nil) {
         self.pointsWide = pointsWide
         self.pointsHigh = pointsHigh
+        self.workingColorSpace = workingColorSpace
+        self.targetICCProfile = targetICCProfile
+        self.profileFileID = serialNum
         self.restoreTarget = restoreOrigin
         self.restoreUntil = restoreOrigin == nil ? .distantPast : Date().addingTimeInterval(6)
         self.onOriginChange = onOriginChange
@@ -59,6 +70,7 @@ final class VirtualDisplay {
             return nil
         }
         Log.info("virtual display created: id=\(display.displayID) \(pointsWide)x\(pointsHigh)pt @2x")
+        _ = ensureWorkingColorProfile()
 
         // macOS defaults the new display to its 1x mode AND can restore a
         // stale saved mode for this serial asynchronously, seconds after the
@@ -76,11 +88,85 @@ final class VirtualDisplay {
                     guard let self else { return }
                     self.ensureNotMirrored()
                     if self.selectHiDPIMode(recover: settled) { settled = true }
+                    _ = self.ensureWorkingColorProfile()
                     self.manageOrigin()
                 }
-                try? await Task.sleep(for: .milliseconds(settled ? 2000 : 200))
+                try? await Task.sleep(for: .milliseconds(settled ? 10000 : 200))
             }
         }
+    }
+
+    /// Give WindowServer a wide-gamut framebuffer when the receiving panel is
+    /// P3. Capture-space selection alone is too late: if this virtual display
+    /// remains sRGB, ColorSync clips app content while compositing the desktop
+    /// and those colors cannot be recovered by the encoder or receiver.
+    @discardableResult
+    func ensureWorkingColorProfile() -> Bool {
+        let id = display.displayID
+        let activeSpace = CGDisplayCopyColorSpace(id)
+        let activeData = activeSpace.copyICCData().map { $0 as Data }
+        let activeName = activeSpace.name as String?
+        let activeGamut = ICCProfileGamut.preferredWorkingSpace(
+            profileData: activeData, name: activeName)
+        if let targetICCProfile, activeData == targetICCProfile {
+            logColorProfile("active exact receiver ICC verified (\(targetICCProfile.count)B)")
+            return true
+        } else if targetICCProfile == nil, activeGamut == workingColorSpace {
+            logColorProfile("active \(workingColorSpace.rawValue) profile verified")
+            return true
+        }
+
+        guard let profileURL = requestedProfileURL(),
+              let uuid = CGDisplayCreateUUIDFromDisplayID(id)?.takeRetainedValue(),
+              let deviceClass = kColorSyncDisplayDeviceClass?.takeUnretainedValue(),
+              let defaultProfile = kColorSyncDeviceDefaultProfileID?.takeUnretainedValue()
+        else {
+            logColorProfile("profile prerequisites unavailable")
+            return false
+        }
+
+        let info = [defaultProfile as String: profileURL] as CFDictionary
+        let applied = ColorSyncDeviceSetCustomProfiles(deviceClass, uuid, info)
+        let requested = targetICCProfile == nil
+            ? workingColorSpace.rawValue
+            : "exact receiver ICC \(targetICCProfile!.count)B"
+        logColorProfile("requested \(requested) profile "
+            + "(active=\(activeName ?? activeGamut.rawValue), result=\(applied))")
+        return false // ColorSync publishes the new active profile asynchronously.
+    }
+
+    private func requestedProfileURL() -> URL? {
+        guard let targetICCProfile else {
+            let profileName = workingColorSpace == .displayP3
+                ? "Display P3.icc"
+                : "sRGB Profile.icc"
+            let url = URL(fileURLWithPath:
+                "/System/Library/ColorSync/Profiles/\(profileName)")
+            return FileManager.default.fileExists(atPath: url.path) ? url : nil
+        }
+        do {
+            let root = FileManager.default.urls(
+                for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            let directory = root
+                .appendingPathComponent("OpenDisplay", isDirectory: true)
+                .appendingPathComponent("Receiver Color Profiles", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: directory, withIntermediateDirectories: true)
+            let url = directory.appendingPathComponent("\(profileFileID).icc")
+            if (try? Data(contentsOf: url)) != targetICCProfile {
+                try targetICCProfile.write(to: url, options: .atomic)
+            }
+            return url
+        } catch {
+            logColorProfile("could not persist receiver ICC: \(error)")
+            return nil
+        }
+    }
+
+    private func logColorProfile(_ message: String) {
+        guard message != lastColorProfileLog else { return }
+        lastColorProfileLog = message
+        Log.info("virtual display color: \(message)")
     }
 
     /// Returns true when the display is (now) in its HiDPI mode. Silent when

--- a/MacReceiver/DisplayReceiver.swift
+++ b/MacReceiver/DisplayReceiver.swift
@@ -1,0 +1,1336 @@
+// DisplayReceiver — the Mac counterpart of iOS/PhoneReceiver.swift: receive
+// H.264 over TCP and display it, turning this Mac into a second monitor for
+// another Mac running the OpenDisplay sender.
+//
+// Pipeline:  TCP socket -> deframe -> Annex B parse -> CMSampleBuffer
+//            -> AVSampleBufferDisplayLayer (decodes + renders)
+//
+// The receiver LISTENS; the sender Mac connects — same wire protocol and
+// ordering as the iOS app, so the unmodified sender discovers this Mac over
+// Bonjour exactly like an iPhone. Wire: [4-byte big-endian length][payload].
+//
+// Deliberately kept close to PhoneReceiver so protocol fixes port both ways;
+// iOS-only concerns (backgrounding, rotation, the Metal path) are dropped.
+
+import Foundation
+import Network
+import AVFoundation
+import CoreMedia
+import AppKit
+import VideoToolbox
+
+/// One-second window of pipeline health for the HUD overlay.
+struct PerfStats: Equatable {
+    var fps = 0
+    var mbps = 0.0
+    var avgFrameMs = 0.0
+    var maxFrameMs = 0.0
+    var stalls = 0               // frames that arrived >50ms late (this window)
+    var decodeFlushes = 0        // display layer failures since connect
+    var samples: [Double] = []   // last ~120 inter-frame intervals, ms
+    // True end-to-end latency (sender capture → display handoff), using the
+    // clock offset estimated from timestamped ping/pong.
+    var e2eP50 = 0.0
+    var e2eP95 = 0.0
+    var encodeP50 = 0.0          // sender-side capture→socket (encode + queue)
+    var rttMs = 0.0              // control-channel round trip
+    var e2eSamples: [Double] = []  // last ~120 per-frame e2e latencies, ms
+    var transport = "—"
+    var macDrops = 0             // enc + net drops (legacy total)
+    var macEncDrops = 0          // sender skipped capture: encoder busy
+    var macNetDrops = 0          // sender skipped capture: TCP queue full
+    var macPending = 0           // sender send queue depth right now
+    var inputP50 = 0.0           // input sent → CGEvent injected on the sender, ms
+    var inputP95 = 0.0
+    var capFps = 0               // frames ScreenCaptureKit delivered on the sender
+}
+
+final class DisplayReceiver: ObservableObject {
+
+    @Published var status = "Starting…"
+    @Published var fps = 0
+    @Published var connected = false
+    @Published var videoSize = CGSize.zero   // for input coordinate mapping
+    @Published var perf = PerfStats()
+    // Compatibility signal from the connected sender (issue #132). This build
+    // speaks the current protocol, so it should never fire — surfaced anyway
+    // in case a far-future sender raises its floor past us.
+    @Published var peerMessage: String?
+
+    private var listener: NWListener?
+    private var cursorListener: NWListener?
+    private var cursorConnection: NWConnection?
+    private var listenerHealthy = false
+    private var connection: NWConnection?
+    private let queue = DispatchQueue(label: "receiver.video")
+    private var buffer = Data()
+    private var formatDesc: CMVideoFormatDescription?
+    private enum StreamCodec { case h264, hevc, prores4444, prores4444XQ }
+    private var codec = StreamCodec.h264
+    private var peerProtocolVersion = WireProtocol.assumedWhenAbsent
+    // Parameter sets, ordered as received. Arrays, not single values: the
+    // sender's low-latency static-refresh HEVC session emits one VPS, one
+    // SPS and FOUR PPS entries with distinct ids — keeping only the last
+    // PPS made every refresh IDR undecodable (-12909).
+    private var vpsSets: [Data] = [] // HEVC only
+    private var spsSets: [Data] = []
+    private var ppsSets: [Data] = []
+
+    // Liveness: the sender streams video and pings every 2s; if nothing
+    // arrives for 5s the connection is half-open — drop it so the listener
+    // can accept a fresh one.
+    private var lastDataReceived = Date()
+    private var port: UInt16 = 9000
+    private let cursorPort: UInt16 = 9001
+    private var lastCursorDatagramSequence: UInt64 = 0
+    private var monitorsStarted = false
+
+    private var framesThisWindow = 0
+    private var fpsWindowStart = Date()
+    private var bytesThisWindow = 0
+    private var stallsThisWindow = 0
+    private var decodeFlushes = 0
+    private var lastFrameAt: Date?
+    private var frameIntervals: [Double] = []   // ring buffer, ms
+    private let maxSamples = 120
+
+    // Clock sync (NTP-style): offset = senderClock − ourClock, taken from the
+    // ping/pong sample with the lowest RTT (least asymmetric).
+    private var offsetSamples: [(rtt: Double, offset: Double)] = []
+    private var clockOffsetMs: Double?
+    private var lastRttMs = 0.0
+    private var e2eWindow: [Double] = []        // capture→display, ms
+    private var encodeWindow: [Double] = []     // capture→socket on the sender, ms
+    private var e2eRing: [Double] = []          // per-frame, for the HUD graph
+    private var statsReportCounter = 0
+    private var transport = "—"
+    private var macDrops = 0
+    private var macEncDrops = 0
+    private var macNetDrops = 0
+    private var macPending = 0
+    private var macInputP50 = 0.0
+    private var macInputP95 = 0.0
+    private var macCapFps = 0
+    private var destinationColorDiagnostic = "window-unavailable"
+
+    private var nowMs: Double { Date().timeIntervalSince1970 * 1000 }
+
+    // Local cursor echo (both called on the main thread): position is
+    // normalized [0,1] in video space; the sprite arrives as a PNG with its
+    // hotspot anchor and size normalized against the sender display.
+    var onCursor: ((_ x: Double, _ y: Double, _ visible: Bool) -> Void)?
+    var onCursorImage: ((_ image: NSImage, _ anchor: CGPoint, _ normSize: CGSize) -> Void)?
+    // Explicit VideoToolbox + Metal remains available in the source for
+    // diagnostics, but production presentation follows upstream OpenDisplay:
+    // AVSampleBufferDisplayLayer lets the system decoder/compositor perform
+    // the final ColorSync conversion into the receiver display's active ICC.
+    var onDecodedFrame: ((_ pixelBuffer: CVPixelBuffer) -> Void)?
+    private var decompressionSession: VTDecompressionSession?
+    private var decodeErrorCount = 0
+
+    let displayLayer: AVSampleBufferDisplayLayer
+    let metalRenderer: MetalVideoRenderer?
+
+    /// Announced panel size in pixels + scale, sent to the sender in a
+    /// "hello" message so it can size the virtual display (it creates
+    /// pixels/2 points at @2x HiDPI). Set before start(); setPanel() with new
+    /// dimensions re-announces and the sender rebuilds the virtual display.
+    private(set) var devicePixelsWide = 0
+    private(set) var devicePixelsHigh = 0
+    var deviceScale: Double = 2
+    private(set) var deviceColorSpace = WireColorSpace.sRGB
+    private(set) var deviceICCProfileData: Data?
+    // Name advertised over Bonjour for the sender's device picker.
+    var serviceName = Host.current().localizedName ?? "Mac"
+
+    // Stable per-install identity, advertised in the Bonjour TXT record and
+    // sent in every hello. The sender uses it to recognize the device across
+    // reconnects and to persist display arrangement (#116).
+    static let installID: String = {
+        if let existing = UserDefaults.standard.string(forKey: "installID") {
+            return existing
+        }
+        let fresh = UUID().uuidString
+        UserDefaults.standard.set(fresh, forKey: "installID")
+        return fresh
+    }()
+
+    /// Detect this Mac's Thunderbolt bridge address (normally the link-local
+    /// IPv4 on bridge*). During cable bring-up IPv6 can appear slightly before
+    /// IPv4, so keep a scoped IPv6 address as a fallback instead of omitting
+    /// the low-latency cursor endpoint from the initial hello.
+    private static var bridgeIP: String? {
+        var ifaddrPtr: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&ifaddrPtr) == 0, let first = ifaddrPtr else { return nil }
+        defer { freeifaddrs(first) }
+        var ipv6Fallback: String?
+        var ptr: UnsafeMutablePointer<ifaddrs>? = first
+        while let iface = ptr?.pointee {
+            let name = String(cString: iface.ifa_name)
+            if name.hasPrefix("bridge"), (iface.ifa_flags & UInt32(IFF_UP)) != 0 {
+                if let sa = iface.ifa_addr,
+                   sa.pointee.sa_family == sa_family_t(AF_INET)
+                    || sa.pointee.sa_family == sa_family_t(AF_INET6) {
+                    var buf = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                    if getnameinfo(sa, socklen_t(sa.pointee.sa_len),
+                                   &buf, socklen_t(buf.count),
+                                   nil, 0, NI_NUMERICHOST) == 0 {
+                        let address = String(cString: buf)
+                        if sa.pointee.sa_family == sa_family_t(AF_INET) {
+                            return address
+                        }
+                        if ipv6Fallback == nil { ipv6Fallback = address }
+                    }
+                }
+            }
+            ptr = iface.ifa_next
+        }
+        return ipv6Fallback
+    }
+
+    private var advertisedService: NWListener.Service {
+        var txt = NWTXTRecord()
+        txt["id"] = Self.installID
+        txt["pv"] = String(WireProtocol.version)   // issue #132
+        if let ip = Self.bridgeIP { txt["ip"] = ip }
+        return NWListener.Service(name: serviceName, type: "_opensidecar._tcp",
+                                  domain: nil, txtRecord: txt)
+    }
+
+    /// Update the advertised name and re-publish if already listening.
+    func setServiceName(_ name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolved = trimmed.isEmpty ? (Host.current().localizedName ?? "Mac") : trimmed
+        queue.async {
+            guard resolved != self.serviceName else { return }
+            self.serviceName = resolved
+            if self.listener != nil {
+                self.listener?.service = self.advertisedService
+                Log.info("re-advertising as \"\(resolved)\"")
+            }
+        }
+    }
+
+    /// Set (or change) the announced panel size. A change while connected
+    /// re-sends hello and the sender rebuilds the virtual display — the Mac
+    /// analogue of the iOS rotation path (screen swap, resolution setting).
+    func setPanel(pixelsWide: Int, pixelsHigh: Int, scale: Double,
+                  colorSpace: WireColorSpace, iccProfileData: Data?) {
+        queue.async {
+            guard pixelsWide > 0, pixelsHigh > 0,
+                  pixelsWide != self.devicePixelsWide
+                  || pixelsHigh != self.devicePixelsHigh
+                  || scale != self.deviceScale
+                  || colorSpace != self.deviceColorSpace
+                  || iccProfileData != self.deviceICCProfileData else { return }
+            let announced = self.devicePixelsWide != 0
+            self.devicePixelsWide = pixelsWide
+            self.devicePixelsHigh = pixelsHigh
+            self.deviceScale = scale
+            self.deviceColorSpace = colorSpace
+            self.deviceICCProfileData = iccProfileData
+            self.metalRenderer?.setNegotiatedSourceColorSpace(
+                self.peerProtocolVersion >= 3 ? colorSpace : nil)
+            self.metalRenderer?.setDeviceICCPassthrough(
+                self.peerProtocolVersion >= 5 && iccProfileData != nil)
+            if announced {
+                Log.info("panel changed -> \(pixelsWide)x\(pixelsHigh) \(colorSpace.rawValue)")
+            }
+            if let connection = self.connection, connection.state == .ready {
+                self.sendHello(on: connection)
+            }
+        }
+    }
+
+    /// Records the final AppKit/ColorSync destination separately from the
+    /// decoded frame's source space, and returns it to the sender in stats.
+    func setDestinationColorDiagnostic(_ description: String) {
+        queue.async { self.destinationColorDiagnostic = description }
+    }
+
+    init(displayLayer: AVSampleBufferDisplayLayer) {
+        self.displayLayer = displayLayer
+        displayLayer.videoGravity = .resizeAspect
+        // AVSampleBufferDisplayLayer can promote desktop content into the
+        // macOS video-overlay path. That path is excellent for ordinary
+        // Rec.709 movies, but on a wide-gamut desktop it may bypass the
+        // window's normal ColorSync composition and look grey even when the
+        // stream carries correct P3/ICC metadata. Decode to retained 10-bit
+        // RGB and perform one explicit Display-P3 -> active-display-ICC
+        // conversion instead. MetalVideoRenderer keeps a latest-wins frame
+        // slot, so this does not add an unbounded presentation queue.
+        let renderer = MetalVideoRenderer()
+        metalRenderer = renderer
+        if let renderer {
+            onDecodedFrame = { [weak renderer] pixelBuffer in
+                renderer?.render(pixelBuffer)
+            }
+            Log.info("display path: explicit 10-bit Metal + Core Image ColorSync")
+        } else {
+            Log.info("display path: AVSampleBufferDisplayLayer fallback (Metal unavailable)")
+        }
+    }
+
+    func start(port: UInt16 = 9000) {
+        self.port = port
+        queue.async {
+            self.startListener()
+            self.startCursorListener()
+        }
+        if !monitorsStarted {
+            monitorsStarted = true
+            schedulePing()
+            scheduleWatchdog()
+        }
+    }
+
+    /// Recreate the listener if it isn't healthy — called on wake (enterSleep
+    /// deliberately took it down when the display went dark).
+    func ensureListening() {
+        queue.async {
+            guard !self.listenerHealthy else { return }
+            Log.info("listener not healthy — restarting")
+            self.restartListener()
+        }
+    }
+
+    /// The screen went dark (display sleep / system sleep) — nobody can see
+    /// the stream, so tell the sender and go silent. Sends "sleeping" (the
+    /// sender drops its virtual display so the cursor isn't stranded on an
+    /// invisible screen and arms a reconnect), then closes the connection AND
+    /// the listener: while asleep we must not accept connections, or the
+    /// sender's wake retries would rebuild the display before anyone can see
+    /// it. ensureListening() re-arms everything on wake.
+    func enterSleep(completion: (() -> Void)? = nil) {
+        closeSession(announcing: WireMessage.sleeping,
+                     status: "Asleep — resumes on wake", completion: completion)
+    }
+
+    /// The app is quitting. Same close, but announced as "closing": quitting
+    /// is deliberate, so the sender ends the session without waiting around.
+    func shutDown(completion: (() -> Void)? = nil) {
+        closeSession(announcing: WireMessage.closing,
+                     status: "Closed", completion: completion)
+    }
+
+    private func closeSession(announcing type: String, status: String,
+                              completion: (() -> Void)?) {
+        queue.async {
+            var finished = false
+            let finish = { [weak self] in
+                guard let self, !finished else { return }
+                finished = true
+                self.connection?.cancel()
+                self.connection = nil
+                self.listener?.cancel()
+                self.listener = nil
+                self.cursorConnection?.cancel()
+                self.cursorConnection = nil
+                self.cursorListener?.cancel()
+                self.cursorListener = nil
+                self.listenerHealthy = false
+                self.setConnected(false)
+                self.setStatus(status)
+                completion?()
+            }
+            guard let conn = self.connection, conn.state == .ready else {
+                Log.info("closing session (\(type)) — no live connection")
+                finish()
+                return
+            }
+            Log.info("closing session — announcing \(type) to the sender")
+            self.sendControl(["type": type], on: conn) {
+                self.queue.async { finish() }
+            }
+            // The send completion may never fire on a dying link — don't
+            // let that keep us accepting connections after going dark.
+            self.queue.asyncAfter(deadline: .now() + 1) { finish() }
+        }
+    }
+
+    private func restartListener() {
+        listener?.cancel()
+        listener = nil
+        cursorConnection?.cancel()
+        cursorConnection = nil
+        cursorListener?.cancel()
+        cursorListener = nil
+        listenerHealthy = false
+        startListener()
+        startCursorListener()
+    }
+
+    /// Cursor positions use a tiny UDP side channel so a multi-megabyte
+    /// ProRes frame on the ordered TCP video stream cannot delay pointer
+    /// motion. Loss is harmless (the next 120Hz position supersedes it), and
+    /// the original TCP cursor messages remain the compatibility fallback.
+    private func startCursorListener() {
+        guard cursorListener == nil,
+              let port = NWEndpoint.Port(rawValue: cursorPort) else { return }
+        do {
+            let params = NWParameters.udp
+            params.allowLocalEndpointReuse = true
+            params.includePeerToPeer = true
+            params.serviceClass = .responsiveData
+            cursorListener = try NWListener(using: params, on: port)
+        } catch {
+            Log.info("cursor UDP listener failed: \(error)")
+            return
+        }
+        cursorListener?.newConnectionHandler = { [weak self] conn in
+            guard let self else { return }
+            self.cursorConnection?.cancel()
+            self.cursorConnection = conn
+            conn.stateUpdateHandler = { state in
+                if case .ready = state {
+                    Log.info("cursor UDP channel ready from \(String(describing: conn.endpoint))")
+                }
+            }
+            conn.start(queue: self.queue)
+            self.receiveCursorDatagrams(on: conn)
+        }
+        cursorListener?.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                Log.info("cursor UDP listener ready on :\(self.cursorPort)")
+            case .failed(let error):
+                Log.info("cursor UDP listener failed: \(error)")
+            default:
+                break
+            }
+        }
+        cursorListener?.start(queue: queue)
+    }
+
+    private func receiveCursorDatagrams(on conn: NWConnection) {
+        conn.receiveMessage { [weak self] data, _, _, error in
+            guard let self else { return }
+            if self.cursorConnection === conn,
+               let data, !data.isEmpty,
+               self.connection?.state == .ready,
+               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               obj["type"] as? String == "cursor" {
+                let sequence = (obj["s"] as? NSNumber)?.uint64Value ?? 0
+                if sequence == 0 || sequence > self.lastCursorDatagramSequence {
+                    if sequence > 0 { self.lastCursorDatagramSequence = sequence }
+                    let visible = (obj["v"] as? Int ?? 0) == 1
+                    let x = obj["x"] as? Double ?? 0
+                    let y = obj["y"] as? Double ?? 0
+                    DispatchQueue.main.async { self.onCursor?(x, y, visible) }
+                }
+            }
+            if let error {
+                Log.info("cursor UDP receive error: \(error)")
+                return
+            }
+            self.receiveCursorDatagrams(on: conn)
+        }
+    }
+
+    private func startListener() {
+        do {
+            // noDelay matters most in THIS direction: input events are tiny
+            // packets, and Nagle would hold each one until the previous is
+            // ACKed — batched, late drags read as input lag.
+            let tcp = NWProtocolTCP.Options()
+            tcp.noDelay = true
+            let params = NWParameters(tls: nil, tcp: tcp)
+            params.allowLocalEndpointReuse = true
+            params.includePeerToPeer = true
+            params.serviceClass = .interactiveVideo
+            listener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: port)!)
+        } catch {
+            setStatus("Listener failed: \(error.localizedDescription)")
+            return
+        }
+        // Advertise on the local network so the sender can discover us.
+        listener?.service = advertisedService
+        listener?.newConnectionHandler = { [weak self] conn in
+            guard let self else { return }
+            Log.info("new connection from \(String(describing: conn.endpoint))")
+            // Loopback would be a tunnel/-host dial; anything else is LAN.
+            let peer = String(describing: conn.endpoint)
+            self.transport = (peer.hasPrefix("127.0.0.1") || peer.hasPrefix("::1")
+                              || peer.hasPrefix("localhost")) ? "USB" : "WiFi"
+            // Replace any existing connection and reset decoder state. A
+            // stale compatibility complaint dies with the peer it was about.
+            self.connection?.cancel()
+            self.connection = conn
+            self.lastCursorDatagramSequence = 0
+            self.resetStreamState()
+            DispatchQueue.main.async { self.peerMessage = nil }
+            conn.stateUpdateHandler = { [weak self] state in
+                switch state {
+                case .ready:
+                    self?.lastDataReceived = Date()
+                    self?.setConnected(true)
+                    self?.sendHello(on: conn, cursorRetryAttempt: 0)
+                    self?.scheduleDarkStreamNudge(on: conn, attempt: 0)
+                case .failed, .cancelled:
+                    self?.setConnected(false)
+                default: break
+                }
+            }
+            conn.start(queue: self.queue)
+            self.receive(on: conn)
+        }
+        listener?.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .ready:
+                self.listenerHealthy = true
+                self.setStatus("Listening on :\(self.port)")
+            case .failed(let error):
+                Log.info("listener failed: \(error) — restarting in 1s")
+                self.listenerHealthy = false
+                self.setStatus("Listener failed — restarting…")
+                self.queue.asyncAfter(deadline: .now() + 1) { self.restartListener() }
+            case .cancelled:
+                self.listenerHealthy = false
+            default: break
+            }
+        }
+        listener?.start(queue: queue)
+    }
+
+    // MARK: - Liveness (ping + watchdog)
+
+    private func schedulePing() {
+        queue.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            guard let self else { return }
+            if self.connection?.state == .ready {
+                self.sendControl(["type": "ping", "t": self.nowMs])
+            }
+            self.schedulePing()
+        }
+    }
+
+    /// JSON on the video channel (pong, cursor, welcome…) — payloads starting '{'.
+    private func handleVideoChannelJSON(_ data: Data) {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = obj["type"] as? String else { return }
+        switch type {
+        case "pong":
+            guard let t1 = obj["t"] as? Double, let mt = obj["mt"] as? Double else { return }
+            let t2 = nowMs
+            let rtt = t2 - t1
+            guard rtt >= 0, rtt < 2000 else { return }
+            let offset = mt - (t1 + t2) / 2
+            offsetSamples.append((rtt, offset))
+            if offsetSamples.count > 15 { offsetSamples.removeFirst() }
+            if let best = offsetSamples.min(by: { $0.rtt < $1.rtt }) {
+                clockOffsetMs = best.offset
+            }
+            lastRttMs = rtt
+        case "ping":
+            // Dark-stream diagnostics: while no video has arrived, the
+            // sender's ping is the only window into its pipeline — log it
+            // verbatim (capFps > 0 with no video = frames die in encode).
+            if formatDesc == nil, let line = String(data: data, encoding: .utf8) {
+                Log.info("sender ping while dark: \(line)")
+            }
+            // The sender piggybacks its send-side health on liveness pings.
+            if let enc = obj["encDrops"] as? Int {
+                macEncDrops = enc
+            } else if let drops = obj["drops"] as? Int {
+                macEncDrops = drops
+            }
+            if let net = obj["netDrops"] as? Int {
+                macNetDrops = net
+            }
+            macDrops = macEncDrops + macNetDrops
+            macPending = obj["pending"] as? Int ?? macPending
+            macInputP50 = obj["inp50"] as? Double ?? macInputP50
+            macInputP95 = obj["inp95"] as? Double ?? macInputP95
+            macCapFps = obj["capFps"] as? Int ?? macCapFps
+        case "cursor":
+            let visible = (obj["v"] as? Int ?? 0) == 1
+            let x = obj["x"] as? Double ?? 0
+            let y = obj["y"] as? Double ?? 0
+            DispatchQueue.main.async { self.onCursor?(x, y, visible) }
+        case "cursorImg":
+            guard let b64 = obj["png"] as? String,
+                  let png = Data(base64Encoded: b64),
+                  let image = NSImage(data: png),
+                  let nw = obj["nw"] as? Double, let nh = obj["nh"] as? Double else { return }
+            let anchor = CGPoint(x: obj["ax"] as? Double ?? 0, y: obj["ay"] as? Double ?? 0)
+            let normSize = CGSize(width: nw, height: nh)
+            DispatchQueue.main.async { self.onCursorImage?(image, anchor, normSize) }
+        case WireMessage.welcome:
+            // The sender identified itself (issue #132). If it speaks a
+            // protocol older than we support, it's the sender that needs
+            // updating — an old sender can't diagnose that itself.
+            let macPV = obj["pv"] as? Int ?? WireProtocol.assumedWhenAbsent
+            peerProtocolVersion = macPV
+            metalRenderer?.setNegotiatedSourceColorSpace(
+                macPV >= 3 ? deviceColorSpace : nil)
+            metalRenderer?.setDeviceICCPassthrough(
+                macPV >= 5 && deviceICCProfileData != nil)
+            if macPV < WireProtocol.minSupportedPeer {
+                let msg = "The OpenDisplay app on the sending Mac is too old for this receiver. Update OpenDisplay there to reconnect."
+                DispatchQueue.main.async { self.peerMessage = msg }
+            }
+        case WireMessage.updateRequired:
+            // The sender refuses this pairing until the receiver updates.
+            // This build is self-updated (rebuilt from source) — surface the
+            // message rather than deep-linking an App Store that isn't ours.
+            let message = obj["message"] as? String
+                ?? "This receiver speaks an older protocol than the sending Mac supports. Update it from the OpenDisplay repository."
+            DispatchQueue.main.async { self.peerMessage = message }
+        default:
+            break
+        }
+    }
+
+    private func scheduleWatchdog() {
+        queue.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            guard let self else { return }
+            if let conn = self.connection, conn.state == .ready,
+               Date().timeIntervalSince(self.lastDataReceived) > 5 {
+                Log.info("watchdog: nothing from the sender for >5s — dropping connection")
+                conn.cancel()
+                self.connection = nil
+                self.setConnected(false)
+            }
+            self.scheduleWatchdog()
+        }
+    }
+
+    private func resetStreamState() {
+        buffer.removeAll(keepingCapacity: true)
+        formatDesc = nil
+        codec = .h264
+        peerProtocolVersion = WireProtocol.assumedWhenAbsent
+        metalRenderer?.setNegotiatedSourceColorSpace(nil)
+        metalRenderer?.setDeviceICCPassthrough(false)
+        vpsSets.removeAll()
+        spsSets.removeAll()
+        ppsSets.removeAll()
+        lastFrameAt = nil
+        frameIntervals.removeAll()
+        decodeFlushes = 0
+        decodeErrorCount = 0
+        if let decompressionSession {
+            VTDecompressionSessionInvalidate(decompressionSession)
+            self.decompressionSession = nil
+        }
+        // Remove the previous session's picture entirely: a fresh session
+        // that sends no video yet must show the idle view, not a frozen
+        // frame the user mistakes for a live (unclickable) desktop.
+        displayLayer.flushAndRemoveImage()
+        DispatchQueue.main.async { self.videoSize = .zero }
+    }
+
+    // MARK: - Control messages (receiver -> sender)
+
+    private func sendHello(on conn: NWConnection, cursorRetryAttempt: Int = 0) {
+        let version = Bundle.main.object(forInfoDictionaryKey:
+            "CFBundleShortVersionString") as? String ?? "unknown"
+        let build = Bundle.main.object(forInfoDictionaryKey:
+            "CFBundleVersion") as? String ?? "unknown"
+        let renderPath = metalRenderer == nil ? "avsamplebuffer" : "metal-device-icc"
+        // AVSampleBufferDisplayLayer may be promoted to a separate WindowServer
+        // plane, where an independently animated cursor layer caused flashes and
+        // trails on some Macs. The normal Metal renderer stays in the same Core
+        // Animation tree, so it can safely use the low-latency local cursor path.
+        let cursorInVideo = metalRenderer == nil
+        // XQ roughly doubles the already-large 4.5K 4:4:4 stream without a
+        // visible improvement on the target iMac. Keep it as an opt-in diagnostic
+        // mode; ordinary ProRes 4444 remains 10-bit 4:4:4 and preserves the exact
+        // device-ICC passthrough path with substantially less network pressure.
+        let proRes4444XQ = UserDefaults.standard.bool(forKey: "enableProRes4444XQ")
+        var hello: [String: Any] = [
+            "type": "hello",
+            "pixelsWide": devicePixelsWide,
+            "pixelsHigh": devicePixelsHigh,
+            "scale": deviceScale,
+            "device": "Mac",
+            "id": Self.installID,
+            "pv": WireProtocol.version,   // issue #132
+            "receiverVersion": version,
+            "receiverBuild": build,
+            "renderPath": renderPath,
+            "colorSpace": deviceColorSpace.rawValue,
+            "cursorInVideo": cursorInVideo,
+            // HEVC keeps a 24-inch iMac at its native 4480×2520 stream size.
+            // The earlier colored blocks came from direct NV12 plane sampling;
+            // this receiver now decodes to retained BGRA before Metal display.
+            "hevc": true,
+            // Protocol 4: frame-delimited Apple ProRes 4444. The sender only
+            // selects it when both apps advertise support, otherwise the
+            // existing HEVC stream remains wire-compatible.
+            "prores4444": true,
+            // XQ materially reduces low-amplitude luma/chroma quantisation
+            // around flat neutral greys. A sender that does not understand
+            // this optional offer simply continues using ordinary 4444.
+            "prores4444XQ": proRes4444XQ,
+        ]
+        let cursorHost = Self.bridgeIP
+        if let cursorHost {
+            hello["cursorHost"] = cursorHost
+            hello["cursorPort"] = Int(cursorPort)
+        }
+        if let deviceICCProfileData {
+            hello["iccProfile"] = deviceICCProfileData.base64EncodedString()
+        }
+        sendControl(hello, on: conn)
+        let cursorHostDiagnostic = cursorHost ?? "pending"
+        Log.info("hello sent: \(devicePixelsWide)x\(devicePixelsHigh) @\(deviceScale)x "
+            + "color=\(deviceColorSpace.rawValue) ICC=\(deviceICCProfileData?.count ?? 0)B "
+            + "cursorInVideo=\(cursorInVideo) cursorHost=\(cursorHostDiagnostic) "
+            + "prores4444=true prores4444XQ=\(proRes4444XQ) "
+            + "receiver=\(version)(\(build)) "
+            + "render=\(renderPath)")
+
+        // bridge0 can have a usable Bonjour path before getifaddrs exposes
+        // its link-local address. Previously that one unlucky hello left the
+        // whole session on the ordered ProRes/TCP stream, adding ~45ms and
+        // making the cursor visibly skip. Re-announce for a short bounded
+        // window; the sender treats identical hellos idempotently.
+        if cursorHost == nil, cursorRetryAttempt < 6 {
+            let delay = min(0.5 + Double(cursorRetryAttempt) * 0.5, 2.0)
+            queue.asyncAfter(deadline: .now() + delay) { [weak self, weak conn] in
+                guard let self, let conn,
+                      self.connection === conn, conn.state == .ready else { return }
+                self.sendHello(on: conn, cursorRetryAttempt: cursorRetryAttempt + 1)
+            }
+        }
+    }
+
+    /// Pointer events mapped onto the wire's touch vocabulary: x/y normalized
+    /// [0,1] in video space, origin top-left. "moved" without a preceding
+    /// "began" is a pure cursor move on the sender (hover); began/moved/ended
+    /// is a click-drag. Stamped in *sender* clock time (our clock + sync
+    /// offset) so the sender can measure input latency without its own sync.
+    func sendTouch(phase: String, x: Double, y: Double) {
+        var msg: [String: Any] = ["type": "touch", "phase": phase, "x": x, "y": y]
+        if let offset = clockOffsetMs { msg["t"] = nowMs + offset }
+        sendControl(msg)
+    }
+
+    /// Announces whether the receiver's local hardware pointer is currently
+    /// driving the remote surface. The sender uses this to stop its sampled
+    /// cursor echo from fighting the receiver's zero-latency local position.
+    func sendPointerPresence(inside: Bool) {
+        sendControl(["type": "pointerPresence", "inside": inside])
+    }
+
+    /// Scroll: dx/dy in video pixels (natural-scrolling sign).
+    func sendScroll(dx: Double, dy: Double) {
+        sendControl(["type": "scroll", "dx": dx, "dy": dy])
+    }
+
+    private func sendControl(_ message: [String: Any], on conn: NWConnection? = nil,
+                             completion: (() -> Void)? = nil) {
+        guard let conn = conn ?? connection,
+              let payload = try? JSONSerialization.data(withJSONObject: message) else {
+            completion?()
+            return
+        }
+        var header = UInt32(payload.count).bigEndian
+        var frame = Data(bytes: &header, count: 4)
+        frame.append(payload)
+        conn.send(content: frame, completion: .contentProcessed { error in
+            if let error { Log.info("control send error: \(error)") }
+            completion?()
+        })
+    }
+
+    // MARK: - Socket read + length-prefixed deframing
+
+    private func receive(on conn: NWConnection) {
+        conn.receive(minimumIncompleteLength: 1, maximumLength: 1 << 18) {
+            [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            if let data, !data.isEmpty {
+                self.lastDataReceived = Date()
+                self.bytesThisWindow += data.count
+                self.buffer.append(data)
+                self.drainFrames()
+            }
+            if let error {
+                Log.info("receive error: \(error)")
+                return
+            }
+            if isComplete {
+                Log.info("peer closed connection")
+                self.setConnected(false)
+                return
+            }
+            self.receive(on: conn)
+        }
+    }
+
+    private func drainFrames() {
+        // Cursor-based drain so we only compact the buffer once per batch.
+        var cursor = buffer.startIndex
+        while buffer.distance(from: cursor, to: buffer.endIndex) >= 4 {
+            let len = buffer[cursor..<buffer.index(cursor, offsetBy: 4)]
+                .withUnsafeBytes { Int(UInt32(bigEndian: $0.loadUnaligned(as: UInt32.self))) }
+            guard buffer.distance(from: cursor, to: buffer.endIndex) >= 4 + len else { break }
+            let start = buffer.index(cursor, offsetBy: 4)
+            let end = buffer.index(start, offsetBy: len)
+            handleVideoPayload(Data(buffer[start..<end]))
+            cursor = end
+        }
+        buffer.removeSubrange(buffer.startIndex..<cursor)
+    }
+
+    // MARK: - Compressed video -> CMSampleBuffer
+
+    private func handleVideoPayload(_ data: Data) {
+        // ProRes frames use one JSON metadata line followed by the complete
+        // compressed frame. A newline delimiter is safe because compressed
+        // bytes begin only after the first line; legacy Annex-B framing is
+        // left untouched.
+        if data.first == UInt8(ascii: "{"),
+           let newline = data.firstIndex(of: UInt8(ascii: "\n")) {
+            let metaData = data[..<newline]
+            if let meta = try? JSONSerialization.jsonObject(with: metaData) as? [String: Any],
+               let codecName = meta["codec"] as? String,
+               codecName == "prores4444" || codecName == "prores4444xq",
+               let width = meta["w"] as? Int,
+               let height = meta["h"] as? Int {
+                let frameStart = data.index(after: newline)
+                handleProRes4444(Data(data[frameStart...]), width: width, height: height,
+                                 xq: codecName == "prores4444xq",
+                                 captureMs: meta["cap"] as? Double,
+                                 sendMs: meta["snd"] as? Double)
+                return
+            }
+        }
+        handleAnnexB(data)
+    }
+
+    private func handleProRes4444(_ data: Data, width: Int, height: Int, xq: Bool,
+                                  captureMs: Double?, sendMs: Double?) {
+        guard !data.isEmpty, width > 0, height > 0 else { return }
+        let dimensionsChanged: Bool
+        if let formatDesc {
+            let dims = CMVideoFormatDescriptionGetDimensions(formatDesc)
+            dimensionsChanged = dims.width != width || dims.height != height
+        } else {
+            dimensionsChanged = true
+        }
+        let requestedCodec: StreamCodec = xq ? .prores4444XQ : .prores4444
+        if codec != requestedCodec || dimensionsChanged {
+            codec = requestedCodec
+            formatDesc = nil
+            if onDecodedFrame == nil { displayLayer.flush() }
+            // Always provide the named metadata as well as the exact ICC.
+            // With ICC alone, VideoToolbox guesses Rec.709 primaries and
+            // transfer for ProRes, creating conflicting colour information
+            // and a visibly grey/incorrect result on a Display P3 iMac.
+            var extensions: [CFString: Any] = [
+                kCMFormatDescriptionExtension_ColorPrimaries:
+                    deviceColorSpace == .displayP3
+                        ? kCMFormatDescriptionColorPrimaries_P3_D65
+                        : kCMFormatDescriptionColorPrimaries_ITU_R_709_2,
+                kCMFormatDescriptionExtension_TransferFunction:
+                    kCMFormatDescriptionTransferFunction_sRGB,
+                kCMFormatDescriptionExtension_YCbCrMatrix:
+                    kCMFormatDescriptionYCbCrMatrix_ITU_R_709_2
+            ]
+            if let deviceICCProfileData {
+                extensions[kCMFormatDescriptionExtension_ICCProfile] = deviceICCProfileData as CFData
+            }
+            let status = CMVideoFormatDescriptionCreate(
+                allocator: kCFAllocatorDefault,
+                codecType: xq
+                    ? kCMVideoCodecType_AppleProRes4444XQ
+                    : kCMVideoCodecType_AppleProRes4444,
+                width: Int32(width), height: Int32(height),
+                extensions: extensions as CFDictionary,
+                formatDescriptionOut: &formatDesc)
+            guard status == noErr else {
+                Log.info("ProRes 4444\(xq ? " XQ" : "") format description FAILED: \(status)")
+                return
+            }
+            DispatchQueue.main.async {
+                self.videoSize = CGSize(width: width, height: height)
+            }
+            setStatus("Receiving \(width)×\(height) (ProRes 4444\(xq ? " XQ" : ""))")
+            let primaries = deviceColorSpace == .displayP3 ? "P3-D65" : "Rec.709"
+            Log.info("format description built (ProRes 4444\(xq ? " XQ" : "")): \(width)x\(height) ICC=\(deviceICCProfileData?.count ?? 0)B primaries=\(primaries) transfer=sRGB matrix=BT.709")
+        }
+        enqueueCompressedFrame(data, captureMs: captureMs, sendMs: sendMs)
+    }
+
+    private func handleAnnexB(_ data: Data) {
+        // Pure JSON payload = control message (pong, cursor sprite etc.).
+        // Video frames also begin with '{' (telemetry prefix) but always
+        // contain start codes — the null bytes make them unambiguous even
+        // against multi-KB JSON (cursor sprites are base64, NUL-free).
+        if data.count < 32_768, data.first == UInt8(ascii: "{"), !data.contains(0x00) {
+            handleVideoChannelJSON(data)
+            return
+        }
+
+        // Split on 4-byte start codes (the sender only emits 00 00 00 01).
+        // Bytes before the FIRST start code are the telemetry prefix
+        // ({"cap":…,"snd":…} stamped by the sender).
+        var nalus: [Data] = []
+        var metaPrefix: Data?
+        data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+            let bytes = raw.bindMemory(to: UInt8.self)
+            var naluStart: Int? = nil
+            var firstSC: Int? = nil
+            var i = 0
+            while i + 4 <= bytes.count {
+                if bytes[i] == 0, bytes[i+1] == 0, bytes[i+2] == 0, bytes[i+3] == 1 {
+                    if firstSC == nil { firstSC = i }
+                    if let s = naluStart, s < i { nalus.append(Data(bytes[s..<i])) }
+                    naluStart = i + 4
+                    i += 4
+                } else {
+                    i += 1
+                }
+            }
+            if let s = naluStart, s < bytes.count { nalus.append(Data(bytes[s...])) }
+            if let f = firstSC, f > 0 { metaPrefix = Data(bytes[0..<f]) }
+        }
+
+        var captureMs: Double?
+        var sendMs: Double?
+        if let metaPrefix,
+           let meta = try? JSONSerialization.jsonObject(with: metaPrefix) as? [String: Any] {
+            captureMs = meta["cap"] as? Double
+            sendMs = meta["snd"] as? Double
+        }
+
+        var vclNALUs: [Data] = []
+        // Parameter sets carried by THIS wire frame (keyframes only). They
+        // are compared and applied as a group after the parse loop — the
+        // refresh stream carries several PPS ids per keyframe, so per-NALU
+        // "replace the single stored PPS" logic would keep only the last.
+        var frameVPS: [Data] = []
+        var frameSPS: [Data] = []
+        var framePPS: [Data] = []
+        for nalu in nalus {
+            guard let first = nalu.first else { continue }
+            let h264Type = first & 0x1F              // 5-bit H.264 nal type
+            let hevcType = (first >> 1) & 0x3F       // 6-bit HEVC nal type
+            // Codec auto-detect on parameter sets only. First bytes alone
+            // are ambiguous — an HEVC IDR_N_LP slice (0x28) reads as an
+            // H.264 PPS — but parameter sets are tiny while slices are KBs,
+            // so only small NALUs may switch the codec: HEVC VPS/SPS/PPS
+            // (0x40/0x42/0x44) read as H.264 types 0/2/4 (never emitted),
+            // and H.264 SPS/PPS (0x67/0x68) read as HEVC 51/52 (invalid).
+            if nalu.count < 128 {
+                if (32...34).contains(hevcType), h264Type != 7, h264Type != 8 {
+                    codec = .hevc
+                } else if h264Type == 7 || h264Type == 8, !(32...34).contains(hevcType) {
+                    codec = .h264
+                }
+            }
+            switch codec {
+            case .h264:
+                switch h264Type {
+                case 7: frameSPS.append(nalu)        // SPS
+                case 8: framePPS.append(nalu)        // PPS
+                case 6: break                        // SEI — skip
+                default: vclNALUs.append(nalu)       // slice data
+                }
+            case .hevc:
+                switch hevcType {
+                case 32: frameVPS.append(nalu)       // VPS
+                case 33: frameSPS.append(nalu)       // SPS
+                case 34: framePPS.append(nalu)       // PPS
+                case 35, 39, 40: break               // AUD / SEI — skip
+                default: vclNALUs.append(nalu)       // slice data
+                }
+            case .prores4444, .prores4444XQ:
+                break
+            }
+        }
+        // A keyframe always carries its complete parameter sets; adopt them
+        // as a group when anything changed (stream size / session switch).
+        // P-frames carry none and leave the stored sets untouched.
+        if !frameSPS.isEmpty || !framePPS.isEmpty,
+           frameVPS != vpsSets || frameSPS != spsSets || framePPS != ppsSets {
+            vpsSets = frameVPS
+            spsSets = frameSPS
+            ppsSets = framePPS
+            formatDesc = nil
+        }
+        if formatDesc == nil {
+            switch codec {
+            case .h264:
+                if !spsSets.isEmpty, !ppsSets.isEmpty {
+                    if onDecodedFrame == nil { displayLayer.flush() }
+                    buildFormatDescription(parameterSets: spsSets + ppsSets, hevc: false)
+                }
+            case .hevc:
+                if !vpsSets.isEmpty, !spsSets.isEmpty, !ppsSets.isEmpty {
+                    if onDecodedFrame == nil { displayLayer.flush() }
+                    buildFormatDescription(parameterSets: vpsSets + spsSets + ppsSets, hevc: true)
+                }
+            case .prores4444, .prores4444XQ:
+                break
+            }
+        }
+        guard !vclNALUs.isEmpty else { return }
+        // All slices of one wire frame go into ONE sample buffer.
+        enqueueFrame(vclNALUs, captureMs: captureMs, sendMs: sendMs)
+    }
+
+    /// Build the format description from ALL parameter sets, ordered
+    /// VPS -> SPS -> PPS. Count is dynamic (see the ppsSets rationale).
+    private func buildFormatDescription(parameterSets: [Data], hevc: Bool) {
+        let sizes = parameterSets.map(\.count)
+        let ptrs: [UnsafeMutablePointer<UInt8>] = parameterSets.map { set in
+            let p = UnsafeMutablePointer<UInt8>.allocate(capacity: set.count)
+            set.copyBytes(to: p, count: set.count)
+            return p
+        }
+        defer { for p in ptrs { p.deallocate() } }
+        let constPtrs = ptrs.map { UnsafePointer($0) }
+        let hevcExtensions: CFDictionary? = {
+            guard hevc, let deviceICCProfileData else { return nil }
+            return [kCMFormatDescriptionExtension_ICCProfile:
+                        deviceICCProfileData as CFData] as CFDictionary
+        }()
+        let status = hevc
+            ? CMVideoFormatDescriptionCreateFromHEVCParameterSets(
+                allocator: kCFAllocatorDefault,
+                parameterSetCount: constPtrs.count,
+                parameterSetPointers: constPtrs,
+                parameterSetSizes: sizes,
+                nalUnitHeaderLength: 4,
+                extensions: hevcExtensions,
+                formatDescriptionOut: &formatDesc)
+            : CMVideoFormatDescriptionCreateFromH264ParameterSets(
+                allocator: kCFAllocatorDefault,
+                parameterSetCount: constPtrs.count,
+                parameterSetPointers: constPtrs,
+                parameterSetSizes: sizes,
+                nalUnitHeaderLength: 4,
+                formatDescriptionOut: &formatDesc)
+        if status == noErr, let formatDesc {
+            let dims = CMVideoFormatDescriptionGetDimensions(formatDesc)
+            let extensions = CMFormatDescriptionGetExtensions(formatDesc) as? [String: Any]
+            let embeddedICC = (extensions?[kCMFormatDescriptionExtension_ICCProfile as String]
+                as? Data)?.count ?? 0
+            let fullRange = extensions?[kCMFormatDescriptionExtension_FullRangeVideo as String]
+                as? Bool
+            Log.info("format description built (\(hevc ? "HEVC" : "H.264"), "
+                + "\(parameterSets.count) parameter sets): \(dims.width)x\(dims.height) "
+                + "ICC=\(embeddedICC)B fullRange=\(fullRange.map(String.init) ?? "unspecified")")
+            DispatchQueue.main.async {
+                self.videoSize = CGSize(width: Int(dims.width), height: Int(dims.height))
+            }
+            setStatus("Receiving \(dims.width)×\(dims.height)\(hevc ? " (HEVC)" : "")")
+        } else {
+            Log.info("format description FAILED (\(hevc ? "HEVC" : "H.264")): \(status)")
+        }
+    }
+
+    private func enqueueFrame(_ nalus: [Data], captureMs: Double? = nil, sendMs: Double? = nil) {
+        guard let formatDesc else { return }
+
+        // Build one AVCC buffer: each NALU prefixed with 4-byte big-endian length.
+        var avcc = Data(capacity: nalus.reduce(0) { $0 + $1.count + 4 })
+        for nalu in nalus {
+            var len = UInt32(nalu.count).bigEndian
+            avcc.append(Data(bytes: &len, count: 4))
+            avcc.append(nalu)
+        }
+
+        enqueueCompressedFrame(avcc, captureMs: captureMs, sendMs: sendMs)
+    }
+
+    /// Wrap one complete compressed frame in an owning CoreMedia buffer and
+    /// present it immediately. Used by both AVCC H.264/HEVC and raw ProRes.
+    private func enqueueCompressedFrame(_ compressed: Data,
+                                        captureMs: Double? = nil,
+                                        sendMs: Double? = nil) {
+        guard let formatDesc else { return }
+
+        // Allocate a block buffer that OWNS its memory and copy the bytes in —
+        // referencing a transient Swift buffer here is a use-after-free.
+        var blockBuffer: CMBlockBuffer?
+        guard CMBlockBufferCreateWithMemoryBlock(
+                allocator: kCFAllocatorDefault,
+                memoryBlock: nil,                   // let CoreMedia allocate
+                blockLength: compressed.count,
+                blockAllocator: kCFAllocatorDefault,
+                customBlockSource: nil, offsetToData: 0,
+                dataLength: compressed.count, flags: 0,
+                blockBufferOut: &blockBuffer) == noErr,
+              let blockBuffer else { return }
+        let copyStatus = compressed.withUnsafeBytes { raw in
+            CMBlockBufferReplaceDataBytes(
+                with: raw.baseAddress!, blockBuffer: blockBuffer,
+                offsetIntoDestination: 0, dataLength: compressed.count)
+        }
+        guard copyStatus == noErr else { return }
+
+        var sample: CMSampleBuffer?
+        var sizeArr = [compressed.count]
+        CMSampleBufferCreateReady(
+            allocator: kCFAllocatorDefault,
+            dataBuffer: blockBuffer,
+            formatDescription: formatDesc,
+            sampleCount: 1,
+            sampleTimingEntryCount: 0, sampleTimingArray: nil,
+            sampleSizeEntryCount: 1, sampleSizeArray: &sizeArr,
+            sampleBufferOut: &sample)
+
+        guard let sample else { return }
+
+        if onDecodedFrame != nil {
+            decodeAndRender(sample)
+        } else {
+            // Fallback only: display immediately with no PTS scheduling.
+            if let attachments = CMSampleBufferGetSampleAttachmentsArray(
+                    sample, createIfNecessary: true),
+               CFArrayGetCount(attachments) > 0 {
+                let dict = unsafeBitCast(
+                    CFArrayGetValueAtIndex(attachments, 0),
+                    to: CFMutableDictionary.self)
+                CFDictionarySetValue(dict,
+                    Unmanaged.passUnretained(
+                        kCMSampleAttachmentKey_DisplayImmediately).toOpaque(),
+                    Unmanaged.passUnretained(kCFBooleanTrue).toOpaque())
+            }
+
+            if displayLayer.status == .failed {
+                Log.info("display layer failed (\(String(describing: displayLayer.error))) — flushing")
+                decodeFlushes += 1
+                displayLayer.flush()
+                requestKeyframeIfNeeded()
+            }
+            displayLayer.enqueue(sample)
+        }
+
+        // Per-frame timing for the HUD.
+        let now = Date()
+        if let last = lastFrameAt {
+            let ms = now.timeIntervalSince(last) * 1000
+            frameIntervals.append(ms)
+            if frameIntervals.count > maxSamples { frameIntervals.removeFirst() }
+            if ms > 50 { stallsThisWindow += 1 }
+        }
+        lastFrameAt = now
+
+        // True end-to-end latency: sender capture timestamp vs our clock
+        // mapped onto the sender's via the ping/pong offset.
+        if let captureMs, let sendMs {
+            encodeWindow.append(sendMs - captureMs)
+            if let offset = clockOffsetMs {
+                let e2e = (nowMs + offset) - captureMs
+                if e2e > -50, e2e < 5000 {
+                    e2eWindow.append(e2e)
+                    e2eRing.append(max(e2e, 0))
+                    if e2eRing.count > maxSamples { e2eRing.removeFirst() }
+                }
+            }
+        }
+
+        framesThisWindow += 1
+        let elapsed = now.timeIntervalSince(fpsWindowStart)
+        if elapsed >= 1.0 {
+            let fps = Int(Double(framesThisWindow) / elapsed)
+            var stats = PerfStats()
+            stats.fps = fps
+            stats.mbps = Double(bytesThisWindow) * 8 / elapsed / 1_000_000
+            stats.samples = frameIntervals
+            if !frameIntervals.isEmpty {
+                stats.avgFrameMs = frameIntervals.reduce(0, +) / Double(frameIntervals.count)
+                stats.maxFrameMs = frameIntervals.max() ?? 0
+            }
+            stats.stalls = stallsThisWindow
+            stats.decodeFlushes = decodeFlushes
+            stats.e2eP50 = percentile(e2eWindow, 0.5)
+            stats.e2eP95 = percentile(e2eWindow, 0.95)
+            stats.encodeP50 = percentile(encodeWindow, 0.5)
+            stats.rttMs = lastRttMs
+            stats.e2eSamples = e2eRing
+            stats.transport = transport
+            stats.macDrops = macDrops
+            stats.macEncDrops = macEncDrops
+            stats.macNetDrops = macNetDrops
+            stats.macPending = macPending
+            stats.inputP50 = macInputP50
+            stats.inputP95 = macInputP95
+            stats.capFps = macCapFps
+            framesThisWindow = 0
+            bytesThisWindow = 0
+            stallsThisWindow = 0
+            fpsWindowStart = now
+
+            // Every 5s, report the aggregate to the sender so its log holds
+            // the full pipeline picture for offline analysis.
+            statsReportCounter += 1
+            if statsReportCounter >= 5 {
+                statsReportCounter = 0
+                // Same aggregate we ship to the sender — also on our own
+                // disk, so receiver-side debugging doesn't need both logs.
+                Log.info(String(format: "stats: %@ fps=%d mbps=%.1f e2e50=%.0f e2e95=%.0f enc50=%.0f rtt=%.0f stalls=%d capFps=%d enc↓=%d net↓=%d",
+                                transport, fps, stats.mbps, stats.e2eP50, stats.e2eP95,
+                                stats.encodeP50, lastRttMs, stats.stalls, macCapFps,
+                                macEncDrops, macNetDrops))
+                sendControl([
+                    "type": "stats",
+                    "transport": transport,
+                    "fps": fps,
+                    "mbps": (stats.mbps * 10).rounded() / 10,
+                    "e2e50": stats.e2eP50.rounded(),
+                    "e2e95": stats.e2eP95.rounded(),
+                    "enc50": stats.encodeP50.rounded(),
+                    "rtt": lastRttMs.rounded(),
+                    "stalls": stats.stalls,
+                    "inp50": macInputP50.rounded(),
+                    "capFps": macCapFps,
+                    "color": metalRenderer?.colorDiagnostic
+                        ?? "AVSampleBufferDisplayLayer",
+                    "targetColor": destinationColorDiagnostic,
+                    "offsetKnown": clockOffsetMs != nil,
+                ])
+                e2eWindow.removeAll(keepingCapacity: true)
+                encodeWindow.removeAll(keepingCapacity: true)
+            }
+
+            DispatchQueue.main.async {
+                self.fps = fps
+                self.perf = stats
+            }
+        }
+    }
+
+    // MARK: - Dark-stream self-rescue
+
+    // MARK: - Explicit VideoToolbox decode (Metal display path)
+
+    private func ensureDecompressionSession() {
+        guard let formatDesc else { return }
+        if let session = decompressionSession {
+            if VTDecompressionSessionCanAcceptFormatDescription(
+                    session, formatDescription: formatDesc) {
+                return
+            }
+            VTDecompressionSessionInvalidate(session)
+            decompressionSession = nil
+        }
+
+        // Preserve Main10 through decode instead of truncating every frame to
+        // 8-bit BGRA. l10r is full-range ARGB2101010 and maps directly to
+        // Metal BGR10A2; Apple's decoder still owns range, matrix and chroma
+        // reconstruction. Some older VideoToolbox implementations reject a
+        // 10-bit packed output request, so retry with BGRA rather than leaving
+        // the receiver black.
+        let outputFormats: [(OSType, String)] = [
+            (kCVPixelFormatType_ARGB2101010LEPacked, "10-bit l10r Metal output"),
+            (kCVPixelFormatType_32BGRA, "8-bit BGRA compatibility fallback"),
+        ]
+        for (pixelFormat, label) in outputFormats {
+            let attributes: [CFString: Any] = [
+                kCVPixelBufferPixelFormatTypeKey: pixelFormat,
+                kCVPixelBufferMetalCompatibilityKey: true,
+                kCVPixelBufferIOSurfacePropertiesKey: [:] as CFDictionary,
+            ]
+            var session: VTDecompressionSession?
+            let status = VTDecompressionSessionCreate(
+                allocator: nil,
+                formatDescription: formatDesc,
+                decoderSpecification: nil,
+                imageBufferAttributes: attributes as CFDictionary,
+                outputCallback: nil,
+                decompressionSessionOut: &session)
+            if status == noErr, let session {
+                decompressionSession = session
+                Log.info("VideoToolbox decoder ready (\(label))")
+                return
+            }
+            Log.info("VTDecompressionSessionCreate \(label) failed: \(status)")
+        }
+        requestKeyframeIfNeeded()
+    }
+
+    private func decodeAndRender(_ sample: CMSampleBuffer) {
+        ensureDecompressionSession()
+        guard let session = decompressionSession else { return }
+        let status = VTDecompressionSessionDecodeFrame(
+            session,
+            sampleBuffer: sample,
+            // Keep decoder state and keyframe requests confined to `queue`.
+            // The renderer itself is asynchronous/latest-wins, so this does
+            // not queue presentation latency behind the decode call.
+            flags: [],
+            infoFlagsOut: nil
+        ) { [weak self] status, _, imageBuffer, _, _ in
+            guard let self else { return }
+            if status == noErr, let imageBuffer {
+                self.onDecodedFrame?(imageBuffer)
+            } else {
+                self.decodeErrorCount += 1
+                if self.decodeErrorCount % 60 == 1 {
+                    Log.info("decode output error: \(status) image=\(imageBuffer != nil) count=\(self.decodeErrorCount)")
+                }
+                self.requestKeyframeIfNeeded()
+            }
+        }
+        if status != noErr {
+            decodeFlushes += 1
+            decodeErrorCount += 1
+            if decodeErrorCount % 60 == 1 {
+                Log.info("decode call error: \(status) count=\(decodeErrorCount)")
+            }
+            requestKeyframeIfNeeded()
+        }
+    }
+
+    /// ScreenCaptureKit only emits frames on content CHANGE — a fresh,
+    /// fully static virtual display can therefore never produce a first
+    /// frame on senders without screenshot seeding. If the stream is still
+    /// dark a few seconds after connect, draw on it ourselves: a tiny
+    /// corner drag renders a selection marquee, which is a real change.
+    /// Runs at most 3 times per connection; a populated display streams
+    /// within the delay, so this only ever touches an empty desktop.
+    private func scheduleDarkStreamNudge(on conn: NWConnection, attempt: Int) {
+        queue.asyncAfter(deadline: .now() + (attempt == 0 ? 3.0 : 4.0)) { [weak self] in
+            guard let self, self.connection === conn, conn.state == .ready,
+                  self.formatDesc == nil, attempt < 3 else { return }
+            Log.info("stream dark \(attempt == 0 ? 3 : 3 + attempt * 4)s after connect — nudging the sender's display (attempt \(attempt + 1))")
+            let steps: [(x: Double, y: Double, phase: String)] = [
+                (0.90, 0.90, "began"), (0.92, 0.92, "moved"),
+                (0.94, 0.94, "moved"), (0.94, 0.94, "ended"),
+            ]
+            for (i, step) in steps.enumerated() {
+                self.queue.asyncAfter(deadline: .now() + Double(i) * 0.04) { [weak self] in
+                    self?.sendControl(["type": "touch", "phase": step.phase,
+                                       "x": step.x, "y": step.y], on: conn)
+                }
+            }
+            self.scheduleDarkStreamNudge(on: conn, attempt: attempt + 1)
+        }
+    }
+
+    private var lastKeyframeRequest = Date.distantPast
+    private func requestKeyframeIfNeeded() {
+        guard Date().timeIntervalSince(lastKeyframeRequest) > 1 else { return }
+        lastKeyframeRequest = Date()
+        Log.info("requesting keyframe (decoder needs sync)")
+        sendControl(["type": "kf"])
+    }
+
+    private func percentile(_ values: [Double], _ p: Double) -> Double {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        let idx = min(sorted.count - 1, Int(Double(sorted.count) * p))
+        return sorted[idx]
+    }
+
+    // MARK: - Helpers
+
+    private func setStatus(_ text: String) {
+        Log.info("status: \(text)")
+        DispatchQueue.main.async { self.status = text }
+    }
+
+    private func setConnected(_ value: Bool) {
+        DispatchQueue.main.async { self.connected = value }
+        if !value { setStatus("Listening on :\(port)") }
+        else { setStatus("Connected") }
+    }
+}

--- a/MacReceiver/Log.swift
+++ b/MacReceiver/Log.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Appends timestamped lines to /tmp/opensidecar-receiver.log (and stdout) so
+/// the stream can be debugged without a debugger attached.
+enum Log {
+    private static let path = "/tmp/opensidecar-receiver.log"
+    private static let queue = DispatchQueue(label: "log")
+    private static let formatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss.SSS"
+        return f
+    }()
+
+    static func info(_ message: String) {
+        let line = "[\(formatter.string(from: Date()))] \(message)\n"
+        print(line, terminator: "")
+        queue.async {
+            if let handle = FileHandle(forWritingAtPath: path) {
+                handle.seekToEndOfFile()
+                handle.write(line.data(using: .utf8)!)
+                try? handle.close()
+            } else {
+                try? line.write(toFile: path, atomically: true, encoding: .utf8)
+            }
+        }
+    }
+}

--- a/MacReceiver/MacReceiverApp.swift
+++ b/MacReceiver/MacReceiverApp.swift
@@ -1,0 +1,568 @@
+// OpenDisplay Receiver — run this on a spare Mac (an iMac gathering dust, an
+// old MacBook) to turn it into a second monitor for another Mac running the
+// OpenDisplay sender app. Speaks the same wire protocol as the iOS receiver,
+// so the sender needs no changes: this Mac shows up in its device list like
+// an iPhone would, over WiFi or wired LAN (Ethernet / Thunderbolt bridge).
+
+import SwiftUI
+import AVFoundation
+import AppKit
+import Combine
+
+@main
+struct MacReceiverApp: App {
+    @NSApplicationDelegateAdaptor(ReceiverAppDelegate.self) private var appDelegate
+
+    var body: some Scene {
+        // A single window (no Cmd+N): the display layer can only live in one
+        // view, so a second window would steal the video from the first.
+        Window("OpenDisplay Receiver", id: "main") {
+            ReceiverRootView()
+        }
+        .commands {
+            CommandMenu("Receiver") {
+                PerfHUDToggle()
+            }
+        }
+    }
+}
+
+/// Menu item bound to the HUD preference so it stays reachable while the
+/// video covers the whole screen.
+private struct PerfHUDToggle: View {
+    @AppStorage("showAnalytics") private var showAnalytics = false
+
+    var body: some View {
+        Toggle("Performance HUD", isOn: $showAnalytics)
+            .keyboardShortcut("i", modifiers: [.command])
+    }
+}
+
+final class ReceiverAppDelegate: NSObject, NSApplicationDelegate {
+    /// Announce "closing" before dying so the sender tears the session down
+    /// immediately instead of waiting out its silence grace. shutDown's
+    /// internal 1s deadline guarantees the completion fires even on a dead
+    /// link, so this can never hang the quit.
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        ReceiverModel.shared.receiver.shutDown {
+            DispatchQueue.main.async {
+                NSApp.reply(toApplicationShouldTerminate: true)
+            }
+        }
+        return .terminateLater
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        true
+    }
+}
+
+// MARK: - Model
+
+@MainActor
+final class ReceiverModel: ObservableObject {
+    static let shared = ReceiverModel()
+
+    let receiver: DisplayReceiver
+    // The hosting window, once known — panel announcements follow the screen
+    // this window actually sits on, not whichever screen owns the menu bar.
+    weak var window: NSWindow? {
+        didSet { if window !== oldValue { applyPanel() } }
+    }
+    private var started = false
+    private var cancellables = Set<AnyCancellable>()
+    private var observers: [NSObjectProtocol] = []
+    private var distObservers: [NSObjectProtocol] = []
+    private var lastWindowColorDescription = ""
+    // Keeps the panel awake while a sender is connected — a second monitor
+    // that falls asleep mid-use isn't one. (The iOS app's isIdleTimerDisabled.)
+    private var activityToken: NSObjectProtocol?
+
+    /// The virtual display is always HiDPI: announced pixels / 2 become its
+    /// logical point size. Read CGDisplayMode.pixelWidth/pixelHeight rather
+    /// than NSScreen.frame so a 24-inch 4.5K iMac announces 4480×2520 even
+    /// though macOS exposes its default desktop as 2240×1260 logical points.
+
+    init() {
+        receiver = DisplayReceiver(displayLayer: AVSampleBufferDisplayLayer())
+        let savedName = UserDefaults.standard.string(forKey: "deviceName")
+        if let savedName, !savedName.isEmpty { receiver.serviceName = savedName }
+        receiver.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+        receiver.$connected
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] connected in
+                self?.setKeepAwake(connected)
+            }
+            .store(in: &cancellables)
+    }
+
+    func start() {
+        guard !started else { return }
+        started = true
+        applyPanel()
+        receiver.start(port: 9000)
+
+        let center = NotificationCenter.default
+        observers.append(center.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil, queue: .main) { [weak self] _ in
+            Task { @MainActor in self?.applyPanel() }
+        })
+        // A user can change the active ICC profile without changing the
+        // display mode. Keep both the announced stream gamut and AppKit's
+        // window backing store synchronized with the new profile.
+        observers.append(center.addObserver(
+            forName: NSScreen.colorSpaceDidChangeNotification,
+            object: nil, queue: .main) { [weak self] _ in
+            Task { @MainActor in self?.applyPanel() }
+        })
+        // The window moving to another display changes which panel we should
+        // announce (multi-monitor spare Macs).
+        observers.append(center.addObserver(
+            forName: NSWindow.didChangeScreenNotification,
+            object: nil, queue: .main) { [weak self] note in
+            Task { @MainActor in
+                guard let self, note.object as? NSWindow === self.window else { return }
+                self.applyPanel()
+            }
+        })
+
+        // Sleep = the panel goes dark — announce it (the sender drops the
+        // virtual display so the cursor isn't stranded) and stop accepting
+        // until the screen is back. The Mac analogue of the iOS device lock.
+        let workspace = NSWorkspace.shared.notificationCenter
+        for name in [NSWorkspace.willSleepNotification,
+                     NSWorkspace.screensDidSleepNotification] {
+            observers.append(workspace.addObserver(
+                forName: name, object: nil, queue: .main) { [weak self] _ in
+                Log.info("sleeping (\(name.rawValue))")
+                Task { @MainActor in self?.receiver.enterSleep() }
+            })
+        }
+        for name in [NSWorkspace.didWakeNotification,
+                     NSWorkspace.screensDidWakeNotification,
+                     // Fast user switching back in: our session is visible again.
+                     NSWorkspace.sessionDidBecomeActiveNotification] {
+            observers.append(workspace.addObserver(
+                forName: name, object: nil, queue: .main) { [weak self] _ in
+                Log.info("awake (\(name.rawValue))")
+                Task { @MainActor in self?.receiver.ensureListening() }
+            })
+        }
+        // Fast user switching away: the stream is hidden behind another
+        // user's session (which keeps the panel awake, so screensDidSleep
+        // never fires) — announce sleeping like a lock would.
+        observers.append(workspace.addObserver(
+            forName: NSWorkspace.sessionDidResignActiveNotification,
+            object: nil, queue: .main) { [weak self] _ in
+            Log.info("session resigned (fast user switch) — sleeping")
+            Task { @MainActor in self?.receiver.enterSleep() }
+        })
+
+        // Screen lock (Ctrl⌘Q / idle lock) hides the stream without any
+        // workspace sleep notification — the direct analogue of the iOS
+        // device lock, delivered only on the distributed center. enterSleep/
+        // ensureListening are idempotent, so overlap with the sleep/wake
+        // pair above is harmless.
+        let dist = DistributedNotificationCenter.default()
+        distObservers.append(dist.addObserver(
+            forName: .init("com.apple.screenIsLocked"),
+            object: nil, queue: .main) { [weak self] _ in
+            Log.info("screen locked — sleeping")
+            Task { @MainActor in self?.receiver.enterSleep() }
+        })
+        distObservers.append(dist.addObserver(
+            forName: .init("com.apple.screenIsUnlocked"),
+            object: nil, queue: .main) { [weak self] _ in
+            Log.info("screen unlocked — re-arming listener")
+            Task { @MainActor in self?.receiver.ensureListening() }
+        })
+    }
+
+    /// Announce this screen's size (see maxEncodePixels). The user's density
+    /// setting scales the announcement down: fewer announced pixels → a
+    /// smaller virtual display in points → larger UI.
+    func applyPanel() {
+        guard let screen = window?.screen ?? NSScreen.main ?? NSScreen.screens.first
+        else { return }
+        syncWindowColorSpace(to: screen)
+        let density = UserDefaults.standard.double(forKey: "announceScale")
+        let user = density > 0 ? density : 1.0
+        let displayID = (screen.deviceDescription[
+            NSDeviceDescriptionKey("NSScreenNumber")
+        ] as? NSNumber).map { CGDirectDisplayID($0.uint32Value) }
+        let mode = displayID.flatMap(CGDisplayCopyDisplayMode)
+        let backing = screen.backingScaleFactor
+        let nativeWidth = mode?.pixelWidth ?? Int(screen.frame.width * backing)
+        let nativeHeight = mode?.pixelHeight ?? Int(screen.frame.height * backing)
+        let w = Double(nativeWidth) * user
+        let h = Double(nativeHeight) * user
+        let profileName = screen.colorSpace?.localizedName
+        let workingColorSpace = ICCProfileGamut.preferredWorkingSpace(
+            profileData: screen.colorSpace?.iccProfileData,
+            name: profileName)
+        Log.info("panel mode: logical=\(Int(screen.frame.width))x\(Int(screen.frame.height)) "
+            + "backing=\(backing)x native=\(nativeWidth)x\(nativeHeight) density=\(user) "
+            + "ICC=\(profileName ?? "unnamed") streamColor=\(workingColorSpace.rawValue)")
+        receiver.setPanel(pixelsWide: Int(w) & ~1, pixelsHigh: Int(h) & ~1,
+                          scale: 2, colorSpace: workingColorSpace,
+                          iccProfileData: screen.colorSpace?.iccProfileData)
+    }
+
+    /// AppKit otherwise creates the window backing store in its default RGB
+    /// space. That intermediate can clip Display P3 before Core Animation has
+    /// a chance to map the Metal layer to the receiving iMac's active ICC
+    /// profile. Make the backing store use the exact current screen profile.
+    private func syncWindowColorSpace(to screen: NSScreen) {
+        guard let window, let target = screen.colorSpace else {
+            receiver.setDestinationColorDiagnostic("window-or-screen-profile-unavailable")
+            return
+        }
+        let previous = window.colorSpace
+        let matchedBefore = previous?.iccProfileData == target.iccProfileData
+        if !matchedBefore { window.colorSpace = target }
+
+        let applied = window.colorSpace
+        let matchedAfter = applied?.iccProfileData == target.iccProfileData
+        let targetName = target.localizedName ?? "unnamed"
+        let windowName = applied?.localizedName ?? "unnamed"
+        let targetBytes = target.iccProfileData?.count ?? 0
+        let windowBytes = applied?.iccProfileData?.count ?? 0
+        if let targetCGColorSpace = target.cgColorSpace {
+            receiver.metalRenderer?.setDestinationColorSpace(
+                targetCGColorSpace,
+                description: "\(targetName)|\(targetBytes)B")
+        }
+        let description = "window=\(windowName)|\(windowBytes)B|display="
+            + "\(targetName)|\(targetBytes)B|match=\(matchedAfter)"
+        receiver.setDestinationColorDiagnostic(description)
+        guard description != lastWindowColorDescription else { return }
+        lastWindowColorDescription = description
+        Log.info("ColorSync window target: \(description)"
+            + (matchedBefore ? "" : " (updated)"))
+    }
+
+    private func setKeepAwake(_ on: Bool) {
+        if on, activityToken == nil {
+            activityToken = ProcessInfo.processInfo.beginActivity(
+                options: [.idleDisplaySleepDisabled, .userInitiated],
+                reason: "Streaming as a second display")
+        } else if !on, let token = activityToken {
+            ProcessInfo.processInfo.endActivity(token)
+            activityToken = nil
+        }
+    }
+}
+
+// MARK: - Root view
+
+struct ReceiverRootView: View {
+    @ObservedObject private var model = ReceiverModel.shared
+    @StateObject private var fullscreen = FullscreenCoordinator()
+    @AppStorage("showAnalytics") private var showAnalytics = false
+    @AppStorage("autoFullscreen") private var autoFullscreen = true
+
+    // Streaming = connected and the video format is known.
+    private var isStreaming: Bool {
+        model.receiver.connected && model.receiver.videoSize != .zero
+    }
+
+    var body: some View {
+        ZStack {
+            if isStreaming {
+                Color.black.ignoresSafeArea()
+                VideoHostView(displayLayer: model.receiver.displayLayer,
+                              receiver: model.receiver)
+                    .ignoresSafeArea()
+                if showAnalytics {
+                    VStack {
+                        Spacer()
+                        PerfHUD(stats: model.receiver.perf,
+                                videoSize: model.receiver.videoSize)
+                            .padding(.bottom, 10)
+                    }
+                    .allowsHitTesting(false)   // never block mouse input
+                }
+                // A compatibility demand from the sender must survive the
+                // idle view being swapped out (the iOS app gates the stream
+                // with a cover; a banner is the lightweight equivalent).
+                if let message = model.receiver.peerMessage {
+                    VStack {
+                        Text(message)
+                            .font(.callout.bold())
+                            .foregroundStyle(.white)
+                            .padding(10)
+                            .background(.red.opacity(0.85),
+                                        in: RoundedRectangle(cornerRadius: 10))
+                            .padding(.top, 12)
+                        Spacer()
+                    }
+                    .allowsHitTesting(false)
+                }
+            } else {
+                IdleView(model: model)
+            }
+        }
+        .background(WindowAccessor { window in
+            model.window = window
+            fullscreen.attach(window)
+        })
+        .onChange(of: isStreaming) { _, streaming in
+            fullscreen.streamingChanged(streaming, autoFullscreen: autoFullscreen)
+        }
+        .onAppear { model.start() }
+        .navigationTitle("OpenDisplay Receiver")
+        .frame(minWidth: 520, minHeight: 460)
+    }
+}
+
+/// Drives native fullscreen from streaming state. NSWindow fullscreen
+/// transitions animate for ~1s and AppKit silently drops toggleFullScreen
+/// calls made mid-transition — so this tracks the transition via the window
+/// notifications and reconciles a *desired* state once each transition
+/// settles, instead of firing one-shot toggles against a styleMask snapshot
+/// (which strands the idle view fullscreen when a sender disconnects during
+/// the enter animation). Only fullscreen WE entered is auto-exited: a user
+/// who fullscreened manually keeps their window state when the stream ends.
+@MainActor
+final class FullscreenCoordinator: ObservableObject {
+    private weak var window: NSWindow?
+    private var transitioning = false
+    private var desired: Bool?          // pending target; nil = settled
+    private var autoEntered = false
+    private var generation = 0          // guards the stuck-transition rescue
+    private var tokens: [NSObjectProtocol] = []
+
+    func attach(_ window: NSWindow) {
+        guard self.window !== window else { return }
+        self.window = window
+        window.collectionBehavior.insert(.fullScreenPrimary)
+        let nc = NotificationCenter.default
+        tokens.forEach(nc.removeObserver)
+        let starting: [Notification.Name] = [NSWindow.willEnterFullScreenNotification,
+                                             NSWindow.willExitFullScreenNotification]
+        let settledEnter = NSWindow.didEnterFullScreenNotification
+        let settledExit = NSWindow.didExitFullScreenNotification
+        tokens = starting.map { name in
+            nc.addObserver(forName: name, object: window, queue: .main) { [weak self] _ in
+                Task { @MainActor in self?.transitioning = true }
+            }
+        }
+        tokens.append(nc.addObserver(forName: settledEnter, object: window, queue: .main) {
+            [weak self] _ in Task { @MainActor in self?.settled(fullscreen: true) }
+        })
+        tokens.append(nc.addObserver(forName: settledExit, object: window, queue: .main) {
+            [weak self] _ in Task { @MainActor in self?.settled(fullscreen: false) }
+        })
+        reconcile()   // a stream may have started before the window was known
+    }
+
+    func streamingChanged(_ streaming: Bool, autoFullscreen: Bool) {
+        if streaming {
+            desired = autoFullscreen ? true : nil
+        } else {
+            desired = autoEntered ? false : nil
+        }
+        reconcile()
+    }
+
+    private func reconcile() {
+        guard !transitioning, let window, let want = desired else { return }
+        let isFullscreen = window.styleMask.contains(.fullScreen)
+        guard want != isFullscreen else {
+            desired = nil
+            return
+        }
+        if want { autoEntered = true }
+        transitioning = true
+        generation += 1
+        let expected = generation
+        window.toggleFullScreen(nil)
+        // AppKit can swallow a toggle without any notification (e.g. issued
+        // in a dead spot right after a transition) — don't stay wedged.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { [weak self] in
+            guard let self, self.generation == expected, self.transitioning else { return }
+            Log.info("fullscreen transition never settled — reconciling")
+            self.transitioning = false
+            self.reconcile()
+        }
+    }
+
+    private func settled(fullscreen: Bool) {
+        transitioning = false
+        generation += 1
+        if let want = desired {
+            if want == fullscreen {
+                desired = nil
+            } else {
+                reconcile()   // e.g. the stream ended mid-enter: now leave
+            }
+        } else {
+            // A transition we didn't request is the user's own toggle — from
+            // here on, their choice owns the window state.
+            autoEntered = false
+        }
+    }
+}
+
+/// Grabs the hosting NSWindow so streaming can drive native fullscreen.
+private struct WindowAccessor: NSViewRepresentable {
+    let onWindow: (NSWindow) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async {
+            if let window = view.window { onWindow(window) }
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async {
+            if let window = nsView.window { onWindow(window) }
+        }
+    }
+}
+
+// MARK: - Idle view (no sender connected)
+
+struct IdleView: View {
+    @ObservedObject var model: ReceiverModel
+    @AppStorage("deviceName") private var deviceName =
+        Host.current().localizedName ?? "Mac"
+    @AppStorage("announceScale") private var announceScale = 1.0
+    @AppStorage("autoFullscreen") private var autoFullscreen = true
+    @AppStorage("showAnalytics") private var showAnalytics = false
+
+    private var version: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "dev"
+    }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer(minLength: 12)
+
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .frame(width: 96, height: 96)
+
+            VStack(spacing: 6) {
+                Text("OpenDisplay Receiver")
+                    .font(.largeTitle.bold())
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(model.receiver.connected ? Color.green : Color.orange)
+                        .frame(width: 8, height: 8)
+                    Text(model.receiver.status)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                if let message = model.receiver.peerMessage {
+                    Text(message)
+                        .font(.callout)
+                        .foregroundStyle(.red)
+                        .multilineTextAlignment(.center)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                Label("Run the OpenDisplay app on the Mac whose screen you want to extend",
+                      systemImage: "macbook")
+                Label("Both Macs on the same network — WiFi, Ethernet, or a Thunderbolt bridge",
+                      systemImage: "network")
+                Label("Pick this Mac in the sender's device list — streaming starts automatically",
+                      systemImage: "play.circle")
+            }
+            .font(.subheadline)
+            .padding(18)
+            .frame(maxWidth: 460)
+            .background(.quaternary.opacity(0.5),
+                        in: RoundedRectangle(cornerRadius: 14))
+
+            Form {
+                TextField("Name", text: $deviceName)
+                    .onChange(of: deviceName) { _, name in
+                        model.receiver.setServiceName(name)
+                    }
+                    .help("Shown in the sender's device list.")
+                Picker("Text size", selection: $announceScale) {
+                    Text("Match this display").tag(1.0)
+                    Text("Larger").tag(0.75)
+                    Text("Largest").tag(0.5)
+                }
+                .onChange(of: announceScale) { model.applyPanel() }
+                .help("Larger sizes announce a smaller virtual display, so everything on it is bigger — and cheaper to stream.")
+                Toggle("Enter fullscreen while streaming", isOn: $autoFullscreen)
+                Toggle("Performance HUD (⌘I)", isOn: $showAnalytics)
+            }
+            .formStyle(.columns)
+            .frame(maxWidth: 460)
+
+            Spacer(minLength: 8)
+
+            Text("v\(version) · same LAN, port 9000 · github.com/peetzweg/opendisplay")
+                .font(.footnote)
+                .foregroundStyle(.tertiary)
+                .padding(.bottom, 10)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Performance HUD (compact cousin of the iOS overlay)
+
+struct PerfHUD: View {
+    let stats: PerfStats
+    let videoSize: CGSize
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Text(stats.transport)
+                .font(.system(size: 12, weight: .bold, design: .monospaced))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(stats.transport == "WiFi" ? Color.blue.opacity(0.4)
+                            : Color.gray.opacity(0.3),
+                            in: Capsule())
+                .foregroundStyle(.white)
+            if stats.e2eP50 > 0 {
+                metric("latency", String(format: "%.0f ms", stats.e2eP50))
+                metric("p95", String(format: "%.0f ms", stats.e2eP95))
+                metric("encode", String(format: "%.0f ms", stats.encodeP50))
+            }
+            if stats.inputP50 > 0 {
+                metric("input", String(format: "%.0f ms", stats.inputP50))
+            }
+            metric("rtt", String(format: "%.0f ms", stats.rttMs))
+            metric("FPS", "\(stats.fps)")
+            if stats.capFps > 0 {
+                metric("sender cap", "\(stats.capFps)")
+            }
+            metric("Mbit/s", String(format: "%.1f", stats.mbps))
+            metric("stalls", "\(stats.stalls)")
+            if stats.macDrops > 0 {
+                metric("drops", "\(stats.macDrops)")
+            }
+            metric("res", "\(Int(videoSize.width))×\(Int(videoSize.height))")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 9)
+        .background(.black.opacity(0.55), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func metric(_ label: String, _ value: String) -> some View {
+        VStack(spacing: 1) {
+            Text(value)
+                .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                .foregroundStyle(.white)
+            Text(label)
+                .font(.system(size: 8, design: .monospaced))
+                .foregroundStyle(.white.opacity(0.5))
+        }
+    }
+}

--- a/MacReceiver/MetalVideoRenderer.swift
+++ b/MacReceiver/MetalVideoRenderer.swift
@@ -1,0 +1,361 @@
+// MetalVideoRenderer — macOS display path for the receiver.
+//
+// AVSampleBufferDisplayLayer may be promoted to a dedicated video overlay on
+// macOS. Moving another layer (the low-latency cursor) above that overlay can
+// make WindowServer switch composition paths and briefly expose black on some
+// Intel Macs. Decode explicitly to NV12 and render through CAMetalLayer so the
+// video and cursor remain in one ordinary Core Animation composition tree.
+//
+// Frames use a latest-wins slot. The receiver never queues more latency when
+// the GPU or the 60 Hz panel cannot consume every decoded frame.
+
+import Foundation
+import Metal
+import QuartzCore
+import CoreVideo
+import CoreGraphics
+import CoreImage
+
+final class MetalVideoRenderer {
+    let metalLayer = CAMetalLayer()
+    private let device: MTLDevice
+    private let commandQueue: MTLCommandQueue
+    private let pipeline: MTLRenderPipelineState
+    private let ciContext: CIContext
+    private var textureCache: CVMetalTextureCache?
+
+    private let renderQueue = DispatchQueue(label: "receiver.metal.render",
+                                             qos: .userInteractive)
+    private let lock = NSLock()
+    private var pendingFrame: CVPixelBuffer?
+    private var drainScheduled = false
+    private var loggedPixelFormat: OSType?
+    private var loggedSourceColorDescription = ""
+    // Protocol v3 makes the negotiated working space authoritative. Decoder
+    // attachments remain diagnostic because some VideoToolbox versions drop
+    // or rewrite P3_D65 when producing packed RGB output.
+    private var negotiatedSourceColorSpace: WireColorSpace?
+    // The receiving screen's exact active ICC profile. Core Image performs
+    // source→destination conversion explicitly on the GPU; the CAMetalLayer
+    // is then tagged with that same destination profile, making the final
+    // WindowServer transform an identity operation instead of relying on an
+    // implicit P3→display conversion that differs across macOS/GPU versions.
+    private var destinationColorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+    private var destinationColorDescription = "sRGB"
+    // Protocol 5 sender virtual displays are already composited in the exact
+    // receiver ICC device space. In that mode the decoded 10-bit RGB values
+    // must not be interpreted as Display P3 and transformed a second time.
+    private var deviceICCPassthrough = false
+    private var deviceCopyActive = false
+    private var latestColorDiagnostic = "waiting-for-frame"
+
+    var colorDiagnostic: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return latestColorDiagnostic
+    }
+
+    init?() {
+        guard let device = MTLCreateSystemDefaultDevice(),
+              let queue = device.makeCommandQueue() else { return nil }
+        self.device = device
+        commandQueue = queue
+        ciContext = CIContext(mtlDevice: device, options: [
+            .cacheIntermediates: false,
+        ])
+
+        let source = """
+        #include <metal_stdlib>
+        using namespace metal;
+        struct VOut { float4 pos [[position]]; float2 uv; };
+        vertex VOut vmain(uint vid [[vertex_id]]) {
+            float2 p[4] = { float2(-1,-1), float2(1,-1),
+                            float2(-1, 1), float2(1, 1) };
+            VOut o;
+            o.pos = float4(p[vid], 0, 1);
+            o.uv = float2((p[vid].x + 1.0) * 0.5,
+                          (1.0 - p[vid].y) * 0.5);
+            return o;
+        }
+        fragment float4 fmain(VOut in [[stage_in]],
+                              texture2d<float> image [[texture(0)]]) {
+            constexpr sampler s(filter::linear);
+            return image.sample(s, in.uv);
+        }
+        """
+
+        let library: MTLLibrary
+        do {
+            library = try device.makeLibrary(source: source, options: nil)
+        } catch {
+            Log.info("Metal shader compile failed: \(error)")
+            return nil
+        }
+        guard let vertex = library.makeFunction(name: "vmain"),
+              let fragment = library.makeFunction(name: "fmain") else {
+            Log.info("Metal shader functions missing")
+            return nil
+        }
+
+        let descriptor = MTLRenderPipelineDescriptor()
+        descriptor.vertexFunction = vertex
+        descriptor.fragmentFunction = fragment
+        descriptor.colorAttachments[0].pixelFormat = .bgr10a2Unorm
+        do {
+            pipeline = try device.makeRenderPipelineState(descriptor: descriptor)
+        } catch {
+            Log.info("Metal pipeline creation failed: \(error)")
+            return nil
+        }
+
+        metalLayer.device = device
+        // Match the receiver's 10-bit decoder output so Main10 survives all
+        // the way to Core Animation/ColorSync instead of being truncated to
+        // BGRA8 before the active iMac ICC transform.
+        metalLayer.pixelFormat = .bgr10a2Unorm
+        // Core Image performs the explicit source→display ICC transform with
+        // a Metal compute kernel. A framebuffer-only drawable rejects that
+        // shader write and Core Image displays its magenta error surface.
+        // Allow general GPU access while keeping the drawable private to this
+        // renderer; this is required for the explicit-ICC path.
+        metalLayer.framebufferOnly = false
+        metalLayer.isOpaque = true
+        metalLayer.backgroundColor = CGColor(gray: 0, alpha: 1)
+        // Start conservatively in sRGB. Each decoded frame's HEVC VUI updates
+        // this to Display P3 when the sender negotiated a wide-gamut stream;
+        // Core Animation then performs one source→active-display ICC transform.
+        metalLayer.colorspace = CGColorSpace(name: CGColorSpace.sRGB)
+        metalLayer.maximumDrawableCount = 3
+        metalLayer.displaySyncEnabled = true
+        metalLayer.presentsWithTransaction = false
+        CVMetalTextureCacheCreate(nil, nil, device, nil, &textureCache)
+    }
+
+    /// Called on the receiver queue. Replaces any older frame that has not
+    /// reached the GPU yet and returns immediately.
+    func render(_ pixelBuffer: CVPixelBuffer) {
+        lock.lock()
+        pendingFrame = pixelBuffer
+        let shouldSchedule = !drainScheduled
+        if shouldSchedule { drainScheduled = true }
+        lock.unlock()
+
+        if shouldSchedule {
+            renderQueue.async { [weak self] in self?.drainLatestFrames() }
+        }
+    }
+
+    func setNegotiatedSourceColorSpace(_ colorSpace: WireColorSpace?) {
+        renderQueue.async { [weak self] in
+            guard let self else { return }
+            negotiatedSourceColorSpace = colorSpace
+            loggedSourceColorDescription = ""
+            Log.info("Metal negotiated source color: \(colorSpace?.rawValue ?? "attachment-fallback")")
+        }
+    }
+
+    func setDestinationColorSpace(_ colorSpace: CGColorSpace,
+                                  description: String) {
+        renderQueue.async { [weak self] in
+            guard let self else { return }
+            destinationColorSpace = colorSpace
+            destinationColorDescription = description
+            metalLayer.colorspace = colorSpace
+            loggedSourceColorDescription = ""
+            Log.info("Metal explicit ICC target: \(description)")
+        }
+    }
+
+    func setDeviceICCPassthrough(_ enabled: Bool) {
+        renderQueue.async { [weak self] in
+            guard let self else { return }
+            deviceICCPassthrough = enabled
+            loggedSourceColorDescription = ""
+            Log.info("Metal receiver-device ICC passthrough: \(enabled)")
+        }
+    }
+
+    private func drainLatestFrames() {
+        while true {
+            lock.lock()
+            guard let frame = pendingFrame else {
+                drainScheduled = false
+                lock.unlock()
+                return
+            }
+            pendingFrame = nil
+            lock.unlock()
+            draw(frame)
+        }
+    }
+
+    private func draw(_ pixelBuffer: CVPixelBuffer) {
+        let width = CVPixelBufferGetWidth(pixelBuffer)
+        let height = CVPixelBufferGetHeight(pixelBuffer)
+        // Native mode is a one-to-one 4480x2520 texture. No reconstruction,
+        // sharpening or intermediate GPU surface is allowed in the accurate
+        // path; Core Animation only places this source-sized drawable in the
+        // view and color-matches it to the active display profile.
+        let size = CGSize(width: width, height: height)
+        if metalLayer.drawableSize != size { metalLayer.drawableSize = size }
+
+        let pixelFormat = CVPixelBufferGetPixelFormatType(pixelBuffer)
+        if loggedPixelFormat != pixelFormat {
+            loggedPixelFormat = pixelFormat
+            Log.info("Metal pixel format: \(fourCC(pixelFormat)) \(width)x\(height)")
+        }
+        switch pixelFormat {
+        case kCVPixelFormatType_ARGB2101010LEPacked:
+            // l10r bit layout is A:31...30, R:29...20, G:19...10,
+            // B:9...0 — exactly MTLPixelFormat.bgr10a2Unorm.
+            break
+        case kCVPixelFormatType_32BGRA:
+            break // 8-bit compatibility input; output remains 10-bit.
+        default:
+            return
+        }
+
+        let sourceColorSpace = updateSourceColorSpace(from: pixelBuffer)
+
+        guard let drawable = metalLayer.nextDrawable(),
+              let commandBuffer = commandQueue.makeCommandBuffer() else { return }
+
+        let targetColorSpace = destinationColorSpace
+        let copiedDevicePixels = deviceICCPassthrough
+            && pixelFormat == kCVPixelFormatType_ARGB2101010LEPacked
+            && encodeBitExactCopy(from: pixelBuffer, to: drawable.texture,
+                                  commandBuffer: commandBuffer)
+        if copiedDevicePixels != deviceCopyActive {
+            deviceCopyActive = copiedDevicePixels
+            loggedSourceColorDescription = ""
+            Log.info("Metal bit-exact 10-bit device copy: \(copiedDevicePixels)")
+        }
+        if !copiedDevicePixels {
+            // Canonical-space compatibility path for protocol <= 4 peers.
+            let image = CIImage(cvPixelBuffer: pixelBuffer, options: [
+                .colorSpace: sourceColorSpace,
+            ])
+            ciContext.render(image, to: drawable.texture,
+                             commandBuffer: commandBuffer,
+                             bounds: image.extent,
+                             colorSpace: targetColorSpace)
+        }
+        metalLayer.colorspace = targetColorSpace
+
+        // The decoder owns a pool of IOSurface-backed pixel buffers. Retain the
+        // source buffer itself (not only its CVMetalTexture wrappers) until the
+        // GPU has finished reading it; otherwise VideoToolbox may recycle the
+        // surface early and a flat color reveals mixed old/new macroblocks.
+        let retainedPixelBuffer = pixelBuffer
+        commandBuffer.addCompletedHandler { _ in
+            _ = retainedPixelBuffer
+        }
+        commandBuffer.present(drawable)
+        commandBuffer.commit()
+    }
+
+    /// `l10r` and `.bgr10a2Unorm` have the same packed bit layout. A Metal
+    /// blit therefore preserves every decoded 10-bit channel code exactly —
+    /// no shader interpolation, Core Image dither, or second ICC transform.
+    private func encodeBitExactCopy(from pixelBuffer: CVPixelBuffer,
+                                    to destination: MTLTexture,
+                                    commandBuffer: MTLCommandBuffer) -> Bool {
+        guard let textureCache else { return false }
+        var cvTexture: CVMetalTexture?
+        let width = CVPixelBufferGetWidth(pixelBuffer)
+        let height = CVPixelBufferGetHeight(pixelBuffer)
+        let status = CVMetalTextureCacheCreateTextureFromImage(
+            kCFAllocatorDefault, textureCache, pixelBuffer, nil,
+            .bgr10a2Unorm, width, height, 0, &cvTexture)
+        guard status == kCVReturnSuccess,
+              let cvTexture,
+              let source = CVMetalTextureGetTexture(cvTexture),
+              source.width == destination.width,
+              source.height == destination.height,
+              let blit = commandBuffer.makeBlitCommandEncoder() else { return false }
+        blit.copy(from: source, sourceSlice: 0, sourceLevel: 0,
+                  sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
+                  sourceSize: MTLSize(width: width, height: height, depth: 1),
+                  to: destination, destinationSlice: 0, destinationLevel: 0,
+                  destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0))
+        blit.endEncoding()
+        commandBuffer.addCompletedHandler { _ in _ = cvTexture }
+        return true
+    }
+
+    private func encodeCopy(from source: MTLTexture, to destination: MTLTexture,
+                            commandBuffer: MTLCommandBuffer) -> Bool {
+        let pass = MTLRenderPassDescriptor()
+        pass.colorAttachments[0].texture = destination
+        pass.colorAttachments[0].loadAction = .dontCare
+        pass.colorAttachments[0].storeAction = .store
+        guard let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: pass) else {
+            return false
+        }
+        encoder.setRenderPipelineState(pipeline)
+        encoder.setFragmentTexture(source, index: 0)
+        encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+        encoder.endEncoding()
+        return true
+    }
+
+    /// VideoToolbox propagates the bitstream's source color description onto
+    /// decoded buffers. Use its primaries to select the matching standard
+    /// working space, then let Core Animation map that source to the active
+    /// screen ICC exactly once.
+    private func updateSourceColorSpace(from pixelBuffer: CVPixelBuffer) -> CGColorSpace {
+        let attachedSpace: CGColorSpace? = {
+            guard let value = CVBufferCopyAttachment(
+                    pixelBuffer, kCVImageBufferCGColorSpaceKey, nil),
+                  CFGetTypeID(value) == CGColorSpace.typeID else { return nil }
+            return (value as! CGColorSpace)
+        }()
+        let primaries = CVBufferCopyAttachment(
+            pixelBuffer, kCVImageBufferColorPrimariesKey, nil) as? String
+        let transfer = CVBufferCopyAttachment(
+            pixelBuffer, kCVImageBufferTransferFunctionKey, nil) as? String
+        let matrix = CVBufferCopyAttachment(
+            pixelBuffer, kCVImageBufferYCbCrMatrixKey, nil) as? String
+
+        // Some VideoToolbox versions synthesize a generic CGColorSpace whose
+        // transfer curve does not match the stream's explicit sRGB transfer.
+        // Trust the VUI primaries, but construct Apple's canonical P3/sRGB
+        // spaces so the transfer function remains deterministic.
+        let p3Primaries = kCVImageBufferColorPrimaries_P3_D65 as String
+        let attachmentColor: WireColorSpace = primaries == p3Primaries
+            ? .displayP3 : .sRGB
+        let selectedColor = negotiatedSourceColorSpace ?? attachmentColor
+        let sourceSpace = CGColorSpace(name: selectedColor == .displayP3
+            ? CGColorSpace.displayP3
+            : CGColorSpace.sRGB)!
+
+        let attachedName = attachedSpace?.name as String? ?? "none"
+        let sourceName = sourceSpace.name as String? ?? "unnamed"
+        let description = "\(sourceName)|neg=\(negotiatedSourceColorSpace?.rawValue ?? "none")|"
+            + "\(primaries ?? "none")|"
+            + "\(transfer ?? "none")|\(matrix ?? "none")|\(attachedName)"
+        if description != loggedSourceColorDescription {
+            loggedSourceColorDescription = description
+            lock.lock()
+            latestColorDiagnostic = description + "|gpuDst="
+                + destinationColorDescription + "|explicitICC=true"
+                + "|devicePassthrough=\(deviceICCPassthrough)"
+                + "|deviceCopy=\(deviceCopyActive)"
+            lock.unlock()
+            Log.info("Metal source color: \(sourceName) primaries=\(primaries ?? "none") "
+                + "transfer=\(transfer ?? "none") matrix=\(matrix ?? "none") "
+                + "decoderSpace=\(attachedName) negotiated="
+                + "\(negotiatedSourceColorSpace?.rawValue ?? "none") "
+                + "explicitTarget=\(destinationColorDescription)")
+        }
+        return sourceSpace
+    }
+
+    private func fourCC(_ value: OSType) -> String {
+        let bytes: [UInt8] = [
+            UInt8((value >> 24) & 0xff), UInt8((value >> 16) & 0xff),
+            UInt8((value >> 8) & 0xff), UInt8(value & 0xff),
+        ]
+        return String(bytes: bytes, encoding: .ascii) ?? String(value)
+    }
+}

--- a/MacReceiver/ReceiverVideoView.swift
+++ b/MacReceiver/ReceiverVideoView.swift
@@ -1,0 +1,521 @@
+// The production streaming surface is a CAMetalLayer in the normal Core
+// Animation tree. Its cursor sprite is another CALayer in that same tree, so
+// pointer updates do not wait for a 4.5K video encode and do not trigger the
+// WindowServer plane transitions seen with AVSampleBufferDisplayLayer.
+//
+// Input mapping: hover moves the sender's cursor ("moved" with no button —
+// the sender injects .mouseMoved), click-drag is began/moved/ended (left
+// mouse down/drag/up), scroll wheel / trackpad scroll forwards as "scroll".
+// The local hardware cursor is hidden over the video; the sprite echoed from
+// the sender (which carries the true shape: arrow, I-beam, resize…) is drawn
+// in its place on the low-latency control path.
+
+import SwiftUI
+import AppKit
+import AVFoundation
+import Combine
+
+struct VideoHostView: NSViewRepresentable {
+    let displayLayer: AVSampleBufferDisplayLayer
+    let receiver: DisplayReceiver
+
+    func makeNSView(context: Context) -> ReceiverVideoView {
+        let view = ReceiverVideoView()
+        view.receiver = receiver
+        view.attach(displayLayer: displayLayer)
+
+        if receiver.metalRenderer != nil {
+            receiver.onCursor = { [weak view] x, y, visible in
+                view?.moveCursor(x: x, y: y, visible: visible)
+            }
+            receiver.onCursorImage = { [weak view] image, anchor, normSize in
+                view?.setCursorSprite(image, anchor: anchor, normSize: normSize)
+            }
+        } else {
+            // A separate cursor CALayer over AVSampleBufferDisplayLayer can
+            // trigger WindowServer plane transitions on affected systems.
+            receiver.onCursor = nil
+            receiver.onCursorImage = nil
+        }
+        // The sender keeps one input injector across reconnects — if a drag
+        // was in flight when the link dropped, its isDown never cleared and
+        // our hover "moved"s would replay as a phantom drag. A "cancelled"
+        // on every (re)connect heals that; with nothing pressed the sender
+        // ignores it outright.
+        view.reconnectCancellable = receiver.$connected
+            .removeDuplicates()
+            .filter { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak view] _ in view?.healSenderDragState() }
+        return view
+    }
+
+    func updateNSView(_ nsView: ReceiverVideoView, context: Context) {
+        // videoSize arrives after the format description — re-fit the layers.
+        nsView.needsLayout = true
+    }
+}
+
+final class ReceiverVideoView: NSView {
+    weak var receiver: DisplayReceiver?
+    var reconnectCancellable: AnyCancellable?
+    private weak var videoLayer: AVSampleBufferDisplayLayer?
+    private weak var metalLayer: CAMetalLayer?
+    private var lastDisplayProfileDescription = ""
+
+    // Top-left-origin coordinates, matching the wire protocol (and making the
+    // layer tree behave like UIKit's, so the cursor code mirrors iOS).
+    override var isFlipped: Bool { true }
+    override var acceptsFirstResponder: Bool { true }
+
+    private let cursorLayer: CALayer = {
+        let layer = CALayer()
+        layer.isHidden = true
+        layer.zPosition = 10
+        // Position updates arrive at 120Hz — implicit animations would
+        // smear the cursor behind every move.
+        layer.actions = ["position": NSNull(), "contents": NSNull(),
+                         "bounds": NSNull(), "hidden": NSNull()]
+        return layer
+    }()
+    private var cursorNormSize = CGSize.zero
+    private var cursorNorm = CGPoint(x: 0.5, y: 0.5)
+    private var cursorVisible = false
+    private var hardwarePointerOverVideo = false
+    private var hardwareCursor = NSCursor.arrow
+    private var hardwareCursorSourceImage: NSImage?
+    private var hardwareCursorAnchor = CGPoint.zero
+    private var hardwareCursorPointSize = CGSize.zero
+    private var nativeCursorHiddenForInactivity = true
+    private var nativeCursorHideWorkItem: DispatchWorkItem?
+    private let nativeCursorHideDelay: TimeInterval = 0.30
+    // While the hardware pointer is over this receiver's video, its AppKit
+    // coordinates are the freshest possible cursor position. Do not let the
+    // sender's round-trip echo (which is necessarily a few samples older)
+    // overwrite them and create a saw-tooth path on diagonal movement.
+    private var localCursorOverride = false
+    private var lastLocalCursorEventAt = Date.distantPast
+    // The receiver's native pointer must not be replaced by a delayed sender
+    // echo during a brief AppKit event gap. A quarter second still hands the
+    // surface back quickly when the sending Mac's physical mouse takes over.
+    private let localCursorOverrideGrace: TimeInterval = 0.25
+
+    // Fully transparent cursor shown while the pointer is over the video —
+    // the sender's echoed sprite replaces it.
+    private static let blankCursor: NSCursor = {
+        let image = NSImage(size: NSSize(width: 1, height: 1))
+        image.lockFocus()
+        NSColor.clear.set()
+        NSRect(x: 0, y: 0, width: 1, height: 1).fill()
+        image.unlockFocus()
+        return NSCursor(image: image, hotSpot: .zero)
+    }()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.black.cgColor
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not used") }
+
+    func attach(displayLayer: AVSampleBufferDisplayLayer) {
+        displayLayer.removeFromSuperlayer()
+        if let renderer = receiver?.metalRenderer {
+            let metal = renderer.metalLayer
+            metal.removeFromSuperlayer()
+            metal.frame = bounds
+            metalLayer = metal
+            videoLayer = nil
+            layer?.insertSublayer(metal, at: 0)
+            layer?.addSublayer(cursorLayer)
+            Log.info("video view attached Metal surface")
+        } else {
+            displayLayer.frame = bounds
+            videoLayer = displayLayer
+            metalLayer = nil
+            layer?.insertSublayer(displayLayer, at: 0)
+            Log.info("video view attached AVSampleBufferDisplayLayer fallback")
+        }
+        if metalLayer == nil {
+            cursorLayer.removeFromSuperlayer()
+        }
+        syncContentsScale()
+        needsLayout = true
+    }
+
+    // Unlike iOS, macOS layers default to contentsScale 1.0 — the compositor
+    // would render the video into a point-sized (half-resolution) backing on
+    // Retina panels. Track the window's actual backing scale.
+    private func syncContentsScale() {
+        let scale = window?.backingScaleFactor ?? 2
+        let changed = layer?.contentsScale != scale
+            || videoLayer?.contentsScale != scale
+            || metalLayer?.contentsScale != scale
+            || cursorLayer.contentsScale != scale
+        layer?.contentsScale = scale
+        videoLayer?.contentsScale = scale
+        metalLayer?.contentsScale = scale
+        cursorLayer.contentsScale = scale
+        if changed { Log.info("contentsScale -> \(scale)") }
+    }
+
+    /// CAMetalLayer receives the decoded frame's actual source profile, then
+    /// Core Animation color-matches it to this screen's active ICC profile.
+    private func logDisplayColorProfile() {
+        guard let window, let screen = window.screen else { return }
+        let displaySpace = screen.colorSpace
+        let windowSpace = window.colorSpace
+        let displayName = displaySpace?.localizedName ?? "unnamed"
+        let windowName = windowSpace?.localizedName ?? "unnamed"
+        let displayBytes = displaySpace?.iccProfileData?.count ?? 0
+        let windowBytes = windowSpace?.iccProfileData?.count ?? 0
+        let matches = displaySpace?.iccProfileData == windowSpace?.iccProfileData
+        let description = "\(windowName)|\(windowBytes)|\(displayName)|"
+            + "\(displayBytes)|\(matches)"
+        guard description != lastDisplayProfileDescription else { return }
+        lastDisplayProfileDescription = description
+        Log.info("ColorSync target: window=\(windowName) ICC=\(windowBytes)B "
+            + "display=\(displayName) ICC=\(displayBytes)B match=\(matches)")
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        syncContentsScale()
+        logDisplayColorProfile()
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        syncContentsScale()
+        logDisplayColorProfile()
+    }
+
+    // MARK: - Layout
+
+    private var lastLoggedLayout = ""
+
+    override func layout() {
+        super.layout()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        if let metalLayer {
+            // Metal draws a full quad, so aspect-fit by sizing its layer.
+            metalLayer.frame = videoRect() ?? bounds
+        } else {
+            // AVSBDL fallback aspect-fits internally (videoGravity).
+            videoLayer?.frame = bounds
+        }
+        updateCursorLayout()
+        rebuildHardwareCursor()
+        CATransaction.commit()
+        let video = receiver?.videoSize ?? .zero
+        let line = "layout: bounds=\(Int(bounds.width))x\(Int(bounds.height))"
+            + " video=\(Int(video.width))x\(Int(video.height))"
+        if line != lastLoggedLayout {
+            lastLoggedLayout = line
+            Log.info(line)
+        }
+    }
+
+    /// Aspect-fit rect of the video inside the view (inverse of normalized()).
+    private func videoRect() -> CGRect? {
+        guard let video = receiver?.videoSize, video != .zero,
+              bounds.width > 0, bounds.height > 0 else { return nil }
+        let scale = min(bounds.width / video.width, bounds.height / video.height)
+        let size = CGSize(width: video.width * scale, height: video.height * scale)
+        return CGRect(x: (bounds.width - size.width) / 2,
+                      y: (bounds.height - size.height) / 2,
+                      width: size.width, height: size.height)
+    }
+
+    // MARK: - Cursor echo
+
+    func moveCursor(x: Double, y: Double, visible: Bool) {
+        if localCursorOverride {
+            // Ignore only echoes that overlap active receiver-side movement.
+            // Once local events stop, a different sender-side coordinate is
+            // allowed to take ownership so the sending Mac's physical mouse
+            // remains visible on the virtual display.
+            guard Date().timeIntervalSince(lastLocalCursorEventAt)
+                    > localCursorOverrideGrace else { return }
+            localCursorOverride = false
+            nativeCursorHideWorkItem?.cancel()
+            nativeCursorHideWorkItem = nil
+            nativeCursorHiddenForInactivity = true
+            receiver?.sendPointerPresence(inside: false)
+            if hardwarePointerOverVideo {
+                Self.blankCursor.set()
+            }
+        }
+        let wasVisible = cursorVisible && !cursorLayer.isHidden
+        let oldPresentationPosition = cursorLayer.presentation()?.position
+            ?? cursorLayer.position
+        cursorNorm = CGPoint(x: x, y: y)
+        cursorVisible = visible
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        cursorLayer.isHidden = !visible || cursorLayer.contents == nil
+        updateCursorLayout()
+        CATransaction.commit()
+
+        // UDP samples can arrive between the receiver's 60Hz display ticks.
+        // A tiny, linear, one-sample interpolation lets Core Animation fill
+        // that gap without adding the floaty lag of conventional smoothing.
+        // Large jumps and visibility transitions still snap immediately.
+        if visible, wasVisible, cursorLayer.contents != nil {
+            let target = cursorLayer.position
+            let distance = hypot(target.x - oldPresentationPosition.x,
+                                 target.y - oldPresentationPosition.y)
+            if distance > 0.25, distance < max(bounds.width, bounds.height) * 0.08 {
+                let animation = CABasicAnimation(keyPath: "position")
+                animation.fromValue = NSValue(point: oldPresentationPosition)
+                animation.toValue = NSValue(point: target)
+                animation.duration = 1.0 / 120.0
+                animation.timingFunction = CAMediaTimingFunction(name: .linear)
+                cursorLayer.add(animation, forKey: "remoteCursorPosition")
+            } else {
+                cursorLayer.removeAnimation(forKey: "remoteCursorPosition")
+            }
+        } else {
+            cursorLayer.removeAnimation(forKey: "remoteCursorPosition")
+        }
+    }
+
+    func setCursorSprite(_ image: NSImage, anchor: CGPoint, normSize: CGSize) {
+        hardwareCursorSourceImage = image
+        hardwareCursorAnchor = anchor
+        hardwareCursorPointSize = .zero
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        cursorLayer.contents = image.cgImage(forProposedRect: nil, context: nil, hints: nil)
+        cursorLayer.anchorPoint = anchor
+        cursorNormSize = normSize
+        cursorLayer.isHidden = !cursorVisible
+        updateCursorLayout()
+        rebuildHardwareCursor()
+        CATransaction.commit()
+    }
+
+    /// PNG decoding reports Retina backing pixels as NSImage points on some
+    /// macOS versions, making a normal 32pt cursor appear around 64pt. The
+    /// wire already carries the authoritative cursor size normalized against
+    /// the sender display, so reconstruct its point size from our fitted video
+    /// rect instead of trusting PNG metadata.
+    private func rebuildHardwareCursor() {
+        guard let source = hardwareCursorSourceImage else { return }
+        let desired: CGSize
+        if let rect = videoRect(), cursorNormSize != .zero {
+            desired = CGSize(width: cursorNormSize.width * rect.width,
+                             height: cursorNormSize.height * rect.height)
+        } else {
+            let scale = window?.backingScaleFactor ?? 2
+            desired = CGSize(width: source.size.width / scale,
+                             height: source.size.height / scale)
+        }
+        guard desired.width >= 1, desired.height >= 1,
+              desired.width <= 256, desired.height <= 256,
+              desired != hardwareCursorPointSize else { return }
+        guard let sizedImage = source.copy() as? NSImage else { return }
+        sizedImage.size = desired
+        let hotSpot = NSPoint(x: hardwareCursorAnchor.x * desired.width,
+                              y: hardwareCursorAnchor.y * desired.height)
+        hardwareCursor = NSCursor(image: sizedImage, hotSpot: hotSpot)
+        hardwareCursorPointSize = desired
+        if localCursorOverride, hardwarePointerOverVideo,
+           !nativeCursorHiddenForInactivity {
+            hardwareCursor.set()
+        }
+    }
+
+    private func updateCursorLayout() {
+        guard let rect = videoRect(), cursorNormSize != .zero else { return }
+        cursorLayer.bounds = CGRect(x: 0, y: 0,
+                                    width: cursorNormSize.width * rect.width,
+                                    height: cursorNormSize.height * rect.height)
+        cursorLayer.position = CGPoint(x: rect.minX + cursorNorm.x * rect.width,
+                                       y: rect.minY + cursorNorm.y * rect.height)
+    }
+
+    // MARK: - Tracking (hover + native local cursor)
+
+    private var trackingArea: NSTrackingArea?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea { removeTrackingArea(trackingArea) }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseMoved, .mouseEnteredAndExited, .cursorUpdate,
+                      .activeInKeyWindow],
+            owner: self, userInfo: nil)
+        addTrackingArea(area)
+        trackingArea = area
+    }
+
+    override func cursorUpdate(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        if videoRect()?.contains(point) == true {
+            hardwarePointerOverVideo = true
+            if localCursorOverride, !nativeCursorHiddenForInactivity {
+                hardwareCursor.set()
+            } else {
+                Self.blankCursor.set()
+            }
+        } else {
+            hardwarePointerOverVideo = false
+            NSCursor.arrow.set()
+        }
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        endLocalCursorOverride()
+        NSCursor.arrow.set()
+    }
+
+    // Teardown (stream ended) fires no mouseExited for the dying tracking
+    // area — restore the arrow or the idle view inherits an invisible cursor.
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        super.viewWillMove(toWindow: newWindow)
+        if newWindow == nil {
+            nativeCursorHideWorkItem?.cancel()
+            nativeCursorHideWorkItem = nil
+            nativeCursorHiddenForInactivity = true
+            hardwarePointerOverVideo = false
+            NSCursor.arrow.set()
+        }
+    }
+
+    // First click on an inactive window should already register on the
+    // extended desktop, like a real monitor would.
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    // MARK: - Mouse -> wire
+
+    // The video is aspect-fit inside the view; map view coords into the
+    // displayed video rect and normalize to [0,1] (origin top-left — the
+    // view is flipped, so location(in:) already is).
+    private func normalized(_ point: CGPoint) -> (x: Double, y: Double)? {
+        guard let rect = videoRect() else { return nil }
+        let x = (point.x - rect.minX) / rect.width
+        let y = (point.y - rect.minY) / rect.height
+        return (min(max(x, 0), 1), min(max(y, 0), 1))
+    }
+
+    private var lastNorm: (x: Double, y: Double) = (0.5, 0.5)
+    private var isMouseDown = false
+
+    private func beginLocalCursorOverride(x: Double, y: Double) {
+        lastLocalCursorEventAt = Date()
+        hardwarePointerOverVideo = true
+        nativeCursorHiddenForInactivity = false
+        if !localCursorOverride {
+            localCursorOverride = true
+            receiver?.sendPointerPresence(inside: true)
+        }
+        cursorNorm = CGPoint(x: x, y: y)
+        cursorVisible = true
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        // Receiver-local movement uses the WindowServer hardware pointer.
+        // Keep the sprite layer exclusively for the sending Mac's pointer.
+        cursorLayer.isHidden = true
+        CATransaction.commit()
+        hardwareCursor.set()
+        scheduleNativeCursorHide()
+    }
+
+    private func scheduleNativeCursorHide() {
+        nativeCursorHideWorkItem?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.localCursorOverride,
+                  self.hardwarePointerOverVideo,
+                  Date().timeIntervalSince(self.lastLocalCursorEventAt)
+                    >= self.nativeCursorHideDelay else { return }
+            self.nativeCursorHiddenForInactivity = true
+            self.cursorVisible = false
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            self.cursorLayer.isHidden = true
+            CATransaction.commit()
+            Self.blankCursor.set()
+        }
+        nativeCursorHideWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + nativeCursorHideDelay,
+                                      execute: work)
+    }
+
+    private func endLocalCursorOverride() {
+        let wasLocal = localCursorOverride
+        nativeCursorHideWorkItem?.cancel()
+        nativeCursorHideWorkItem = nil
+        nativeCursorHiddenForInactivity = true
+        localCursorOverride = false
+        hardwarePointerOverVideo = false
+        cursorVisible = false
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        cursorLayer.isHidden = true
+        CATransaction.commit()
+        if wasLocal {
+            receiver?.sendPointerPresence(inside: false)
+        }
+    }
+
+    func healSenderDragState() {
+        receiver?.sendTouch(phase: "cancelled", x: lastNorm.x, y: lastNorm.y)
+    }
+
+    private func send(_ phase: String, _ event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        // Passive hover in the letterbox bars stays local: clamping it would
+        // drag the sender's cursor along the video edge. Clicks and drags
+        // keep the clamp (iOS parity — a drag may legitimately leave the
+        // video and still needs its moved/ended delivered).
+        if phase == "moved", !isMouseDown,
+           let rect = videoRect(), !rect.contains(point) {
+            endLocalCursorOverride()
+            NSCursor.arrow.set()
+            return
+        }
+        guard let norm = normalized(point) else {
+            // videoSize can blip away mid-drag (format renegotiation) — still
+            // release the button, or the sender's cursor stays stuck dragging.
+            if phase == "ended" || phase == "cancelled" {
+                receiver?.sendTouch(phase: phase, x: lastNorm.x, y: lastNorm.y)
+            }
+            return
+        }
+        lastNorm = norm
+        beginLocalCursorOverride(x: norm.x, y: norm.y)
+        receiver?.sendTouch(phase: phase, x: norm.x, y: norm.y)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        isMouseDown = true
+        send("began", event)
+    }
+    override func mouseDragged(with event: NSEvent) { send("moved", event) }
+    override func mouseUp(with event: NSEvent) {
+        send("ended", event)
+        isMouseDown = false
+    }
+    // Hover: "moved" with no active press injects a pure cursor move.
+    override func mouseMoved(with event: NSEvent) { send("moved", event) }
+
+    override func scrollWheel(with event: NSEvent) {
+        guard let video = receiver?.videoSize, video != .zero,
+              bounds.width > 0, bounds.height > 0 else { return }
+        // Precise deltas (trackpad/Magic Mouse) are in points; line-based
+        // wheel clicks get a conventional points-per-line factor.
+        let factor = event.hasPreciseScrollingDeltas ? 1.0 : 10.0
+        let scale = min(bounds.width / video.width, bounds.height / video.height)
+        // Deltas in video pixels. AppKit's scrollingDelta sign convention
+        // matches the wire's natural-scrolling sign (both mean "content
+        // moves this way"), so pass it straight through.
+        let dx = event.scrollingDeltaX * factor / scale
+        let dy = event.scrollingDeltaY * factor / scale
+        guard dx != 0 || dy != 0 else { return }
+        receiver?.sendScroll(dx: dx, dy: dy)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -232,6 +232,42 @@ Open the iPhone app, then pick **"iPhone (WiFi)"** from the Connection menu
 in the Mac app. Discovery is automatic via Bonjour. USB has lower latency;
 WiFi has no cable.
 
+### Run (Mac as the second display — experimental)
+
+A spare Mac (an iMac gathering dust, an old MacBook) can be the *receiving*
+side ([#17](https://github.com/peetzweg/opendisplay/issues/17)): the
+**OpenDisplay Receiver** app speaks the same wire protocol as the iOS app,
+so the sender needs no changes and lists the Mac like it would an iPhone.
+
+```sh
+xcodebuild -project OpenSidecar.xcodeproj -scheme OpenSidecarMacReceiver \
+  -configuration Release -derivedDataPath build build
+```
+
+1. Copy `build/Build/Products/Release/OpenDisplay Receiver.app` onto the
+   spare Mac (macOS 14+) and open it — it listens on port 9000 and
+   advertises itself via Bonjour. If that Mac runs the application firewall
+   (System Settings → Network → Firewall), allow incoming connections when
+   asked — and prefer building with `DEVELOPMENT_TEAM` set (see `.env`),
+   since the firewall can't remember the choice for an ad-hoc-signed build.
+2. Both Macs on the same network — WiFi works; **wired Ethernet (or a
+   Thunderbolt bridge) gives the lowest latency**. There is no USB mode
+   between two Macs (`usbmuxd` is iOS-only).
+3. On the sending Mac, open OpenDisplay and pick the receiver from the
+   device list. The receiver goes fullscreen and becomes a true extended
+   display; the video window's mouse works as input on it (hover moves the
+   pointer, click-drag and scroll pass through).
+
+The receiver announces its panel at native HiDPI size, so UI density
+matches a real monitor; the sender clamps the *encoded stream* to
+3840×2160@60 (H.264 level 5.2's ceiling — the low-latency encoder silently
+drops every frame beyond it), so panels above 4K get a downscaled stream on
+a native-sized display. A "Text size" setting on the receiver's idle screen
+trades resolution for larger UI and lower bandwidth. Keyboard passthrough
+and right-click don't exist on the wire yet (see
+[#5](https://github.com/peetzweg/opendisplay/issues/5) /
+[#6](https://github.com/peetzweg/opendisplay/issues/6)).
+
 ### Permissions checklist
 
 macOS and iOS gate several things this app needs — most prompt on first use,

--- a/Shared/Protocol.swift
+++ b/Shared/Protocol.swift
@@ -11,7 +11,9 @@ import Foundation
 /// protocol 1 — that's every install in the field that predates the handshake.
 enum WireProtocol {
     /// The protocol version this build speaks.
-    static let version = 3
+    // Protocol 5 adds optional receiver-device-ICC passthrough and ProRes
+    // 4444 XQ negotiation. It also includes protocol 3's Pencil messages.
+    static let version = 5
 
     /// Protocol version that introduced Apple Pencil / proximity wire messages.
     /// Peers below this get pencil input as legacy `touch` events.
@@ -24,6 +26,79 @@ enum WireProtocol {
 
     /// A peer that advertises no `pv` is defined as protocol 1.
     static let assumedWhenAbsent = 1
+}
+
+/// Device-independent working color spaces supported by the stream. The
+/// receiver chooses the smallest space that preserves its panel gamut; the
+/// sender uses that same space for the virtual display, capture and codec VUI.
+/// Unknown/absent values intentionally fall back to sRGB for old peers.
+enum WireColorSpace: String, Codable {
+    case sRGB = "srgb"
+    case displayP3 = "displayP3"
+}
+
+/// Reads the RGB primary XYZ tags from an ICC display profile and chooses the
+/// closest stream working space. This stays Foundation-only so both Mac apps
+/// can share the decision without making the iOS target depend on ColorSync.
+enum ICCProfileGamut {
+    static func preferredWorkingSpace(profileData: Data?, name: String?) -> WireColorSpace {
+        if name?.lowercased().contains("p3") == true { return .displayP3 }
+        guard let profileData, let primaries = rgbXYZ(from: profileData) else { return .sRGB }
+
+        // D50-adapted XYZ values from Apple's standard sRGB and Display P3
+        // profiles. Calibrated iMac profiles vary slightly but remain much
+        // closer to P3 than sRGB.
+        let sRGB = [
+            0.436096, 0.222504, 0.013931,
+            0.385071, 0.716888, 0.097076,
+            0.143036, 0.060608, 0.713898,
+        ]
+        let displayP3 = [
+            0.515121, 0.241196, -0.001053,
+            0.291977, 0.692245, 0.041885,
+            0.157104, 0.066574, 0.784073,
+        ]
+        func distance(to reference: [Double]) -> Double {
+            zip(primaries, reference).reduce(0) { result, pair in
+                let delta = pair.0 - pair.1
+                return result + delta * delta
+            }
+        }
+        return distance(to: displayP3) < distance(to: sRGB) ? .displayP3 : .sRGB
+    }
+
+    private static func rgbXYZ(from data: Data) -> [Double]? {
+        guard let tagCount = uint32(data, at: 128), tagCount <= 256 else { return nil }
+        var tags: [UInt32: Int] = [:]
+        for index in 0..<Int(tagCount) {
+            let entry = 132 + index * 12
+            guard let signature = uint32(data, at: entry),
+                  let offset = uint32(data, at: entry + 4) else { return nil }
+            tags[signature] = Int(offset)
+        }
+        let signatures: [UInt32] = [0x7258_595A, 0x6758_595A, 0x6258_595A] // rXYZ/gXYZ/bXYZ
+        var result: [Double] = []
+        for signature in signatures {
+            guard let offset = tags[signature],
+                  uint32(data, at: offset) == 0x5859_5A20 else { return nil } // "XYZ "
+            for component in 0..<3 {
+                guard let raw = uint32(data, at: offset + 8 + component * 4) else { return nil }
+                result.append(Double(Int32(bitPattern: raw)) / 65536.0)
+            }
+        }
+        return result
+    }
+
+    private static func uint32(_ data: Data, at offset: Int) -> UInt32? {
+        guard offset >= 0, offset + 4 <= data.count else { return nil }
+        return data.withUnsafeBytes { bytes in
+            let p = bytes.bindMemory(to: UInt8.self)
+            return UInt32(p[offset]) << 24
+                | UInt32(p[offset + 1]) << 16
+                | UInt32(p[offset + 2]) << 8
+                | UInt32(p[offset + 3])
+        }
+    }
 }
 
 /// Control-message `type` strings introduced with the handshake. The pre-

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -327,6 +327,7 @@ final class PhoneReceiver: ObservableObject {
             tcp.noDelay = true
             let params = NWParameters(tls: nil, tcp: tcp)
             params.allowLocalEndpointReuse = true
+            params.includePeerToPeer = true
             params.serviceClass = .interactiveVideo
             listener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: port)!)
         } catch {

--- a/project.yml
+++ b/project.yml
@@ -23,8 +23,17 @@ schemes:
     build:
       targets:
         OpenSidecariOS: all
+  OpenSidecarMacReceiver:
+    build:
+      targets:
+        OpenSidecarMacReceiver: all
 # DEVELOPMENT_TEAM comes from the environment (see generate.sh / .env) so no
-# personal team ID lives in the repo. Unset = unsigned, fine for CI.
+# personal team ID lives in the repo. Unset = ad-hoc signing: fine for CI and
+# the outgoing-only apps, but the Mac RECEIVER accepts incoming connections
+# on :9000 — build that one with DEVELOPMENT_TEAM set if the receiving Mac
+# runs the application firewall, which can't persist an allow choice for an
+# ad-hoc identity (it re-prompts every rebuild; denied = Bonjour-visible but
+# unconnectable).
 settings:
   base:
     DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}
@@ -105,6 +114,39 @@ targets:
         # run, which fails the build before a single test executes.
         GENERATE_INFOPLIST_FILE: "YES"
         SWIFT_OBJC_BRIDGING_HEADER: Mac/OpenSidecarMac-Bridging-Header.h
+
+  # A Mac as the RECEIVING side: run this on a spare iMac/MacBook to use it as
+  # a second monitor for another Mac running OpenSidecarMac. Speaks the same
+  # wire protocol as the iOS app, so the sender needs no changes. Not
+  # distributed (yet) — build it yourself, see README.
+  OpenSidecarMacReceiver:
+    type: application
+    platform: macOS
+    deploymentTarget: "14.0"
+    sources:
+      - MacReceiver
+      - Shared
+      # Reuse the sender's icon so the receiver is recognizably OpenDisplay.
+      - path: Mac/Assets.xcassets
+    info:
+      path: MacReceiver/Info.plist
+      properties:
+        NSPrincipalClass: NSApplication
+        CFBundleDisplayName: OpenDisplay Receiver
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+        NSLocalNetworkUsageDescription: OpenDisplay Receiver advertises itself on the local network so the sending Mac can connect.
+        NSBonjourServices: ["_opensidecar._tcp"]
+        LSApplicationCategoryType: public.app-category.utilities
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.peetzweg.opensidecar.mac.receiver
+        PRODUCT_NAME: OpenDisplay Receiver
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+      configs:
+        Debug:
+          PRODUCT_BUNDLE_IDENTIFIER: com.peetzweg.opensidecar.mac.receiver.debug
+
   OpenSidecariOS:
     type: application
     platform: iOS


### PR DESCRIPTION
## Summary

- add an experimental macOS receiver target that turns a spare Mac into a native HiDPI second display
- negotiate HEVC / ProRes 4444, Display P3, and the receiver display ICC profile for high-fidelity Mac-to-Mac streaming
- add dynamic Thunderbolt Bridge selection plus a low-latency UDP cursor side channel
- support receiver-side mouse input, cursor ownership, auto-hide behavior, reconnects, sleep/wake handling, and performance diagnostics
- preserve upstream Apple Pencil protocol support while extending the additive wire protocol

## Why

This implements the Mac receiver use case discussed in #17. The sender creates a virtual display at the receiver panel's native HiDPI geometry, while the receiver decodes and presents the stream using its active display profile. Cursor motion is separated from the large ordered video stream to avoid visible lag under ProRes load.

## User impact

A second Mac (tested with a 24-inch iMac receiver) can act as an extended display over Wi-Fi or Thunderbolt Bridge, with native resolution, local mouse input, automatic discovery, and reconnect behavior.

## Validation

- `xcodegen generate`
- `xcodebuild test -project OpenSidecar.xcodeproj -scheme OpenSidecarMac -destination platform=macOS CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` — 13 tests passed
- `xcodebuild build -project OpenSidecar.xcodeproj -scheme OpenSidecarMacReceiver -configuration Release -destination platform=macOS CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` — succeeded for arm64 and x86_64

## Notes

This is opened as a draft because the feature is substantial and may be easier to review in follow-up slices. Branding assets, packaged apps, and local build artifacts are intentionally excluded.