### PR TITLE
fix(mac): preserve virtual displays across rotation

### DIFF
--- a/Mac/DisplayArrangement.swift
+++ b/Mac/DisplayArrangement.swift
@@ -4,13 +4,13 @@ import Foundation
 /// Remembers where the user placed each device's virtual display (#116).
 ///
 /// macOS does persist display arrangement, but keys it on the monitor
-/// identity (vendor/product/serial) — and ours legitimately changes: each
-/// orientation uses a distinct serial (saved-mode separation, see
-/// setupExtend), and the serial also derives from the session id, so USB
-/// and WiFi produce different identities for the same iPad. Every such
-/// change makes macOS treat the display as a brand-new monitor and park it
-/// at the default position. Keying saved origins on the device's install id
-/// makes the arrangement follow the physical device instead.
+/// identity (vendor/product/serial) — and ours legitimately changes: the
+/// serial derives from the session id, so USB and WiFi produce different
+/// identities for the same iPad, and a display that has to be rebuilt comes
+/// back as a fresh monitor. Every such change makes macOS treat the display
+/// as brand new and park it at the default position. Keying saved origins on
+/// the device's install id makes the arrangement follow the physical device
+/// instead.
 enum DisplayArrangement {
 
     /// Record the origin (global desktop points) the display settled at.
@@ -31,10 +31,11 @@ enum DisplayArrangement {
 
     /// Where a new display of `size` points should go: the saved spot
     /// verbatim when the size matches. On rotation, keep the device on the
-    /// same side of the built-in display and retain its cross-axis offset. A
-    /// center-preserving remap puts a rotated display half the aspect-ratio
-    /// difference into a gap or overlap; WindowServer then snaps it, and the
-    /// snap becomes the next saved position (#203).
+    /// same side of the built-in display and as close to its cross-axis
+    /// position as still shares an edge with it. A center-preserving remap
+    /// puts a rotated display half the aspect-ratio difference into a gap or
+    /// overlap; WindowServer then snaps it, and the snap becomes the next
+    /// saved position (#203).
     ///
     /// Nil on first contact — let macOS choose.
     static func origin(for size: CGSize, device: String) -> CGPoint? {
@@ -68,14 +69,18 @@ enum DisplayArrangement {
     /// Pure geometry seam for side-preserving arrangement tests.
     static func origin(for size: CGSize, from saved: CGRect, side: Side, relativeTo main: CGRect) -> CGPoint {
         switch side {
-        case .left:
-            return CGPoint(x: main.minX - size.width, y: saved.minY)
-        case .right:
-            return CGPoint(x: main.maxX, y: saved.minY)
-        case .above:
-            return CGPoint(x: saved.minX, y: main.minY - size.height)
-        case .below:
-            return CGPoint(x: saved.minX, y: main.maxY)
+        case .left, .right:
+            let y = crossAxisPosition(
+                saved: saved.minY, length: size.height,
+                against: main.minY...main.maxY,
+                keeping: sharedLength(of: saved.minY...saved.maxY, and: main.minY...main.maxY))
+            return CGPoint(x: side == .left ? main.minX - size.width : main.maxX, y: y)
+        case .above, .below:
+            let x = crossAxisPosition(
+                saved: saved.minX, length: size.width,
+                against: main.minX...main.maxX,
+                keeping: sharedLength(of: saved.minX...saved.maxX, and: main.minX...main.maxX))
+            return CGPoint(x: x, y: side == .above ? main.minY - size.height : main.maxY)
         }
     }
 
@@ -87,19 +92,20 @@ enum DisplayArrangement {
         guard saved.size != size else { return saved.origin }
 
         if let attachment = attachment(of: saved, to: displays) {
+            let neighbour = attachment.display
             switch attachment.side {
-            case .left:
-                return CGPoint(x: attachment.display.minX - size.width,
-                               y: attachment.display.minY + attachment.crossAxisOffset)
-            case .right:
-                return CGPoint(x: attachment.display.maxX,
-                               y: attachment.display.minY + attachment.crossAxisOffset)
-            case .above:
-                return CGPoint(x: attachment.display.minX + attachment.crossAxisOffset,
-                               y: attachment.display.minY - size.height)
-            case .below:
-                return CGPoint(x: attachment.display.minX + attachment.crossAxisOffset,
-                               y: attachment.display.maxY)
+            case .left, .right:
+                let y = crossAxisPosition(saved: saved.minY, length: size.height,
+                                          against: neighbour.minY...neighbour.maxY,
+                                          keeping: attachment.overlap)
+                return CGPoint(x: attachment.side == .left ? neighbour.minX - size.width : neighbour.maxX,
+                               y: y)
+            case .above, .below:
+                let x = crossAxisPosition(saved: saved.minX, length: size.width,
+                                          against: neighbour.minX...neighbour.maxX,
+                                          keeping: attachment.overlap)
+                return CGPoint(x: x,
+                               y: attachment.side == .above ? neighbour.minY - size.height : neighbour.maxY)
             }
         }
 
@@ -138,10 +144,27 @@ enum DisplayArrangement {
         side(of: rect, relativeTo: main, preferring: nil)
     }
 
+    /// Where the rotated display sits along the edge it shares with its
+    /// neighbour: as close to `saved` as it can while still overlapping that
+    /// edge by as much as it did before. Carrying the old offset over verbatim
+    /// is what put a shorter rotated display past the end of the shared edge —
+    /// a disconnected arrangement WindowServer snaps, and the snap is what
+    /// gets saved (#203). `overlap` may legitimately be 0: a corner
+    /// attachment stays a corner attachment.
+    private static func crossAxisPosition(saved: CGFloat, length: CGFloat,
+                                          against neighbour: ClosedRange<CGFloat>,
+                                          keeping overlap: CGFloat) -> CGFloat {
+        let neighbourLength = neighbour.upperBound - neighbour.lowerBound
+        let required = min(overlap, min(length, neighbourLength))
+        let lowest = neighbour.lowerBound - length + required
+        let highest = neighbour.upperBound - required
+        guard lowest <= highest else { return saved }
+        return min(max(saved, lowest), highest)
+    }
+
     private struct Attachment {
         let side: Side
         let display: CGRect
-        let crossAxisOffset: CGFloat
         let overlap: CGFloat
     }
 
@@ -150,27 +173,19 @@ enum DisplayArrangement {
             var attachments: [Attachment] = []
             if saved.maxX == display.minX,
                let overlap = overlap(of: saved.minY...saved.maxY, and: display.minY...display.maxY) {
-                attachments.append(Attachment(side: .left, display: display,
-                                              crossAxisOffset: saved.minY - display.minY,
-                                              overlap: overlap))
+                attachments.append(Attachment(side: .left, display: display, overlap: overlap))
             }
             if saved.minX == display.maxX,
                let overlap = overlap(of: saved.minY...saved.maxY, and: display.minY...display.maxY) {
-                attachments.append(Attachment(side: .right, display: display,
-                                              crossAxisOffset: saved.minY - display.minY,
-                                              overlap: overlap))
+                attachments.append(Attachment(side: .right, display: display, overlap: overlap))
             }
             if saved.maxY == display.minY,
                let overlap = overlap(of: saved.minX...saved.maxX, and: display.minX...display.maxX) {
-                attachments.append(Attachment(side: .above, display: display,
-                                              crossAxisOffset: saved.minX - display.minX,
-                                              overlap: overlap))
+                attachments.append(Attachment(side: .above, display: display, overlap: overlap))
             }
             if saved.minY == display.maxY,
                let overlap = overlap(of: saved.minX...saved.maxX, and: display.minX...display.maxX) {
-                attachments.append(Attachment(side: .below, display: display,
-                                              crossAxisOffset: saved.minX - display.minX,
-                                              overlap: overlap))
+                attachments.append(Attachment(side: .below, display: display, overlap: overlap))
             }
             return attachments
         }
@@ -189,6 +204,10 @@ enum DisplayArrangement {
         // WindowServer permits a desktop to be connected at a single corner.
         // That still gives us a valid attachment side to preserve on rotation.
         return amount >= 0 ? amount : nil
+    }
+
+    private static func sharedLength(of first: ClosedRange<CGFloat>, and second: ClosedRange<CGFloat>) -> CGFloat {
+        overlap(of: first, and: second) ?? 0
     }
 
     private static func activeDisplayBounds() -> [CGRect] {

--- a/Mac/DisplayArrangement.swift
+++ b/Mac/DisplayArrangement.swift
@@ -20,22 +20,183 @@ enum DisplayArrangement {
     /// old position reads as broken; deliberate split positions are a
     /// possible opt-in, see #128).
     static func save(origin: CGPoint, size: CGSize, device: String) {
-        UserDefaults.standard.set([Int(origin.x), Int(origin.y), Int(size.width), Int(size.height)],
-                                  forKey: key(device))
+        let rect = CGRect(origin: origin, size: size)
+        let previousSide = load(device)?.side
+        let main = CGDisplayBounds(CGMainDisplayID())
+        let side = side(of: rect, relativeTo: main, preferring: previousSide)
+        var record = [Int(origin.x), Int(origin.y), Int(size.width), Int(size.height)]
+        if let side { record.append(side.rawValue) }
+        UserDefaults.standard.set(record, forKey: key(device))
     }
 
-    /// Where a new display of `size` points should go: the saved spot —
-    /// verbatim when the size matches, else mapped to keep the display's
-    /// center (WindowServer then snaps that to the nearest valid adjacent
-    /// arrangement, so a rotated display stays on the same side of the
-    /// desktop). Nil on first contact — let macOS choose.
+    /// Where a new display of `size` points should go: the saved spot
+    /// verbatim when the size matches. On rotation, keep the device on the
+    /// same side of the built-in display and retain its cross-axis offset. A
+    /// center-preserving remap puts a rotated display half the aspect-ratio
+    /// difference into a gap or overlap; WindowServer then snaps it, and the
+    /// snap becomes the next saved position (#203).
+    ///
+    /// Nil on first contact — let macOS choose.
     static func origin(for size: CGSize, device: String) -> CGPoint? {
-        guard let v = UserDefaults.standard.array(forKey: key(device)) as? [Int],
-              v.count == 4 else { return nil }
-        let saved = CGRect(x: CGFloat(v[0]), y: CGFloat(v[1]),
-                           width: CGFloat(v[2]), height: CGFloat(v[3]))
-        if saved.size == size { return saved.origin }
-        return CGPoint(x: saved.midX - size.width / 2, y: saved.midY - size.height / 2)
+        guard let placement = load(device) else { return nil }
+        if placement.rect.size == size { return placement.rect.origin }
+        let main = CGDisplayBounds(CGMainDisplayID())
+        // Records from before #203 did not store a side. If one already
+        // touches the main display, infer it now so an otherwise clean
+        // existing arrangement also gains the stable behavior on rotation.
+        if let side = placement.side ?? side(of: placement.rect, relativeTo: main, preferring: nil) {
+            return origin(for: size, from: placement.rect, side: side,
+                          relativeTo: main)
+        }
+        return remappedOrigin(from: placement.rect, to: size, against: activeDisplayBounds())
+    }
+
+    /// The user-visible slot a virtual display occupies relative to the main
+    /// desktop. This survives the virtual display being destroyed and rebuilt
+    /// on every device rotation.
+    enum Side: Int {
+        case left, right, above, below
+
+        var priority: Int {
+            switch self {
+            case .left, .right: return 1
+            case .above, .below: return 0
+            }
+        }
+    }
+
+    /// Pure geometry seam for side-preserving arrangement tests.
+    static func origin(for size: CGSize, from saved: CGRect, side: Side, relativeTo main: CGRect) -> CGPoint {
+        switch side {
+        case .left:
+            return CGPoint(x: main.minX - size.width, y: saved.minY)
+        case .right:
+            return CGPoint(x: main.maxX, y: saved.minY)
+        case .above:
+            return CGPoint(x: saved.minX, y: main.minY - size.height)
+        case .below:
+            return CGPoint(x: saved.minX, y: main.maxY)
+        }
+    }
+
+    /// Pure geometry seam for arrangement regression tests. `displays` are
+    /// the displays already on the desktop; the rebuilt virtual display is
+    /// deliberately not present yet.
+    static func remappedOrigin(from saved: CGRect, to size: CGSize,
+                               against displays: [CGRect]) -> CGPoint {
+        guard saved.size != size else { return saved.origin }
+
+        if let attachment = attachment(of: saved, to: displays) {
+            switch attachment.side {
+            case .left:
+                return CGPoint(x: attachment.display.minX - size.width,
+                               y: attachment.display.minY + attachment.crossAxisOffset)
+            case .right:
+                return CGPoint(x: attachment.display.maxX,
+                               y: attachment.display.minY + attachment.crossAxisOffset)
+            case .above:
+                return CGPoint(x: attachment.display.minX + attachment.crossAxisOffset,
+                               y: attachment.display.minY - size.height)
+            case .below:
+                return CGPoint(x: attachment.display.minX + attachment.crossAxisOffset,
+                               y: attachment.display.maxY)
+            }
+        }
+
+        // A record written by an older version, or a layout whose neighbour
+        // disappeared, has no reliable attachment to preserve. Keep the old
+        // behaviour as a compatibility fallback rather than guessing a side.
+        return CGPoint(x: saved.midX - size.width / 2,
+                       y: saved.midY - size.height / 2)
+    }
+
+    private struct Placement {
+        let rect: CGRect
+        let side: Side?
+    }
+
+    private static func load(_ device: String) -> Placement? {
+        guard let record = UserDefaults.standard.array(forKey: key(device)) as? [Int],
+              record.count == 4 || record.count == 5 else { return nil }
+        let rect = CGRect(x: CGFloat(record[0]), y: CGFloat(record[1]),
+                          width: CGFloat(record[2]), height: CGFloat(record[3]))
+        return Placement(rect: rect, side: record.count == 5 ? Side(rawValue: record[4]) : nil)
+    }
+
+    private static func side(of rect: CGRect, relativeTo main: CGRect,
+                             preferring preferred: Side?) -> Side? {
+        var candidates: [Side] = []
+        if rect.maxX == main.minX { candidates.append(.left) }
+        if rect.minX == main.maxX { candidates.append(.right) }
+        if rect.maxY == main.minY { candidates.append(.above) }
+        if rect.minY == main.maxY { candidates.append(.below) }
+        if let preferred, candidates.contains(preferred) { return preferred }
+        return candidates.max { $0.priority < $1.priority }
+    }
+
+    static func inferredMainDisplaySide(of rect: CGRect, relativeTo main: CGRect) -> Side? {
+        side(of: rect, relativeTo: main, preferring: nil)
+    }
+
+    private struct Attachment {
+        let side: Side
+        let display: CGRect
+        let crossAxisOffset: CGFloat
+        let overlap: CGFloat
+    }
+
+    private static func attachment(of saved: CGRect, to displays: [CGRect]) -> Attachment? {
+        let candidates = displays.flatMap { display -> [Attachment] in
+            var attachments: [Attachment] = []
+            if saved.maxX == display.minX,
+               let overlap = overlap(of: saved.minY...saved.maxY, and: display.minY...display.maxY) {
+                attachments.append(Attachment(side: .left, display: display,
+                                              crossAxisOffset: saved.minY - display.minY,
+                                              overlap: overlap))
+            }
+            if saved.minX == display.maxX,
+               let overlap = overlap(of: saved.minY...saved.maxY, and: display.minY...display.maxY) {
+                attachments.append(Attachment(side: .right, display: display,
+                                              crossAxisOffset: saved.minY - display.minY,
+                                              overlap: overlap))
+            }
+            if saved.maxY == display.minY,
+               let overlap = overlap(of: saved.minX...saved.maxX, and: display.minX...display.maxX) {
+                attachments.append(Attachment(side: .above, display: display,
+                                              crossAxisOffset: saved.minX - display.minX,
+                                              overlap: overlap))
+            }
+            if saved.minY == display.maxY,
+               let overlap = overlap(of: saved.minX...saved.maxX, and: display.minX...display.maxX) {
+                attachments.append(Attachment(side: .below, display: display,
+                                              crossAxisOffset: saved.minX - display.minX,
+                                              overlap: overlap))
+            }
+            return attachments
+        }
+        return candidates.max {
+            if $0.overlap != $1.overlap { return $0.overlap < $1.overlap }
+            // At a corner, both a horizontal and vertical attachment are
+            // geometrically valid. Prefer the horizontal side: it preserves
+            // the display's relationship to the Mac's left/right desktop
+            // region and maximises continuity through a phone rotation.
+            return $0.side.priority < $1.side.priority
+        }
+    }
+
+    private static func overlap(of first: ClosedRange<CGFloat>, and second: ClosedRange<CGFloat>) -> CGFloat? {
+        let amount = min(first.upperBound, second.upperBound) - max(first.lowerBound, second.lowerBound)
+        // WindowServer permits a desktop to be connected at a single corner.
+        // That still gives us a valid attachment side to preserve on rotation.
+        return amount >= 0 ? amount : nil
+    }
+
+    private static func activeDisplayBounds() -> [CGRect] {
+        var count: UInt32 = 0
+        guard CGGetActiveDisplayList(0, nil, &count) == .success, count > 0 else { return [] }
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard CGGetActiveDisplayList(count, &ids, &count) == .success else { return [] }
+        return ids.prefix(Int(count)).map(CGDisplayBounds)
     }
 
     private static func key(_ device: String) -> String { "displayOrigin.\(device)" }

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -210,6 +210,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private var lastCursorSent: (x: Double, y: Double, visible: Bool) = (-1, -1, false)
     private var lastCursorPNGHash = 0
     private var captureDisplayID: CGDirectDisplayID = 0
+    // ScreenCaptureKit and VideoToolbox finish work asynchronously. During a
+    // rotation, an old capture callback or a late encoder completion must not
+    // put a frame from the retired display onto this device's new socket.
+    private var captureGeneration: UInt64 = 0
 
     // Input latency: touches arrive stamped in our clock (the phone applies
     // its sync offset); delta to now = network + deframe + dispatch.
@@ -340,13 +344,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         let displayName = endpointName.hasPrefix("iPhone / iPad")
             ? "OpenDisplay — \(info.kind)"
             : "OpenDisplay — \(endpointName)"
-        // Orientation-specific serial: macOS persists the chosen mode per
-        // serial, and a portrait mode restored onto a landscape display
-        // pillarboxes the desktop INTO the framebuffer (streamed as-is).
-        // Distinct serials per orientation keep the two configs apart.
-        let serial = info.pixelsWide >= info.pixelsHigh
-            ? displaySerial
-            : displaySerial ^ 0x8000_0000
+        // Keep one stable identity across rotations. Reconfiguration below
+        // applies a new mode to the existing virtual monitor, so macOS keeps
+        // its windows and arrangement attached to this physical device.
+        let serial = displaySerial
         // Arrangement memory (#116): keyed on the device's install id so the
         // display returns to its spot across transports and orientations —
         // the serial-keyed memory macOS keeps starts from scratch whenever
@@ -368,15 +369,15 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             // `if stopped` checks in the permission-poll loops above.)
             if stopped { return }
             vd = await MainActor.run {
-                VirtualDisplay(name: displayName,
-                               pointsWide: pointsWide, pointsHigh: pointsHigh,
-                               sizeInMillimeters: mm, serialNum: serial,
-                               restoreOrigin: DisplayArrangement.origin(for: sizeInPoints,
-                                                                        device: arrangementKey),
-                               onOriginChange: { origin in
-                                   DisplayArrangement.save(origin: origin, size: sizeInPoints,
-                                                           device: arrangementKey)
-                               })
+                let restoreOrigin = DisplayArrangement.origin(for: sizeInPoints, device: arrangementKey)
+                return VirtualDisplay(name: displayName,
+                                      pointsWide: pointsWide, pointsHigh: pointsHigh,
+                                      sizeInMillimeters: mm, serialNum: serial,
+                                      restoreOrigin: restoreOrigin,
+                                      onOriginChange: { origin, currentSize in
+                                          DisplayArrangement.save(origin: origin, size: currentSize,
+                                                                  device: arrangementKey)
+                                      })
             }
             if vd != nil { break }
             Log.info("virtual display creation failed (attempt \(attempt + 1)) — retrying")
@@ -416,14 +417,25 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         var target = info
         while !stopped {
             Log.info("reconfiguring for \(target.pixelsWide)x\(target.pixelsHigh)")
+            // A cached frame is valid for a network reconnect to the same
+            // display, but never for a rotation: it belongs to the retired
+            // desktop and can otherwise be replayed onto the new one.
+            invalidateCapturePipeline(discardingLastFrame: true)
             if let stream { try? await stream.stopCapture() }
             stream = nil
             if let encoder { VTCompressionSessionInvalidate(encoder) }
             encoder = nil
-            virtualDisplay = nil   // removes the old display
             needsKeyframe = true
             do {
-                try await setupExtend(target)
+                if try await resizeExistingDisplay(for: target) {
+                    // The display identity survived, so WindowServer has no
+                    // reason to migrate this device's windows to a sibling.
+                } else {
+                    // Safety fallback for a system that refuses an in-place
+                    // mode switch. This keeps the old recovery behaviour.
+                    virtualDisplay = nil
+                    try await setupExtend(target)
+                }
             } catch {
                 Log.info("reconfigure failed: \(error)")
                 await status("Rotation failed: \(error.localizedDescription)")
@@ -438,11 +450,46 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         }
     }
 
+    /// Apply the rotated mode to the existing virtual monitor and restart
+    /// only the capture/encoder pieces that depend on pixel dimensions.
+    /// Returns false when there is no reusable display or macOS rejected the
+    /// mode switch, letting the caller use the legacy rebuild fallback.
+    private func resizeExistingDisplay(for info: PhoneInfo) async throws -> Bool {
+        guard let vd = virtualDisplay else { return false }
+
+        let pointsWide = (info.pixelsWide / 2) & ~1
+        let pointsHigh = (info.pixelsHigh / 2) & ~1
+        let arrangementKey = info.id ?? String(format: "serial-%08x", displaySerial)
+        let size = CGSize(width: pointsWide, height: pointsHigh)
+        let didResize = await MainActor.run {
+            vd.resize(pointsWide: pointsWide, pointsHigh: pointsHigh,
+                      movingTo: DisplayArrangement.origin(for: size, device: arrangementKey))
+        }
+        guard didResize else { return false }
+
+        let display = try await findSCDisplay(id: vd.displayID, expectedSize: size)
+        let captureW = (Int(Double(pointsWide * 2) * quality.scale)) & ~1
+        let captureH = (Int(Double(pointsHigh * 2) * quality.scale)) & ~1
+        try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
+        inputInjector = InputInjector(displayID: vd.displayID)
+
+        if UserDefaults.standard.bool(forKey: "testPattern") {
+            let id = vd.displayID
+            Task { @MainActor in TestPattern.show(on: id) }
+        }
+        return true
+    }
+
     /// The virtual display takes a moment to show up in shareable content.
-    private func findSCDisplay(id: CGDirectDisplayID) async throws -> SCDisplay {
+    private func findSCDisplay(id: CGDirectDisplayID, expectedSize: CGSize? = nil) async throws -> SCDisplay {
         for _ in 0..<20 {
             let content = try await SCShareableContent.current
-            if let display = content.displays.first(where: { $0.displayID == id }) {
+            if let display = content.displays.first(where: {
+                $0.displayID == id
+                    && (expectedSize == nil
+                        || ($0.width == Int(expectedSize!.width)
+                            && $0.height == Int(expectedSize!.height)))
+            }) {
                 return display
             }
             try await Task.sleep(for: .milliseconds(250))
@@ -471,23 +518,31 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         config.queueDepth = 8
         config.showsCursor = !localCursor
 
+        invalidateCapturePipeline(discardingLastFrame: true)
+        let generation = captureGeneration
         try setupEncoder(width: pixelsWide, height: pixelsHigh)
 
         let stream = SCStream(filter: filter, configuration: config, delegate: self)
         try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: queue)
-        try await stream.startCapture()
         self.stream = stream
+        do {
+            try await stream.startCapture()
+        } catch {
+            if self.stream === stream { self.stream = nil }
+            throw error
+        }
         captureDisplayID = display.displayID
         lastCursorPNGHash = 0      // rotation rebuilds: re-send the sprite
         lastCursorSent = (-1, -1, false)
         startCursorEcho()
-        Log.info("capture started: \(pixelsWide)x\(pixelsHigh) display \(display.displayID) mode \(mode.rawValue) localCursor=\(localCursor)")
+        Log.info("capture started: \(pixelsWide)x\(pixelsHigh) display \(display.displayID) generation \(generation) mode \(mode.rawValue) localCursor=\(localCursor)")
         let kind = lastHello?.kind ?? "device"
         await status("\(mode == .extend ? "Extending to" : "Mirroring to") \(kind) (\(pixelsWide)×\(pixelsHigh))")
     }
 
     func stop() {
         stopped = true
+        invalidateCapturePipeline(discardingLastFrame: true)
         cursorTimer?.cancel()
         cursorTimer = nil
         cursorImageTimer?.cancel()
@@ -585,11 +640,15 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     }
 
     func stream(_ stream: SCStream, didStopWithError error: Error) {
+        // A retired stream commonly reports its stop after the replacement is
+        // already live. It must not tear down that replacement (#203).
+        guard stream === self.stream else { return }
         Log.info("stream stopped with error: \(error)")
         Task { await status("Capture stopped: \(error.localizedDescription)") }
         // E.g. display sleep can tear the virtual display down underneath the
         // stream — rebuild instead of sitting dead until an app restart.
         guard !stopped, mode == .extend else { return }
+        invalidateCapturePipeline()
         self.stream = nil
         scheduleCaptureRecovery()
     }
@@ -867,9 +926,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             // the receiver would stay black — replay the last frame as IDR.
             if self.connectionReady, self.needsKeyframe,
                Date().timeIntervalSince(self.lastCaptureAt) > 1,
-               let pixelBuffer = self.lastPixelBuffer {
-                Log.info("static screen after reconnect — replaying last frame as keyframe")
-                self.encode(pixelBuffer, pts: CMClockGetTime(CMClockGetHostTimeClock()))
+                let pixelBuffer = self.lastPixelBuffer {
+                Log.info("static screen after reconnect to \(self.endpointName) — replaying last frame as keyframe")
+                self.encode(pixelBuffer, pts: CMClockGetTime(CMClockGetHostTimeClock()),
+                            generation: self.captureGeneration)
             }
             self.scheduleWatchdog()
         }
@@ -1199,10 +1259,13 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     func stream(_ stream: SCStream,
                 didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
                 of type: SCStreamOutputType) {
-        guard type == .screen,
+        guard stream === self.stream,
+              type == .screen,
               CMSampleBufferIsValid(sampleBuffer),
               let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
         else { return }
+
+        let generation = captureGeneration
 
         lastPixelBuffer = pixelBuffer
         lastCaptureAt = Date()
@@ -1213,7 +1276,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         if shouldDropFrame(reason: "pending_encode") { return }  // encoder busy
         if shouldDropFrame(reason: "pending_sends") { return }   // TCP send queue full
 
-        encode(pixelBuffer, pts: CMSampleBufferGetPresentationTimeStamp(sampleBuffer))
+        encode(pixelBuffer, pts: CMSampleBufferGetPresentationTimeStamp(sampleBuffer), generation: generation)
     }
 
     /// Drop when encode or send pipeline is busy.
@@ -1246,8 +1309,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         return true
     }
 
-    private func encode(_ pixelBuffer: CVPixelBuffer, pts: CMTime) {
-        guard let encoder else { return }
+    private func encode(_ pixelBuffer: CVPixelBuffer, pts: CMTime, generation: UInt64) {
+        guard generation == captureGeneration, let encoder else { return }
         pipelineLock.lock()
         pendingEncodes += 1
         pipelineLock.unlock()
@@ -1283,6 +1346,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 self.handleEncodeOutputFailureLogAction(logAction)
                 return
             }
+            guard generation == self.captureGeneration else { return }
             if let data = self.annexB(from: buffer) {
                 let sndMs = Int64(Date().timeIntervalSince1970 * 1000)
                 var framed = Data("{\"cap\":\(capturedAtMs),\"snd\":\(sndMs)}".utf8)
@@ -1497,5 +1561,16 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     private func status(_ text: String) async {
         await MainActor.run { onStatus?(text) }
+    }
+
+    /// Invalidate the retired ScreenCaptureKit/VideoToolbox callbacks before
+    /// changing the display or encoder they feed.
+    private func invalidateCapturePipeline(discardingLastFrame: Bool = false) {
+        captureGeneration &+= 1
+        captureDisplayID = 0
+        if discardingLastFrame {
+            lastPixelBuffer = nil
+            lastCaptureAt = .distantPast
+        }
     }
 }

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -213,7 +213,15 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // ScreenCaptureKit and VideoToolbox finish work asynchronously. During a
     // rotation, an old capture callback or a late encoder completion must not
     // put a frame from the retired display onto this device's new socket.
+    // Bumped on `queue` but read from the SCK sample queue and the VideoToolbox
+    // callback queue, so it lives under `pipelineLock` like the other counters
+    // those callbacks touch — read it via `captureGenerationNow`.
     private var captureGeneration: UInt64 = 0
+    private var captureGenerationNow: UInt64 {
+        pipelineLock.lock()
+        defer { pipelineLock.unlock() }
+        return captureGeneration
+    }
 
     // Input latency: touches arrive stamped in our clock (the phone applies
     // its sync offset); delta to now = network + deframe + dispatch.
@@ -519,7 +527,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         config.showsCursor = !localCursor
 
         invalidateCapturePipeline(discardingLastFrame: true)
-        let generation = captureGeneration
+        let generation = captureGenerationNow
         try setupEncoder(width: pixelsWide, height: pixelsHigh)
 
         let stream = SCStream(filter: filter, configuration: config, delegate: self)
@@ -929,7 +937,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 let pixelBuffer = self.lastPixelBuffer {
                 Log.info("static screen after reconnect to \(self.endpointName) — replaying last frame as keyframe")
                 self.encode(pixelBuffer, pts: CMClockGetTime(CMClockGetHostTimeClock()),
-                            generation: self.captureGeneration)
+                            generation: self.captureGenerationNow)
             }
             self.scheduleWatchdog()
         }
@@ -1265,7 +1273,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
               let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
         else { return }
 
-        let generation = captureGeneration
+        let generation = captureGenerationNow
 
         lastPixelBuffer = pixelBuffer
         lastCaptureAt = Date()
@@ -1310,7 +1318,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     }
 
     private func encode(_ pixelBuffer: CVPixelBuffer, pts: CMTime, generation: UInt64) {
-        guard generation == captureGeneration, let encoder else { return }
+        guard generation == captureGenerationNow, let encoder else { return }
         pipelineLock.lock()
         pendingEncodes += 1
         pipelineLock.unlock()
@@ -1346,7 +1354,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 self.handleEncodeOutputFailureLogAction(logAction)
                 return
             }
-            guard generation == self.captureGeneration else { return }
+            guard generation == self.captureGenerationNow else { return }
             if let data = self.annexB(from: buffer) {
                 let sndMs = Int64(Date().timeIntervalSince1970 * 1000)
                 var framed = Data("{\"cap\":\(capturedAtMs),\"snd\":\(sndMs)}".utf8)
@@ -1566,7 +1574,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     /// Invalidate the retired ScreenCaptureKit/VideoToolbox callbacks before
     /// changing the display or encoder they feed.
     private func invalidateCapturePipeline(discardingLastFrame: Bool = false) {
+        pipelineLock.lock()
         captureGeneration &+= 1
+        pipelineLock.unlock()
         captureDisplayID = 0
         if discardingLastFrame {
             lastPixelBuffer = nil

--- a/Mac/Usbmux.swift
+++ b/Mac/Usbmux.swift
@@ -222,7 +222,31 @@ final class UsbmuxDeviceWatcher {
 
     init(onChange: @escaping ([UsbmuxDevice]) -> Void) {
         self.onChange = onChange
-        Task { await listenLoop() }
+        Task {
+            // `Listen` only reports changes after its subscription begins.
+            // Seed the watcher from usbmuxd's current inventory as well, so
+            // devices already plugged in when the Mac app launches are not
+            // silently omitted until they are physically reattached.
+            await loadInitiallyAttachedDevices()
+            await listenLoop()
+        }
+    }
+
+    private func loadInitiallyAttachedDevices() async {
+        do {
+            let attached = try await Usbmux.listDevices(queue: queue)
+            guard !attached.isEmpty else { return }
+            for device in attached {
+                devices[device.deviceID] = device
+                Log.info("usbmux initial device: \(device.udid)")
+                resolveName(deviceID: device.deviceID)
+            }
+            publish()
+        } catch {
+            // The long-lived listener retries independently. A failed seed
+            // must not prevent it from observing later attach events.
+            Log.info("usbmux initial device scan: \(error)")
+        }
     }
 
     private func listenLoop() async {

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -7,14 +7,15 @@ import CoreGraphics
 final class VirtualDisplay {
 
     private let display: CGVirtualDisplay
-    private let settings: CGVirtualDisplaySettings
-    let pointsWide: Int
-    let pointsHigh: Int
+    private var settings: CGVirtualDisplaySettings
+    private let maxPointsPerAxis: Int
+    private(set) var pointsWide: Int
+    private(set) var pointsHigh: Int
 
     private var restoreTarget: CGPoint?
     private let restoreUntil: Date
     private var lastReportedOrigin: CGPoint?
-    private let onOriginChange: ((CGPoint) -> Void)?
+    private let onOriginChange: ((CGPoint, CGSize) -> Void)?
 
     var displayID: CGDirectDisplayID { display.displayID }
 
@@ -27,9 +28,13 @@ final class VirtualDisplay {
     /// caller can persist user drags.
     init?(name: String, pointsWide: Int, pointsHigh: Int, sizeInMillimeters: CGSize,
           serialNum: UInt32 = 0x0001, restoreOrigin: CGPoint? = nil,
-          onOriginChange: ((CGPoint) -> Void)? = nil) {
+          onOriginChange: ((CGPoint, CGSize) -> Void)? = nil) {
         self.pointsWide = pointsWide
         self.pointsHigh = pointsHigh
+        // Reserve the longer orientation on both axes. That lets a phone or
+        // tablet change orientation by applying a new mode to this *same*
+        // virtual monitor instead of removing it and stranding its windows.
+        maxPointsPerAxis = max(pointsWide, pointsHigh)
         self.restoreTarget = restoreOrigin
         self.restoreUntil = restoreOrigin == nil ? .distantPast : Date().addingTimeInterval(6)
         self.onOriginChange = onOriginChange
@@ -37,8 +42,8 @@ final class VirtualDisplay {
         let descriptor = CGVirtualDisplayDescriptor()
         descriptor.setDispatchQueue(DispatchQueue.main)
         descriptor.name = name
-        descriptor.maxPixelsWide = UInt32(pointsWide * 2)
-        descriptor.maxPixelsHigh = UInt32(pointsHigh * 2)
+        descriptor.maxPixelsWide = UInt32(maxPointsPerAxis * 2)
+        descriptor.maxPixelsHigh = UInt32(maxPointsPerAxis * 2)
         descriptor.sizeInMillimeters = sizeInMillimeters
         descriptor.productID = 0x4F53   // "OS"
         descriptor.vendorID = 0x5043    // "PC"
@@ -83,6 +88,47 @@ final class VirtualDisplay {
         }
     }
 
+    /// Change orientation without changing the virtual monitor's identity.
+    /// Releasing a CGVirtualDisplay makes WindowServer redistribute every
+    /// window on it before the replacement appears; with multiple devices,
+    /// it may choose a sibling virtual display. Applying a new mode avoids
+    /// that reassignment entirely.
+    ///
+    /// Must be called on the main thread.
+    @discardableResult
+    func resize(pointsWide: Int, pointsHigh: Int, movingTo origin: CGPoint?) -> Bool {
+        guard pointsWide <= maxPointsPerAxis, pointsHigh <= maxPointsPerAxis else {
+            Log.info("virtual display \(display.displayID) cannot resize beyond its descriptor")
+            return false
+        }
+
+        let newSettings = CGVirtualDisplaySettings()
+        newSettings.hiDPI = 1
+        newSettings.modes = [
+            CGVirtualDisplayMode(width: UInt(pointsWide), height: UInt(pointsHigh), refreshRate: 60)
+        ]
+        guard display.apply(newSettings) else {
+            Log.info("virtual display \(display.displayID) applySettings FAILED during resize")
+            return false
+        }
+        settings = newSettings
+        self.pointsWide = pointsWide
+        self.pointsHigh = pointsHigh
+
+        if let origin {
+            var config: CGDisplayConfigRef?
+            if CGBeginDisplayConfiguration(&config) == .success {
+                CGConfigureDisplayOrigin(config, display.displayID, Int32(origin.x), Int32(origin.y))
+                let err = CGCompleteDisplayConfiguration(config, .permanently)
+                Log.info("virtual display \(display.displayID) resized to \(pointsWide)x\(pointsHigh)pt "
+                    + "at (\(Int(origin.x)),\(Int(origin.y))) (result \(err.rawValue))")
+            }
+        } else {
+            Log.info("virtual display \(display.displayID) resized to \(pointsWide)x\(pointsHigh)pt")
+        }
+        return true
+    }
+
     /// Returns true when the display is (now) in its HiDPI mode. Silent when
     /// nothing needed doing — this runs every 2s as enforcement. With
     /// `recover`, a missing @2x mode (macOS can replace the whole mode list
@@ -124,7 +170,13 @@ final class VirtualDisplay {
         let id = display.displayID
         let origin = CGDisplayBounds(id).origin
         if let target = restoreTarget, Date() < restoreUntil {
-            guard origin != target else { return }
+            // Initial arrangement is system state, not a user drag. Mark it
+            // observed so it cannot overwrite the saved device placement
+            // when the restore window expires (#203).
+            guard origin != target else {
+                lastReportedOrigin = origin
+                return
+            }
             var config: CGDisplayConfigRef?
             guard CGBeginDisplayConfiguration(&config) == .success else { return }
             CGConfigureDisplayOrigin(config, id, Int32(target.x), Int32(target.y))
@@ -133,6 +185,9 @@ final class VirtualDisplay {
             // arrangement — adopt what it settled on, or every remaining
             // tick of the window would re-apply against the snap.
             restoreTarget = CGDisplayBounds(id).origin
+            // A snap is also system state. Keep observing from the settled
+            // point, but only a later origin change may be a user drag.
+            lastReportedOrigin = restoreTarget
             Log.info("display \(id) origin (\(Int(origin.x)),\(Int(origin.y))) → restored "
                 + "(\(Int(target.x)),\(Int(target.y))), settled "
                 + "(\(Int(restoreTarget!.x)),\(Int(restoreTarget!.y))) (result \(err.rawValue))")
@@ -140,7 +195,7 @@ final class VirtualDisplay {
         }
         if origin != lastReportedOrigin {
             lastReportedOrigin = origin
-            onOriginChange?(origin)
+            onOriginChange?(origin, CGSize(width: pointsWide, height: pointsHigh))
         }
     }
 

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -13,7 +13,7 @@ final class VirtualDisplay {
     private(set) var pointsHigh: Int
 
     private var restoreTarget: CGPoint?
-    private let restoreUntil: Date
+    private var restoreUntil: Date
     private var lastReportedOrigin: CGPoint?
     private let onOriginChange: ((CGPoint, CGSize) -> Void)?
 
@@ -120,8 +120,19 @@ final class VirtualDisplay {
             if CGBeginDisplayConfiguration(&config) == .success {
                 CGConfigureDisplayOrigin(config, display.displayID, Int32(origin.x), Int32(origin.y))
                 let err = CGCompleteDisplayConfiguration(config, .permanently)
+                // A mode change is a display reconfiguration, so macOS may
+                // restore ITS arrangement for this identity a moment later,
+                // exactly as it does after creation. Re-arm the same window so
+                // that gets overridden, and adopt whatever WindowServer settled
+                // on: a snap is system state, and persisting it as if it were a
+                // user drag is the ratchet #203 is about.
+                let settled = CGDisplayBounds(display.displayID).origin
+                restoreTarget = settled
+                restoreUntil = Date().addingTimeInterval(6)
+                lastReportedOrigin = settled
                 Log.info("virtual display \(display.displayID) resized to \(pointsWide)x\(pointsHigh)pt "
-                    + "at (\(Int(origin.x)),\(Int(origin.y))) (result \(err.rawValue))")
+                    + "at (\(Int(origin.x)),\(Int(origin.y))), settled "
+                    + "(\(Int(settled.x)),\(Int(settled.y))) (result \(err.rawValue))")
             }
         } else {
             Log.info("virtual display \(display.displayID) resized to \(pointsWide)x\(pointsHigh)pt")

--- a/MacTests/DisplayArrangementTests.swift
+++ b/MacTests/DisplayArrangementTests.swift
@@ -1,0 +1,92 @@
+import CoreGraphics
+import XCTest
+
+final class DisplayArrangementTests: XCTestCase {
+    private let main = CGRect(x: 0, y: 0, width: 1_512, height: 982)
+
+    func testRotationKeepsDisplayFlushLeftOfItsNeighbour() {
+        let saved = CGRect(x: -588, y: 0, width: 588, height: 1_278)
+
+        let target = DisplayArrangement.remappedOrigin(from: saved,
+                                                        to: CGSize(width: 1_278, height: 588),
+                                                        against: [main])
+
+        XCTAssertEqual(target, CGPoint(x: -1_278, y: 0))
+    }
+
+    func testRotationKeepsDisplayFlushRightOfItsNeighbour() {
+        let saved = CGRect(x: 1_512, y: -933, width: 588, height: 1_278)
+
+        let target = DisplayArrangement.remappedOrigin(from: saved,
+                                                        to: CGSize(width: 1_278, height: 588),
+                                                        against: [main])
+
+        XCTAssertEqual(target, CGPoint(x: 1_512, y: -933))
+    }
+
+    func testRotationKeepsDisplayFlushAboveAndBelowItsNeighbour() {
+        let above = CGRect(x: 200, y: -1_278, width: 588, height: 1_278)
+        let below = CGRect(x: 200, y: 982, width: 588, height: 1_278)
+        let landscape = CGSize(width: 1_278, height: 588)
+
+        XCTAssertEqual(DisplayArrangement.remappedOrigin(from: above, to: landscape, against: [main]),
+                       CGPoint(x: 200, y: -588))
+        XCTAssertEqual(DisplayArrangement.remappedOrigin(from: below, to: landscape, against: [main]),
+                       CGPoint(x: 200, y: 982))
+    }
+
+    func testRepeatedRotationDoesNotDriftTheSavedPlacement() {
+        let portraitSize = CGSize(width: 588, height: 1_278)
+        let landscapeSize = CGSize(width: 1_278, height: 588)
+        let portrait = CGRect(origin: CGPoint(x: -588, y: 0), size: portraitSize)
+
+        let landscapeOrigin = DisplayArrangement.remappedOrigin(from: portrait,
+                                                                 to: landscapeSize,
+                                                                 against: [main])
+        let landscape = CGRect(origin: landscapeOrigin, size: landscapeSize)
+        let restoredPortrait = DisplayArrangement.remappedOrigin(from: landscape,
+                                                                  to: portraitSize,
+                                                                  against: [main])
+
+        XCTAssertEqual(landscapeOrigin, CGPoint(x: -1_278, y: 0))
+        XCTAssertEqual(restoredPortrait, portrait.origin)
+    }
+
+    func testRotationKeepsTheSideWhenTheSavedDisplayTouchesAtOnlyACorner() {
+        // WindowServer allows this top-right corner attachment. It has no
+        // shared vertical edge, so a remap must not fall back to the old
+        // center calculation and request an illegal gap.
+        let saved = CGRect(x: 1_512, y: -588, width: 1_278, height: 588)
+
+        let target = DisplayArrangement.remappedOrigin(from: saved,
+                                                        to: CGSize(width: 588, height: 1_278),
+                                                        against: [main])
+
+        XCTAssertEqual(target, CGPoint(x: 1_512, y: -588))
+    }
+
+    func testSavedMainDisplaySideWinsOverOtherVirtualDisplayGeometry() {
+        let saved = CGRect(x: -588, y: 120, width: 588, height: 1_278)
+
+        let target = DisplayArrangement.origin(for: CGSize(width: 1_278, height: 588),
+                                               from: saved, side: .left, relativeTo: main)
+
+        XCTAssertEqual(target, CGPoint(x: -1_278, y: 120))
+    }
+
+    func testLegacyRecordTouchingMainDisplayCanAlsoKeepItsSide() {
+        let legacy = CGRect(x: 392, y: 982, width: 1_180, height: 820)
+
+        XCTAssertEqual(DisplayArrangement.inferredMainDisplaySide(of: legacy, relativeTo: main), .below)
+    }
+
+    func testRotationFallsBackToCenterWhenTheSavedNeighbourIsGone() {
+        let saved = CGRect(x: -588, y: 0, width: 588, height: 1_278)
+
+        let target = DisplayArrangement.remappedOrigin(from: saved,
+                                                        to: CGSize(width: 1_278, height: 588),
+                                                        against: [])
+
+        XCTAssertEqual(target, CGPoint(x: -933, y: 345))
+    }
+}

--- a/MacTests/DisplayArrangementTests.swift
+++ b/MacTests/DisplayArrangementTests.swift
@@ -15,13 +15,19 @@ final class DisplayArrangementTests: XCTestCase {
     }
 
     func testRotationKeepsDisplayFlushRightOfItsNeighbour() {
+        // The saved portrait hangs above the main display, overlapping it by
+        // only its bottom 345pt. Carrying y over verbatim would put the
+        // shorter landscape entirely above the main display — a disconnected
+        // arrangement WindowServer would snap. Slide it down just far enough
+        // to keep the 345pt of shared edge it had.
         let saved = CGRect(x: 1_512, y: -933, width: 588, height: 1_278)
 
         let target = DisplayArrangement.remappedOrigin(from: saved,
                                                         to: CGSize(width: 1_278, height: 588),
                                                         against: [main])
 
-        XCTAssertEqual(target, CGPoint(x: 1_512, y: -933))
+        XCTAssertEqual(target, CGPoint(x: 1_512, y: -243))
+        XCTAssertEqual(CGRect(origin: target, size: CGSize(width: 1_278, height: 588)).maxY - main.minY, 345)
     }
 
     func testRotationKeepsDisplayFlushAboveAndBelowItsNeighbour() {
@@ -72,6 +78,42 @@ final class DisplayArrangementTests: XCTestCase {
                                                from: saved, side: .left, relativeTo: main)
 
         XCTAssertEqual(target, CGPoint(x: -1_278, y: 120))
+    }
+
+    func testSavedSideStillYieldsAConnectedArrangementWhenTheDisplayShrinks() {
+        // Same shape as the remap case above, on the path that actually runs
+        // once a record carries its side: the rotated display must still share
+        // an edge with the main display rather than float off its top.
+        let saved = CGRect(x: 1_512, y: -933, width: 588, height: 1_278)
+        let size = CGSize(width: 1_278, height: 588)
+
+        let target = DisplayArrangement.origin(for: size, from: saved, side: .right, relativeTo: main)
+
+        XCTAssertEqual(target, CGPoint(x: 1_512, y: -243))
+        XCTAssertTrue(CGRect(origin: target, size: size).intersects(main.insetBy(dx: -1, dy: 0)))
+    }
+
+    func testSavedSideRoundTripsWithoutDrift() {
+        let portrait = CGSize(width: 588, height: 1_278)
+        let landscape = CGSize(width: 1_278, height: 588)
+        let saved = CGRect(origin: CGPoint(x: -588, y: 120), size: portrait)
+
+        let rotated = DisplayArrangement.origin(for: landscape, from: saved, side: .left, relativeTo: main)
+        let back = DisplayArrangement.origin(for: portrait,
+                                             from: CGRect(origin: rotated, size: landscape),
+                                             side: .left, relativeTo: main)
+
+        XCTAssertEqual(rotated, CGPoint(x: -1_278, y: 120))
+        XCTAssertEqual(back, saved.origin)
+    }
+
+    func testSavedSideKeepsACornerAttachmentACorner() {
+        let saved = CGRect(x: 1_512, y: -588, width: 1_278, height: 588)
+
+        let target = DisplayArrangement.origin(for: CGSize(width: 588, height: 1_278),
+                                               from: saved, side: .right, relativeTo: main)
+
+        XCTAssertEqual(target, CGPoint(x: 1_512, y: -588))
     }
 
     func testLegacyRecordTouchingMainDisplayCanAlsoKeepItsSide() {

--- a/project.yml
+++ b/project.yml
@@ -93,6 +93,7 @@ targets:
     deploymentTarget: "14.0"
     sources:
       - MacTests
+      - Mac/DisplayArrangement.swift
       - Mac/Log.swift
       - Mac/LogPolicies.swift
     settings:


### PR DESCRIPTION
Closes #203

Rotation no longer destroys and rebuilds the virtual display. It applies a new mode to the existing one, so the monitor keeps its identity, its windows, and its place in the arrangement.

**Why:** with two devices connected, each rotation released the CGVirtualDisplay. WindowServer redistributes every window on a display that disappears, and with a sibling virtual display present it would hand them to the wrong device. The replacement then asked for a center-preserving origin that was often an illegal arrangement, so WindowServer snapped it, the snap got saved as the new position, and the next rotation started from there. The display walked across the desktop.

**How:** the descriptor reserves the longer orientation on both axes, so `resize()` can swap modes in place; the old destroy-and-rebuild stays as a fallback if the system refuses the mode switch. Saved arrangement records now carry which side of the main display the device sits on, and rotation recomputes the origin from that side rather than from the old center, clamped so the rotated display keeps the edge it shared with its neighbour. Retired ScreenCaptureKit and VideoToolbox callbacks are fenced behind a capture generation so a late frame from the old display cannot reach the new socket.

Also seeds the usbmux watcher from the current device inventory, so devices already plugged in when the Mac app launches show up without a reattach.

## Validation
- `xcodebuild test -project OpenSidecar.xcodeproj -scheme OpenSidecarMac -destination "platform=macOS"` (24 tests)
- `xcodebuild build -project OpenSidecar.xcodeproj -scheme OpenSidecariOS -destination "generic/platform=iOS" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- Physical validation with an iPad and iPhone connected simultaneously over USB: repeated portrait/landscape rotations preserved each device's own content, its windows, and its arrangement relative to the Mac display.
