### PR TITLE
feat(web): add compatible apps section to the landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The capture/streaming pipeline itself uses only public APIs.
 
 ## Compatible apps
 
-The official apps cover a Mac sender and an iPhone/iPad receiver on iOS 17+.
+The official apps cover a Mac sender and an iPhone/iPad receiver on iOS 16.4+.
 Other people have built their own clients that speak the same protocol, so
 you can also use an Android device or an older iPad as a display, or drive
 one from Linux. If your hardware is not covered yet, start here:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -136,6 +136,7 @@ export default function App() {
             <a href="#features">Features</a>
             <a href="#why">Compare</a>
             <a href="#faq">FAQ</a>
+            <a href="#compatible">Other platforms</a>
             <a href="#contribute">Contribute</a>
             <a
               className="gh"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -446,6 +446,52 @@ export default function App() {
         </div>
       </section>
 
+      {/* Community clients for hardware the official apps don't cover. Keep in
+          sync with the "Compatible apps" section in the README. */}
+      <section id="compatible">
+        <div className="wrap sec">
+          <p className="eyebrow">Compatible apps</p>
+          <h2>Android, older iPads, Linux.</h2>
+          <p className="compat-lead">
+            The official apps are a Mac sender and an iPhone or iPad receiver. Other people have
+            built their own clients that speak the same protocol, so you can also use an Android
+            device or an older iPad as a display, or drive one from Linux. If your hardware isn't
+            covered yet, start here.
+          </p>
+          <div className="compat">
+            <a className="compat-item" href="https://github.com/gprot42/android-opendisplay">
+              <span className="compat-role">Android receiver</span>
+              <span className="compat-repo">gprot42/android-opendisplay ↗</span>
+              <p>GrapheneOS receiver for de-Googled Pixel phones and tablets. Android 8.0+.</p>
+            </a>
+            <a className="compat-item" href="https://github.com/josepacelli/opendisplay-android">
+              <span className="compat-role">Android receiver</span>
+              <span className="compat-repo">josepacelli/opendisplay-android ↗</span>
+              <p>Android receiver that works with an unmodified Mac app. Android 8.0+.</p>
+            </a>
+            <a
+              className="compat-item"
+              href="https://github.com/cuongpham1/ipad-iphone-second-monitor-ios12-free"
+            >
+              <span className="compat-role">iOS 12 receiver</span>
+              <span className="compat-repo">cuongpham1/ipad-iphone-second-monitor-ios12-free ↗</span>
+              <p>For iPads and iPhones too old to run the official receiver.</p>
+            </a>
+            <a className="compat-item" href="https://github.com/tixwho/opendisplay-linux">
+              <span className="compat-role">Linux sender</span>
+              <span className="compat-repo">tixwho/opendisplay-linux ↗</span>
+              <p>Drive an iPhone or iPad from a Wayland desktop (KDE Plasma, Hyprland).</p>
+            </a>
+          </div>
+          <p className="compat-note">
+            These are fan-made projects, not official builds. They aren't affiliated with
+            OpenDisplay and aren't maintained, reviewed or supported by us, so please report issues
+            with them in their own repositories. Listing them here also says nothing about our own
+            plans: an official OpenDisplay app may still ship for any of these platforms later.
+          </p>
+        </div>
+      </section>
+
       <section id="contribute">
         <div className="wrap sec">
           <p className="eyebrow">Contribute</p>

--- a/src/index.css
+++ b/src/index.css
@@ -269,6 +269,29 @@ summary::after { content: "+"; font-family: var(--mono); color: var(--faint);
 details[open] summary::after { content: "–"; }
 details p { color: var(--muted); padding: 0 0 24px; max-width: 78ch; }
 
+/* ---- compatible apps ---- */
+/* Same hairline-cell grid as .fgrid, but every cell is a link to a community
+   repo: mono role label on top, repo path as the heading. */
+.compat-lead { color: var(--muted); max-width: 78ch; margin-top: 8px; }
+.compat { display: grid; grid-template-columns: repeat(2, 1fr);
+  border-top: 1px solid var(--line); border-left: 1px solid var(--line);
+  margin-top: 32px; }
+a.compat-item { display: block; padding: 24px; text-decoration: none; color: var(--fg);
+  border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+a.compat-item:hover { background: #fafafa; }
+.compat-role { font-family: var(--mono); font-size: 0.78rem; color: var(--faint);
+  display: block; margin-bottom: 12px; }
+/* Repo paths are long (one runs to 45 chars) — allow a mid-path break so a
+   narrow cell wraps instead of overflowing. */
+.compat-repo { display: block; font-weight: 600; font-size: 1.02rem;
+  letter-spacing: -0.01em; overflow-wrap: anywhere; }
+.compat-item p { color: var(--muted); font-size: 0.92rem; margin-top: 6px; }
+.compat-note { color: var(--muted); font-size: 0.9rem; max-width: 78ch; margin-top: 28px; }
+@media (max-width: 560px) {
+  .compat { grid-template-columns: 1fr; }
+  a.compat-item { padding: 20px; }
+}
+
 /* ---- support / ko-fi ---- */
 .support { text-align: center; }
 .support h2 { max-width: 22ch; margin: 0 auto; }

--- a/src/index.css
+++ b/src/index.css
@@ -37,6 +37,9 @@ nav .links a:hover { color: var(--fg); }
 nav .links a.gh { display: inline-flex; align-items: center; gap: 6px; }
 nav .gh-logo { width: 16px; height: 16px; fill: currentColor; display: block; }
 nav .gh-stars { font-variant-numeric: tabular-nums; }
+/* Seven links plus the star count outgrow the row well before the 680px
+   cutoff — tighten the spacing instead of dropping an item. */
+@media (max-width: 900px) { nav .links { gap: 14px; font-size: 0.85rem; } }
 @media (max-width: 680px) { nav .links { display: none; } }
 
 /* ---- section scaffolding ---- */


### PR DESCRIPTION
Brings the README's new **Compatible apps** section to the landing page, as a `#compatible` section between the FAQ and Contribute, plus an "Other platforms" nav link.

**Why:** People with an Android tablet, an iPad stuck on iOS 12, or a Linux desktop keep finding the community clients by accident. The README lists them now; the website is where those visitors actually land first.

**How:** The cards reuse the existing `.fgrid` hairline-cell treatment, with each cell a link to its repo, so nothing new enters the visual language. Two deliberate calls: the nav says "Other platforms" rather than "Compatible apps", because "Compatible" sits two labels away from "Compare" and the two blur while scanning; and the nav row gets tighter spacing under 900px, since seven links plus the star badge would otherwise crowd before the 680px hide-breakpoint.

Also fixes a wrong version claim in the README from the previous PR: the receiver's deployment target is iOS 16.4, not 17+.