### PR TITLE
feat(mac,ios): right-click input, multi-click timing & InputInjector test suite (#4, #5, #189, #190)

### DIFF
--- a/Mac/InputInjector.swift
+++ b/Mac/InputInjector.swift
@@ -25,8 +25,8 @@ private enum SystemClickMetrics {
 final class InputInjector {
 
     private let displayID: CGDirectDisplayID
-    private var isDown = false
-    private var penDown = false
+    private(set) var isDown = false
+    private(set) var penDown = false
     // A real event source (vs nil) plus non-zero clickState on down/up: menu
     // tracking treats sourceless/zero-click synthetic clicks as malformed — menus
     // open but their tracking session breaks, leaving zombie menu windows
@@ -40,23 +40,24 @@ final class InputInjector {
     private let pointerID: Int64 = 0x0D02              // pen tip
     private let vendorPointerType: Int64 = 0x0802    // Grip Pen (what apps expect)
     private let capabilityMask: Int64 = 0x05C7       // pressure + tilt + rotation + buttons
-    private var inRange = false
+    private(set) var inRange = false
 
-    // Pencil-only synthetic click counting — tablet events don't get click
-    // state from the Window Server, so we mirror macOS double-click prefs here.
-    private struct PenClickSession {
+    // Synthetic click counting — mirror macOS double-click prefs for both finger touch and pencil.
+    private struct ClickSession {
         let downLocation: CGPoint
         let clickState: Int
     }
 
-    private struct PenCompletedClick {
+    private struct CompletedClick {
         let upTime: CFAbsoluteTime
         let downLocation: CGPoint
         let clickState: Int
     }
 
-    private var penClickSession: PenClickSession?
-    private var penLastClick: PenCompletedClick?
+    private var touchClickSession: ClickSession?
+    private var touchLastClick: CompletedClick?
+    private var penClickSession: ClickSession?
+    private var penLastClick: CompletedClick?
 
     init(displayID: CGDirectDisplayID) {
         self.displayID = displayID
@@ -71,44 +72,69 @@ final class InputInjector {
         return trusted
     }
 
+    /// Resets all input state on client disconnect or session reset:
+    /// releases held mouse/touch buttons, releases held pen state,
+    /// exits tablet proximity, and clears click sessions.
+    func reset() {
+        let p = currentCursor()
+        if isDown {
+            if let ev = CGEvent(mouseEventSource: source, mouseType: .leftMouseUp,
+                                mouseCursorPosition: p, mouseButton: .left) {
+                ev.setIntegerValueField(.mouseEventClickState, value: 0)
+                ev.post(tap: .cghidEventTap)
+            }
+            isDown = false
+        }
+        if penDown {
+            postTabletPoint(phase: .up, x: nil, y: nil, pressure: 0, tiltX: 0, tiltY: 0, rotation: 0)
+            penDown = false
+        }
+        if inRange {
+            setProximity(entering: false, at: p)
+        }
+        touchClickSession = nil
+        touchLastClick = nil
+        penClickSession = nil
+        penLastClick = nil
+    }
+
     /// x/y are normalized [0,1] in video space (origin top-left).
-    func handleTouch(phase: String, x: Double, y: Double) {
+    func handleTouch(phase: String, x: Double, y: Double, button: String = "left") {
         let bounds = CGDisplayBounds(displayID)   // global CG coords, y-down
         let point = CGPoint(
             x: bounds.origin.x + x * bounds.width,
             y: bounds.origin.y + y * bounds.height
         )
 
+        let isRight = (button == "right")
+        let btn: CGMouseButton = isRight ? .right : .left
         let type: CGEventType
-        // Click count on the release. A cancel means "a second finger joined,
-        // this was a scroll, not a tap" — but there is no CGEvent for undoing a
-        // press, and a plain up over the press point is indistinguishable from a
-        // click, so every two-finger scroll opened whatever was under finger one.
-        // Releasing with clickCount 0 keeps the button state honest while telling
-        // AppKit and WebKit not to synthesize a click. Only the cancel path gets
-        // 0: a zero-click *down* is what breaks menu tracking (see above).
         var clickState = 1
         switch phase {
         case "began":
-            type = .leftMouseDown
+            type = isRight ? .rightMouseDown : .leftMouseDown
             isDown = true
+            clickState = beginTouchClickSession(at: point)
         case "moved":
-            type = isDown ? .leftMouseDragged : .mouseMoved
+            type = isDown ? (isRight ? .rightMouseDragged : .leftMouseDragged) : .mouseMoved
         case "ended":
             guard isDown else { return }   // spurious up without a down
-            type = .leftMouseUp
+            type = isRight ? .rightMouseUp : .leftMouseUp
             isDown = false
+            clickState = finishTouchClickSession(at: point)
         case "cancelled":
             guard isDown else { return }
-            type = .leftMouseUp
+            type = isRight ? .rightMouseUp : .leftMouseUp
             isDown = false
+            touchClickSession = nil
+            touchLastClick = nil
             clickState = 0
         default:
             return
         }
 
         guard let event = CGEvent(mouseEventSource: source, mouseType: type,
-                                  mouseCursorPosition: point, mouseButton: .left) else { return }
+                                  mouseCursorPosition: point, mouseButton: btn) else { return }
         event.setIntegerValueField(.mouseEventClickState, value: Int64(clickState))
         event.post(tap: .cghidEventTap)
     }
@@ -140,7 +166,7 @@ final class InputInjector {
         if phase == "down", !inRange {
             setProximity(entering: true, at: p)
         }
-        let (tiltX, tiltY) = deriveTilt(azimuth: azimuth, altitude: altitude)
+        let (tiltX, tiltY) = Self.deriveTilt(azimuth: azimuth, altitude: altitude)
 
         switch phase {
         case "down":
@@ -237,9 +263,9 @@ final class InputInjector {
         ev.post(tap: .cghidEventTap)
     }
 
-    private func penClickStateForMouseDown(at point: CGPoint) -> Int {
+    private func clickStateForMouseDown(at point: CGPoint, lastClick: CompletedClick?) -> Int {
         let now = CFAbsoluteTimeGetCurrent()
-        guard let last = penLastClick,
+        guard let last = lastClick,
               now - last.upTime <= SystemClickMetrics.interval else {
             return 1
         }
@@ -249,9 +275,33 @@ final class InputInjector {
         return last.clickState + 1
     }
 
+    private func beginTouchClickSession(at point: CGPoint) -> Int {
+        let state = clickStateForMouseDown(at: point, lastClick: touchLastClick)
+        touchClickSession = ClickSession(downLocation: point, clickState: state)
+        return state
+    }
+
+    private func finishTouchClickSession(at upLocation: CGPoint) -> Int {
+        guard let session = touchClickSession else { return 1 }
+        touchClickSession = nil
+
+        let dx = upLocation.x - session.downLocation.x
+        let dy = upLocation.y - session.downLocation.y
+        if hypot(dx, dy) <= SystemClickMetrics.distance {
+            touchLastClick = CompletedClick(
+                upTime: CFAbsoluteTimeGetCurrent(),
+                downLocation: session.downLocation,
+                clickState: session.clickState
+            )
+        } else {
+            touchLastClick = nil
+        }
+        return session.clickState
+    }
+
     private func beginPenClickSession(at point: CGPoint) -> Int {
-        let state = penClickStateForMouseDown(at: point)
-        penClickSession = PenClickSession(downLocation: point, clickState: state)
+        let state = clickStateForMouseDown(at: point, lastClick: penLastClick)
+        penClickSession = ClickSession(downLocation: point, clickState: state)
         return state
     }
 
@@ -264,7 +314,7 @@ final class InputInjector {
         let dx = upLocation.x - session.downLocation.x
         let dy = upLocation.y - session.downLocation.y
         if hypot(dx, dy) <= SystemClickMetrics.distance {
-            penLastClick = PenCompletedClick(
+            penLastClick = CompletedClick(
                 upTime: CFAbsoluteTimeGetCurrent(),
                 downLocation: session.downLocation,
                 clickState: session.clickState
@@ -279,7 +329,7 @@ final class InputInjector {
     /// is a unit vector in -1...1, so normalize rather than pass radians through
     /// (unnormalized, a flat pen reads 1.57 and apps that scale tilt by 90 report
     /// impossible angles).
-    private func deriveTilt(azimuth: Double, altitude: Double) -> (Double, Double) {
+    static func deriveTilt(azimuth: Double, altitude: Double) -> (Double, Double) {
         let mag = min(max(0, Double.pi / 2 - altitude) / (Double.pi / 2), 1)
         return (sin(azimuth) * mag, cos(azimuth) * mag)
     }

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -724,6 +724,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     func stop() {
         stopped = true
+        inputInjector?.reset()
         invalidateCapturePipeline(discardingLastFrame: true)
         cursorTimer?.cancel()
         cursorTimer = nil
@@ -792,6 +793,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private func reportGone(_ reason: String) {
         guard !goneReported, !stopped else { return }
         goneReported = true
+        inputInjector?.reset()
         Log.info(reason)
         Task { @MainActor in self.onDisconnected?() }
     }
@@ -1002,6 +1004,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     /// Bookkeeping shared by both transports once a connection is live.
     private func becomeReady(_ conn: NWConnection) {
+        inputInjector?.reset()
         Log.info("connection ready to \(endpointName)")
         connectionReady = true
         cursorSeq = 0   // per-session; the receiver rewound its floor with the connection
@@ -1762,7 +1765,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             if let phase = obj["phase"] as? String,
                let x = obj["x"] as? Double,
                let y = obj["y"] as? Double {
-                inputInjector?.handleTouch(phase: phase, x: x, y: y)
+                let button = obj["button"] as? String ?? "left"
+                inputInjector?.handleTouch(phase: phase, x: x, y: y, button: button)
                 if let t = obj["t"] as? Double {
                     let delta = Date().timeIntervalSince1970 * 1000 - t
                     if delta > -50, delta < 1000 {
@@ -2274,6 +2278,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     /// Invalidate the retired ScreenCaptureKit/VideoToolbox callbacks before
     /// changing the display or encoder they feed.
     private func invalidateCapturePipeline(discardingLastFrame: Bool = false) {
+        inputInjector?.reset()
         pipelineLock.lock()
         captureGeneration &+= 1
         pipelineLock.unlock()

--- a/MacTests/InputInjectorTests.swift
+++ b/MacTests/InputInjectorTests.swift
@@ -1,0 +1,106 @@
+import CoreGraphics
+import XCTest
+
+final class InputInjectorTests: XCTestCase {
+
+    func testDeriveTiltMath() {
+        // Upright pen (altitude = pi/2)
+        let (tiltX1, tiltY1) = InputInjector.deriveTilt(azimuth: 0, altitude: Double.pi / 2)
+        XCTAssertEqual(tiltX1, 0, accuracy: 1e-5)
+        XCTAssertEqual(tiltY1, 0, accuracy: 1e-5)
+
+        // Flat pen facing right (azimuth = pi/2, altitude = 0)
+        let (tiltX2, tiltY2) = InputInjector.deriveTilt(azimuth: Double.pi / 2, altitude: 0)
+        XCTAssertEqual(tiltX2, 1.0, accuracy: 1e-5)
+        XCTAssertEqual(tiltY2, 0, accuracy: 1e-5)
+
+        // Flat pen facing up (azimuth = 0, altitude = 0)
+        let (tiltX3, tiltY3) = InputInjector.deriveTilt(azimuth: 0, altitude: 0)
+        XCTAssertEqual(tiltX3, 0, accuracy: 1e-5)
+        XCTAssertEqual(tiltY3, 1.0, accuracy: 1e-5)
+
+        // Altitude clamping (> pi/2 or < 0)
+        let (tiltX4, tiltY4) = InputInjector.deriveTilt(azimuth: Double.pi / 4, altitude: Double.pi)
+        XCTAssertEqual(tiltX4, 0, accuracy: 1e-5)
+        XCTAssertEqual(tiltY4, 0, accuracy: 1e-5)
+    }
+
+    func testTouchStateMachine() {
+        let injector = InputInjector(displayID: CGMainDisplayID())
+        XCTAssertFalse(injector.isDown)
+
+        injector.handleTouch(phase: "began", x: 0.5, y: 0.5)
+        XCTAssertTrue(injector.isDown)
+
+        injector.handleTouch(phase: "moved", x: 0.6, y: 0.6)
+        XCTAssertTrue(injector.isDown)
+
+        injector.handleTouch(phase: "ended", x: 0.6, y: 0.6)
+        XCTAssertFalse(injector.isDown)
+    }
+
+    func testRightClickHandling() {
+        let injector = InputInjector(displayID: CGMainDisplayID())
+        XCTAssertFalse(injector.isDown)
+
+        injector.handleTouch(phase: "began", x: 0.3, y: 0.3, button: "right")
+        XCTAssertTrue(injector.isDown)
+
+        injector.handleTouch(phase: "moved", x: 0.35, y: 0.35, button: "right")
+        XCTAssertTrue(injector.isDown)
+
+        injector.handleTouch(phase: "ended", x: 0.35, y: 0.35, button: "right")
+        XCTAssertFalse(injector.isDown)
+    }
+
+    func testTouchCancelled() {
+        let injector = InputInjector(displayID: CGMainDisplayID())
+        injector.handleTouch(phase: "began", x: 0.4, y: 0.4)
+        XCTAssertTrue(injector.isDown)
+
+        injector.handleTouch(phase: "cancelled", x: 0.4, y: 0.4)
+        XCTAssertFalse(injector.isDown)
+    }
+
+    func testPencilStateMachineAndProximity() {
+        let injector = InputInjector(displayID: CGMainDisplayID())
+        XCTAssertFalse(injector.penDown)
+        XCTAssertFalse(injector.inRange)
+
+        injector.handlePencil(phase: "down", x: 0.2, y: 0.2, pressure: 0.5, azimuth: 0, altitude: 0.5, rotation: 0)
+        XCTAssertTrue(injector.penDown)
+        XCTAssertTrue(injector.inRange)
+
+        injector.handlePencil(phase: "move", x: 0.25, y: 0.25, pressure: 0.8, azimuth: 0, altitude: 0.5, rotation: 0)
+        XCTAssertTrue(injector.penDown)
+
+        injector.handlePencil(phase: "up", x: 0.25, y: 0.25, pressure: 0, azimuth: 0, altitude: 0.5, rotation: 0)
+        XCTAssertFalse(injector.penDown)
+        XCTAssertTrue(injector.inRange)
+
+        injector.handlePencil(phase: "hover", x: 0.3, y: 0.3, pressure: 0, azimuth: 0, altitude: 0.5, rotation: 0)
+        XCTAssertFalse(injector.penDown)
+        XCTAssertTrue(injector.inRange)
+
+        injector.handleProximity(entering: false, x: 0.3, y: 0.3)
+        XCTAssertFalse(injector.inRange)
+    }
+
+    func testResetCleansUpAllState() {
+        let injector = InputInjector(displayID: CGMainDisplayID())
+        injector.handleTouch(phase: "began", x: 0.1, y: 0.1)
+        injector.handlePencil(phase: "down", x: 0.1, y: 0.1, pressure: 0.5, azimuth: 0, altitude: 0.5, rotation: 0)
+        XCTAssertTrue(injector.isDown)
+        XCTAssertTrue(injector.penDown)
+        XCTAssertTrue(injector.inRange)
+
+        injector.reset()
+        XCTAssertFalse(injector.isDown)
+        XCTAssertFalse(injector.penDown)
+        XCTAssertFalse(injector.inRange)
+    }
+
+    func testAccessibilityPermissionCheck() {
+        _ = InputInjector.ensureAccessibilityPermission()
+    }
+}

--- a/Shared/StreamReceiver.swift
+++ b/Shared/StreamReceiver.swift
@@ -907,8 +907,9 @@ final class StreamReceiver: ObservableObject {
     /// Touch events: x/y normalized [0,1] in video space, origin top-left.
     /// Stamped in *Mac* clock time (our clock + sync offset) so the Mac can
     /// measure touch→injection latency without doing its own clock sync.
-    func sendTouch(phase: String, x: Double, y: Double) {
+    func sendTouch(phase: String, x: Double, y: Double, button: String = "left") {
         var msg: [String: Any] = ["type": "touch", "phase": phase, "x": x, "y": y]
+        if button != "left" { msg["button"] = button }
         if let offset = clockOffsetMs { msg["t"] = nowMs + offset }
         sendControl(msg)
     }

--- a/Tests/InputInjectorTests.swift
+++ b/Tests/InputInjectorTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import CoreGraphics
+
+// Dummy Log stub for standalone test execution
+enum Log {
+    static func info(_ msg: String) {}
+    static func debug(_ msg: String) {}
+    static func error(_ msg: String) {}
+}
+
+@main
+struct InputInjectorTests {
+    static func main() {
+        print("Running InputInjector unit tests...")
+        var passed = 0
+        var total = 0
+
+        func assertTest(_ condition: Bool, _ name: String) {
+            total += 1
+            if condition {
+                passed += 1
+                print("  ✓ \(name)")
+            } else {
+                print("  FAILED: \(name)")
+            }
+        }
+
+        // Test 1: Tilt math - Upright pen (altitude = pi/2)
+        let (tiltX1, tiltY1) = InputInjector.deriveTilt(azimuth: 0, altitude: Double.pi / 2)
+        assertTest(abs(tiltX1) < 1e-5 && abs(tiltY1) < 1e-5, "Upright pen produces (0, 0) tilt vector")
+
+        // Test 2: Tilt math - Flat pen facing right (azimuth = pi/2, altitude = 0)
+        let (tiltX2, tiltY2) = InputInjector.deriveTilt(azimuth: Double.pi / 2, altitude: 0)
+        assertTest(abs(tiltX2 - 1.0) < 1e-5 && abs(tiltY2) < 1e-5, "Flat pen facing right produces (1.0, 0.0) tilt")
+
+        // Test 3: Tilt math - Flat pen facing up (azimuth = 0, altitude = 0)
+        let (tiltX3, tiltY3) = InputInjector.deriveTilt(azimuth: 0, altitude: 0)
+        assertTest(abs(tiltX3) < 1e-5 && abs(tiltY3 - 1.0) < 1e-5, "Flat pen facing up produces (0.0, 1.0) tilt")
+
+        // Test 4: Tilt math - Altitude clamping (> pi/2 or < 0)
+        let (tiltX4, tiltY4) = InputInjector.deriveTilt(azimuth: Double.pi / 4, altitude: Double.pi)
+        assertTest(abs(tiltX4) < 1e-5 && abs(tiltY4) < 1e-5, "Over-pitched altitude is clamped to zero magnitude")
+
+        // Test 5: InputInjector touch state machine
+        let injector = InputInjector(displayID: CGMainDisplayID())
+        assertTest(!injector.isDown, "Initial touch state is not down")
+
+        injector.handleTouch(phase: "began", x: 0.5, y: 0.5)
+        assertTest(injector.isDown, "Touch began sets isDown to true")
+
+        injector.handleTouch(phase: "moved", x: 0.6, y: 0.6)
+        assertTest(injector.isDown, "Touch moved preserves isDown")
+
+        injector.handleTouch(phase: "ended", x: 0.6, y: 0.6)
+        assertTest(!injector.isDown, "Touch ended resets isDown to false")
+
+        // Test 6: Right-click handling
+        injector.handleTouch(phase: "began", x: 0.3, y: 0.3, button: "right")
+        assertTest(injector.isDown, "Right touch began sets isDown to true")
+
+        injector.handleTouch(phase: "ended", x: 0.3, y: 0.3, button: "right")
+        assertTest(!injector.isDown, "Right touch ended resets isDown to false")
+
+        // Test 7: Touch cancelled path
+        injector.handleTouch(phase: "began", x: 0.4, y: 0.4)
+        injector.handleTouch(phase: "cancelled", x: 0.4, y: 0.4)
+        assertTest(!injector.isDown, "Touch cancelled resets isDown to false")
+
+        // Test 8: Pencil state machine & proximity
+        assertTest(!injector.penDown, "Initial pen state is not down")
+        assertTest(!injector.inRange, "Initial pen proximity is not inRange")
+
+        injector.handlePencil(phase: "down", x: 0.2, y: 0.2, pressure: 0.5, azimuth: 0, altitude: 0.5, rotation: 0)
+        assertTest(injector.penDown, "Pencil down sets penDown to true")
+        assertTest(injector.inRange, "Pencil down automatically enters proximity (inRange)")
+
+        injector.handlePencil(phase: "move", x: 0.25, y: 0.25, pressure: 0.8, azimuth: 0, altitude: 0.5, rotation: 0)
+        assertTest(injector.penDown, "Pencil move while down maintains penDown")
+
+        injector.handlePencil(phase: "up", x: 0.25, y: 0.25, pressure: 0, azimuth: 0, altitude: 0.5, rotation: 0)
+        assertTest(!injector.penDown, "Pencil up resets penDown to false")
+        assertTest(injector.inRange, "Pencil up keeps proximity inRange until hover/leave")
+
+        injector.handlePencil(phase: "hover", x: 0.3, y: 0.3, pressure: 0, azimuth: 0, altitude: 0.5, rotation: 0)
+        assertTest(!injector.penDown && injector.inRange, "Pencil hover maintains inRange and penDown false")
+
+        injector.handleProximity(entering: false, x: 0.3, y: 0.3)
+        assertTest(!injector.inRange, "Proximity exit sets inRange to false")
+
+        // Test 9: Reset cleanup
+        injector.handleTouch(phase: "began", x: 0.1, y: 0.1)
+        injector.handlePencil(phase: "down", x: 0.1, y: 0.1, pressure: 0.5, azimuth: 0, altitude: 0.5, rotation: 0)
+        assertTest(injector.isDown && injector.penDown && injector.inRange, "All inputs active before reset")
+
+        injector.reset()
+        assertTest(!injector.isDown && !injector.penDown && !injector.inRange, "reset() clears touch, pen, and proximity states")
+
+        // Test 10: Accessibility permission check
+        _ = InputInjector.ensureAccessibilityPermission()
+        assertTest(true, "Accessibility permission helper runs without error")
+
+        print("\nResults: \(passed)/\(total) tests passed.")
+        if passed < total {
+            exit(1)
+        }
+    }
+}

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -613,6 +613,10 @@ struct VideoLayerView: UIViewRepresentable {
         pan.maximumNumberOfTouches = 2
         view.addGestureRecognizer(pan)
 
+        let twoFingerTap = UITapGestureRecognizer(target: view, action: #selector(VideoView.didTwoFingerTap(_:)))
+        twoFingerTap.numberOfTouchesRequired = 2
+        view.addGestureRecognizer(twoFingerTap)
+
         // Local cursor echo: position updates ride the ~2ms control path
         // instead of the ~30ms video path, so the pointer feels native.
         receiver.onCursor = { [weak view] x, y, visible in
@@ -782,6 +786,14 @@ struct VideoLayerView: UIViewRepresentable {
             }
         }
 
+        @objc func didTwoFingerTap(_ recognizer: UITapGestureRecognizer) {
+            guard recognizer.state == .ended,
+                  let video = receiver?.videoSize, video != .zero else { return }
+            guard let n = normalized(recognizer.location(in: self)) else { return }
+            receiver?.sendTouch(phase: "began", x: n.x, y: n.y, button: "right")
+            receiver?.sendTouch(phase: "ended", x: n.x, y: n.y, button: "right")
+        }
+
         // A press is only a click once we know a second finger is not coming.
         // Sending `began` on contact posted a mouse-down we then had to take
         // back, and taking it back only works when UIKit happens to deliver
@@ -925,7 +937,8 @@ struct VideoLayerView: UIViewRepresentable {
                 }
             }
             // Palm rejection: ignore resting fingers while the pen is down.
-            if !finger.isEmpty && !inputEngine.hasActivePen {
+            // Suppress began and moved, but forward ended and cancelled so isDown does not stick (#189).
+            if !finger.isEmpty && (!inputEngine.hasActivePen || ended) {
                 send(phase, finger, event)
             }
         }

--- a/project.yml
+++ b/project.yml
@@ -151,6 +151,7 @@ targets:
     sources:
       - MacTests
       - Mac/DisplayArrangement.swift
+      - Mac/InputInjector.swift
       - Mac/Log.swift
       - Mac/LogPolicies.swift
       - Shared/LogSnapshot.swift


### PR DESCRIPTION
# feat(mac,ios): right-click input, multi-click timing & InputInjector test suite (#4, #5, #189, #190)

Resolves #5, #189, and #190; addresses remaining items under #4.

## Summary of Changes

### 1. End-to-End Right-Click Input Support (#5)
- **iOS Gesture & Protocol**: Added a two-finger tap gesture recognizer (`UITapGestureRecognizer(numberOfTouchesRequired: 2)`) to `VideoLayerView.VideoView` and extended `PhoneReceiver.sendTouch(phase:x:y:button:)` to pass `button: "right"` over the control wire.
- **Mac Dispatch & Injection**: `MacSender.swift` parses incoming `button` fields and passes them to `InputInjector.handleTouch(phase:x:y:button:)`.
- **Secondary Mouse Mapping**: In `InputInjector.swift`, right touches map to `CGEventType.rightMouseDown`, `rightMouseDragged`, and `rightMouseUp` with `mouseButton: .right`.

### 2. Finger Double-Click & Multi-Click Timing (#5)
- Fixed the issue where quick finger taps always emitted `mouseEventClickState = 1` and never registered as macOS double-clicks in Extend mode.
- Integrated `SystemClickMetrics` (using system double-click interval and `NSDoubleClickDistance`) to track `ClickSession` state transitions for finger touch, matching the Apple Pencil click tracking behavior.
- Resets click state to `0` on cancelled touches.

### 3. Palm Rejection Touch Lift Fix (#189)
- Updated `routeTouches` in `OpenSidecarPhoneApp.swift` to always forward `ended` and `cancelled` finger touch events even while an Apple Pencil contact is active, ensuring `InputInjector.isDown` is never left held down after lifting a finger during drawing.

### 4. InputInjector State Teardown & Reset (#190)
- Extended `InputInjector.reset()` to release held mouse/touch buttons, release held pen state, exit tablet proximity, and clear active/completed click sessions.
- Wired `inputInjector?.reset()` into `MacSender` connection ready (`becomeReady`), teardown (`stop`), disconnect (`reportGone`), and pipeline invalidation paths.

### 5. InputInjector Test Suite Integration (#4, #5)
- Added `MacTests/InputInjectorTests.swift` (`XCTestCase`) covering tilt unit vector math, touch state machine transitions, right-click handling, cancelled gestures, pencil state & proximity, and session reset cleanup.
- Added `Mac/InputInjector.swift` to the `OpenSidecarMacTests` target in `project.yml`.
- Maintained standalone test runner in `Tests/InputInjectorTests.swift`.

## Verification
- **XcodeGen & macOS Test Suite**: `xcodegen generate && xcodebuild test -project OpenSidecar.xcodeproj -scheme OpenSidecarMac -destination 'platform=macOS'` — all 41/41 tests pass (including 7/7 in `InputInjectorTests`).
- **iOS App Build**: `xcodebuild build -project OpenSidecar.xcodeproj -scheme OpenSidecariOS -destination 'generic/platform=iOS'` builds with zero errors.
- **Standalone Test Runner**: `swiftc -parse-as-library Tests/InputInjectorTests.swift Mac/InputInjector.swift -o /tmp/input_injector_tests && /tmp/input_injector_tests` — 23/23 tests pass.
