### PR TITLE
fix(mac): rebuild stale offline virtual displays

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -466,7 +466,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     /// Returns false when there is no reusable display or macOS rejected the
     /// mode switch, letting the caller use the legacy rebuild fallback.
     private func resizeExistingDisplay(for info: PhoneInfo) async throws -> Bool {
-        guard let vd = virtualDisplay else { return false }
+        guard let vd = virtualDisplay, vd.isUsable else { return false }
 
         let pointsWide = (info.pixelsWide / 2) & ~1
         let pointsHigh = (info.pixelsHigh / 2) & ~1
@@ -675,13 +675,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         queue.asyncAfter(deadline: .now() + 3.0) { [weak self] in
             guard let self, !self.stopped, self.stream == nil,
                   let hello = self.lastHello else { return }
-            // Does our virtual display still exist? CGDisplayBounds returns a
-            // zero rect for an unknown id, so a non-empty bounds means it's live.
-            // Test isEmpty, not isNull: isNull is only true for the special
-            // CGRect.null, so it reads as "live" for a dead display too and the
-            // rebuild fallback below would become unreachable.
-            if let vd = self.virtualDisplay,
-               !CGDisplayBounds(vd.displayID).isEmpty {
+            // WindowServer may keep non-empty bounds for a display it has
+            // already marked offline. Re-attach only to an online, active
+            // display; otherwise rebuild with a fresh identity.
+            if let vd = self.virtualDisplay, vd.isUsable {
                 Log.info("capture died — display still present, re-attaching capture only (#29)")
                 Task {
                     do {
@@ -703,8 +700,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 }
                 return
             }
-            // Display genuinely gone — full rebuild (preserves old behavior).
-            Log.info("capture died — rebuilding pipeline")
+            Log.info("capture died — display offline, rebuilding with fresh identity")
             Task {
                 await self.reconfigure(hello)
                 self.queue.async {

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -18,6 +18,11 @@ final class VirtualDisplay {
     private let onOriginChange: ((CGPoint, CGSize) -> Void)?
 
     var displayID: CGDirectDisplayID { display.displayID }
+    var isUsable: Bool {
+        !CGDisplayBounds(displayID).isEmpty
+            && CGDisplayIsOnline(displayID) != 0
+            && CGDisplayIsActive(displayID) != 0
+    }
 
     /// Must be called on the main thread. `serialNum` must be unique per
     /// concurrent display AND stable per device — macOS keys saved display
@@ -45,7 +50,10 @@ final class VirtualDisplay {
         descriptor.maxPixelsWide = UInt32(maxPointsPerAxis * 2)
         descriptor.maxPixelsHigh = UInt32(maxPointsPerAxis * 2)
         descriptor.sizeInMillimeters = sizeInMillimeters
-        descriptor.productID = 0x4F53   // "OS"
+        // A stale WindowServer record can pin one identity offline. A fresh
+        // product ID per rebuild bypasses that cache; arrangement is restored
+        // separately by DisplayArrangement.
+        descriptor.productID = UInt32.random(in: 0x1000...0xFFFE)
         descriptor.vendorID = 0x5043    // "PC"
         descriptor.serialNum = serialNum
         descriptor.terminationHandler = { _, _ in


### PR DESCRIPTION
## Summary

- require a virtual display to be online and active before reusing it
- rebuild stale/offline displays instead of re-attaching capture to them
- use a fresh product ID on each rebuild to bypass stale WindowServer display-identity records

## Root cause

A stale `CGVirtualDisplay` can retain non-empty `CGDisplayBounds` while `CGDisplayIsOnline` and `CGDisplayIsActive` are both false. The existing recovery path treated non-empty bounds as proof that the display was live, then attempted to re-attach ScreenCaptureKit to an offline display. Extend mode consequently stayed black because the display never appeared in `SCShareableContent`, while mirror mode continued to work by capturing the built-in display.

This change centralizes the liveness check in `VirtualDisplay.isUsable`. Offline or inactive displays now take the existing full-rebuild path, and a fresh product ID prevents the rebuild from resolving to the same stale WindowServer identity. Display placement remains handled independently by `DisplayArrangement`.

## Validation

- `swiftc -frontend -parse Mac/VirtualDisplay.swift`
- `swiftc -frontend -parse Mac/MacSender.swift`
- `git diff --check`
- live test on Apple Silicon / macOS 26.6: Mirror → Extend created a new virtual display ID
- `system_profiler` reported the rebuilt display as `Online: Yes`, `Mirror: Off`, `2388 x 1668`, `60 Hz`
- USB client stream stabilized at 59–60 FPS with no black screen

`CGVirtualDisplay` remains a private macOS API, so future system releases may still require compatibility adjustments.
