### PR TITLE
fix: Prevent Mac & iOS device displays from diverging due to dropped frames

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -255,6 +255,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // keyframe on — so keep the last frame around and re-encode it.
     private var lastPixelBuffer: CVPixelBuffer?
     private var lastCaptureAt = Date.distantPast
+    /// Debounced replay after encoder/send backpressure drops a frame.
+    /// At most one timer is active; each new drop resets the 30ms deadline.
+    private var dropReplayTimer: DispatchSourceTimer?
 
     init(transport: SenderTransport, name: String, mode: CaptureMode,
          quality: StreamQuality = .best, displaySerial: UInt32 = 0x0001,
@@ -562,6 +565,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         if let encoder { VTCompressionSessionInvalidate(encoder) }
         encoder = nil
         virtualDisplay = nil   // releasing it removes the display
+        cancelDropReplayTimer()
         queue.async { [weak self] in
             // Unblock a start() that is still waiting for the hello.
             self?.helloContinuation?.resume(throwing: CancellationError())
@@ -733,6 +737,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         consecutiveRefusals = 0
         disconnectedSince = nil
         needsKeyframe = true   // new peer needs SPS/PPS + IDR
+        // Drop any cached pixels from before this connection — otherwise a
+        // manual reconnect on a static virtual display replays the last
+        // captured frame (e.g. Chrome) even after the app was quit.
+        lastPixelBuffer = nil
+        cancelDropReplayTimer()
         // A reconnect can recreate the phone's video view with no cursor
         // sprite; the sprite is otherwise only sent on shape change, so the
         // cursor would stay invisible until the user hovers something that
@@ -1287,6 +1296,41 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         encode(pixelBuffer, pts: CMSampleBufferGetPresentationTimeStamp(sampleBuffer), generation: generation)
     }
 
+    private func isPipelineBackedUp() -> Bool {
+        pipelineLock.lock()
+        defer { pipelineLock.unlock() }
+        return pendingEncodes >= maxPendingEncodes || pendingSends >= maxPendingSends
+    }
+
+    /// Schedule (or reset) a one-shot replay of `lastPixelBuffer` after drops.
+    private func scheduleDropReplayTimer() {
+        dropReplayTimer?.cancel()
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + .milliseconds(30))
+        timer.setEventHandler { [weak self] in
+            guard let self else { return }
+            self.dropReplayTimer = nil
+            self.replayLastFrameAfterDrop()
+        }
+        timer.resume()
+        dropReplayTimer = timer
+    }
+
+    private func cancelDropReplayTimer() {
+        dropReplayTimer?.cancel()
+        dropReplayTimer = nil
+    }
+
+    /// Re-encode the most recent pixel buffer once backpressure clears.
+    private func replayLastFrameAfterDrop() {
+        guard !stopped, connectionReady, let pixelBuffer = lastPixelBuffer else { return }
+        if isPipelineBackedUp() {
+            scheduleDropReplayTimer()
+            return
+        }
+        encode(pixelBuffer, pts: CMClockGetTime(CMClockGetHostTimeClock()))
+    }
+
     /// Drop when encode or send pipeline is busy.
     /// Pre-encode drops are invisible to the decoder — the H.264 reference
     /// chain stays intact, so the next frame can be a normal P-frame (n → n+2).
@@ -1304,6 +1348,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         }
         pipelineLock.unlock()
         guard drop else { return false }
+        scheduleDropReplayTimer()
         switch reason {
         case "pending_encode":
             dropsEncThisWindow += 1
@@ -1551,6 +1596,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 Log.info("send error: \(error)")
                 return
             }
+            self.cancelDropReplayTimer()
             self.framesSent += 1
             self.bytesSent += frame.count
             // Report stats roughly once a second.

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -1407,7 +1407,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 self.sendFramed(framed)
             }
         }
-        if submitStatus != noErr {
+        if submitStatus == noErr {
+            // Encode submission commits this frame to the pipeline; stale in-flight
+            // encodes started before a drop won't reach here again, so cancel replay.
+            cancelDropReplayTimer()
+        } else {
             pipelineLock.lock()
             pendingEncodes = max(0, pendingEncodes - 1)
             // A dead encoder session keeps failing, and this runs per frame, so
@@ -1596,7 +1600,6 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 Log.info("send error: \(error)")
                 return
             }
-            self.cancelDropReplayTimer()
             self.framesSent += 1
             self.bytesSent += frame.count
             // Report stats roughly once a second.

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -737,10 +737,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         consecutiveRefusals = 0
         disconnectedSince = nil
         needsKeyframe = true   // new peer needs SPS/PPS + IDR
-        // Drop any cached pixels from before this connection — otherwise a
-        // manual reconnect on a static virtual display replays the last
-        // captured frame (e.g. Chrome) even after the app was quit.
-        lastPixelBuffer = nil
+        // Keep cached pixels: ScreenCaptureKit stays quiet on a static
+        // display, and the watchdog needs them to force the reconnect IDR.
         cancelDropReplayTimer()
         // A reconnect can recreate the phone's video view with no cursor
         // sprite; the sprite is otherwise only sent on shape change, so the
@@ -1328,7 +1326,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             scheduleDropReplayTimer()
             return
         }
-        encode(pixelBuffer, pts: CMClockGetTime(CMClockGetHostTimeClock()))
+        encode(pixelBuffer, pts: CMClockGetTime(CMClockGetHostTimeClock()),
+               generation: captureGenerationNow)
     }
 
     /// Drop when encode or send pipeline is busy.


### PR DESCRIPTION
There's a specific series of event that can happen which can cause the mirror device to display something different than the Mac display does indefinitely.

1. Mac encodes a burst of frames, then skips encoding many of them due to backpressure on encoding or sending
2. iPad receives the the ones before we started skipping

Normally this isn't problem, because as soon as something causes the Mac to encode a new frame, it will send that update to the iPad and things look correct

The problem is if we dropped the *last* frame and then the Mac virtual display stops changing. In this case, nothing causes another encode, and the iPad is permanently stuck (at least until something changes on the mac virtual display).

The fix for it is to ensure that, whenever we drop a frame, that we encode at least one more frame after that dropped frame.

The way I did that in this PR was to use a timer. This works fine. There's probably a more elegant solution which doesn't rely on a timer and notices when backpressure has fallen and then re-transmits the last pixel buffer then. Let me know if you'd rather go with that approach. 