### PR TITLE
docs(mac): correct stale defaults domain in debug-knob comments

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -202,7 +202,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // capture→encode→stream→display latency (~30ms perceived). Instead we
     // hide it from capture and stream its position on the control channel —
     // the phone draws it locally on the ~2ms path the touches use.
-    // Escape hatch: `defaults write sh.peet.opensidecar.mac localCursor -bool false`.
+    // Escape hatch: `defaults write com.peetzweg.opensidecar.mac localCursor -bool false`.
     private let localCursor = UserDefaults.standard.object(forKey: "localCursor") == nil
         || UserDefaults.standard.bool(forKey: "localCursor")
     private var cursorTimer: DispatchSourceTimer?
@@ -396,7 +396,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         let captureH = (Int(Double(pointsHigh * 2) * quality.scale)) & ~1
         try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
 
-        // Debug aid (`defaults write sh.peet.opensidecar.mac testPattern -bool true`):
+        // Debug aid (`defaults write com.peetzweg.opensidecar.mac testPattern -bool true`):
         // an animated window on the virtual display generates a constant frame
         // stream so steady-state latency can be measured without user activity.
         if UserDefaults.standard.bool(forKey: "testPattern") {

--- a/Mac/TestPatternWindow.swift
+++ b/Mac/TestPatternWindow.swift
@@ -4,7 +4,7 @@ import AppKit
 /// Debug aid: a full-screen animated window on the virtual display so the
 /// pipeline streams continuously — without it, ScreenCaptureKit emits nothing
 /// while the screen is static and steady-state latency can't be measured.
-/// Enable with `defaults write sh.peet.opensidecar.mac testPattern -bool true`.
+/// Enable with `defaults write com.peetzweg.opensidecar.mac testPattern -bool true`.
 @MainActor
 enum TestPattern {
     // One window per virtual display — multi-device sessions each get their


### PR DESCRIPTION
Fixes the `defaults write` commands cited in comments: they say `sh.peet.opensidecar.mac`, but the actual bundle id (and therefore the `UserDefaults` domain) is `com.peetzweg.opensidecar.mac`, so copy-pasting them silently does nothing.

**Why:** These are the documented knobs for the localCursor escape hatch and the testPattern debug aid; a wrong domain sends whoever uses them down a "the setting has no effect" rabbit hole. Came up while writing the workaround instructions on #133/#160.

**How:** Comment-only substitution in the three places the stale domain appears (`MacSender.swift` x2, `TestPatternWindow.swift`). Note for debug builds the domain gains a `.debug` suffix per project.yml.

Swept the rest of the repo for similar stale identifiers: the only other candidates are the iOS log filename `opensidecar-phone.log` and its NSLog tag, which are functional values rather than docs, so they are left alone.
