### PR TITLE
fix(mac): position touch events on the virtual display

### DIFF
--- a/Mac/InputInjector.swift
+++ b/Mac/InputInjector.swift
@@ -107,6 +107,7 @@ final class InputInjector {
             return
         }
 
+        _ = CGWarpMouseCursorPosition(point)
         guard let event = CGEvent(mouseEventSource: source, mouseType: type,
                                   mouseCursorPosition: point, mouseButton: .left) else { return }
         event.setIntegerValueField(.mouseEventClickState, value: Int64(clickState))


### PR DESCRIPTION
## Summary

- warp the system cursor to the normalized virtual-display point before posting the mouse event
- fix iPad touch input remaining on the physical Mac display in Extend mode

## Root cause

On macOS 26.6, the `CGEvent` was created with the correct coordinates for the `CGVirtualDisplay`, but `CGEventPost(.cghidEventTap)` did not move the cursor across the display boundary. `CGWarpMouseCursorPosition` does, allowing the existing down/move/up event to land on the intended display.

## Testing

- built the macOS app from current `main` for arm64
- connected an iPad at 2388x1668 over Wi-Fi in Extend mode
- verified single-finger drag and tap on a virtual display positioned left of the main display
- `git diff --check` and full Swift compilation pass

Existing Swift 6 sendability warnings are unchanged.