### PR TITLE
fix(macOS): key the virtual display identity to the device, not the transport

### DIFF
--- a/Mac/DisplayIdentity.swift
+++ b/Mac/DisplayIdentity.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Owns the virtual-monitor serial independently of the current transport.
+///
+/// macOS keys saved display state — arrangement, resolution, the hostile
+/// "never come online again" state `MacSender.setupExtend` probes around —
+/// on vendor/product/serial. Deriving that serial from the connection's
+/// session id therefore hands one physical device two unrelated identities,
+/// one for USB and one for WiFi. New receivers report a stable per-install
+/// id in `PhoneInfo.id`, which `DisplayArrangement` already trusts as the
+/// device key; using it here puts both transports on one identity.
+enum DisplayIdentity {
+    /// FNV-1a over the install id. Namespaced so the value cannot collide
+    /// with the session-derived serials older receivers still get.
+    static func serial(for deviceID: String) -> UInt32 {
+        var hash: UInt32 = 2_166_136_261
+        for byte in "device:\(deviceID)".utf8 {
+            hash = (hash ^ UInt32(byte)) &* 16_777_619
+        }
+        return hash == 0 ? 1 : hash
+    }
+}

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -383,10 +383,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         let displayName = endpointName.hasPrefix("iPhone / iPad")
             ? "OpenDisplay — \(info.kind)"
             : "OpenDisplay — \(endpointName)"
-        // Keep one stable identity across rotations. Reconfiguration below
-        // applies a new mode to the existing virtual monitor, so macOS keeps
-        // its windows and arrangement attached to this physical device.
-        let serial = displaySerial
+        // Transport and display identity are separate concerns. New receivers
+        // identify the physical install in `info.id`, so USB/WiFi must use the
+        // same virtual-monitor serial. Older receivers retain the historical
+        // session-derived fallback.
+        let serial = info.id.map { DisplayIdentity.serial(for: $0) } ?? displaySerial
         // Arrangement memory (#116): keyed on the device's install id so the
         // display returns to its spot across transports and orientations —
         // the serial-keyed memory macOS keeps starts from scratch whenever


### PR DESCRIPTION
## Summary

Derive the virtual display serial from the receiver's install id (`PhoneInfo.id`) instead of `ConnectionTarget.sessionID`, so one physical device keeps one macOS display identity across USB and WiFi. Receivers old enough not to send an id keep the historical session-derived serial.

## Why

macOS keys saved display state on vendor/product/serial. OpenDisplay derives that serial from `ConnectionTarget.sessionID`, which *is* the transport — `"usb:<udid>"` or `"wifi:<name>"`. The same iPad therefore presents as two unrelated monitors depending on how it connected, so:

- arrangement and resolution memory are built twice, once per transport
- the identity offset added in #231 is persisted per session id (`displaySerialBump.<sessionID>`), so escaping a poisoned identity over USB teaches the WiFi path nothing
- `upgradeToUSB()` crosses from one identity to the other mid-session

`PhoneInfo.id` is already the transport-independent receiver install id, and `DisplayArrangement` already trusts it as the device key (#116) for exactly this reason. This makes the serial agree with it.

## What this is not

This PR originally also carried its own poisoned-identity recovery. #231 landed a more thorough version of that — offset probing, a matching productID bump, `findSCDisplay` as the online proof, and a dedicated error when every probe fails — so that half is dropped rather than duplicated. The #231 probe loop is untouched here and still owns recovery; it simply probes offsets from a device-stable base instead of a transport-stable one.

## Known limitation

The offset itself is still persisted per session id. With a device-stable base serial, a device that escaped to `+1` over USB starts at `+0` again on its first WiFi session and re-probes, so recovery is one cycle late rather than immediate. Moving that key to the install id means threading `info.id` back to the controller, which only learns it after the hello — deliberately left out of this change.

## Validation

- `xcrun swiftc -typecheck` over `Mac/*.swift Shared/*.swift`: exit 0, 0 errors, 22 warnings — identical counts to untouched `main`, so no new diagnostics (Sparkle stubbed; this machine has Command Line Tools, not Xcode)
- `git diff --check`: clean
- rebased onto `main`; `main` is an ancestor of the branch, so the merge is a fast-forward

Not run here: a real app build and on-device verification, for lack of a full Xcode install on this machine. The earlier hardware validation on macOS 26.6.1 covered the superseded recovery code, not this diff, so I am not carrying those claims over.
