### PR TITLE
feat: connect Android over USB without adb

### DIFF
--- a/Mac/ByteStream.swift
+++ b/Mac/ByteStream.swift
@@ -1,0 +1,43 @@
+// Transport abstraction: send bytes, read exactly N bytes, close.
+// Wire framing is [4-byte BE length][payload].
+
+import Foundation
+import Network
+
+protocol ByteStream: AnyObject {
+    /// `completion` fires once `data` is handed off to the transport.
+    func send(_ data: Data, completion: @escaping (Error?) -> Void)
+
+    /// Reads exactly `count` bytes, or nil on failure/close.
+    func receive(exactly count: Int, completion: @escaping (Data?) -> Void)
+
+    func cancel()
+}
+
+/// NWConnection-backed transport: WiFi, -host/-port, usbmux.
+final class NetworkByteStream: ByteStream {
+    let connection: NWConnection
+
+    init(_ connection: NWConnection) {
+        self.connection = connection
+    }
+
+    func send(_ data: Data, completion: @escaping (Error?) -> Void) {
+        connection.send(content: data, completion: .contentProcessed { completion($0) })
+    }
+
+    func receive(exactly count: Int, completion: @escaping (Data?) -> Void) {
+        connection.receive(minimumIncompleteLength: count, maximumLength: count) {
+            data, _, _, error in
+            guard error == nil, let data, data.count == count else {
+                completion(nil)
+                return
+            }
+            completion(data)
+        }
+    }
+
+    func cancel() {
+        connection.cancel()
+    }
+}

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -83,6 +83,7 @@ struct PhoneInfo: Decodable {
 enum SenderTransport {
     case tcp(NWEndpoint)                   // WiFi (Bonjour) or -host/-port override
     case usb(udid: String?, port: UInt16)  // native usbmuxd dial; nil = first device
+    case accessory                         // Android over USB, no adb — see USBAccessory.swift
 }
 
 @available(macOS 14.0, *)
@@ -111,6 +112,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private var encoder: VTCompressionSession?
     /// Active transport connection. See ByteStream.swift.
     private var peer: ByteStream?
+    /// Kept alive for the duration of an AOA dial — it owns the wait for the
+    /// device to re-enumerate.
+    private var androidAccessoryConnector: AndroidAccessoryConnector?
     private var virtualDisplay: VirtualDisplay?
     private let queue = DispatchQueue(label: "sender.video")
     private let startCode: [UInt8] = [0, 0, 0, 1]
@@ -726,8 +730,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         switch transport {
         case .tcp(let endpoint): connectTCP(endpoint)
         case .usb(let udid, let port): connectUSB(udid: udid, port: port)
+        case .accessory: connectAndroidAccessory()
         }
     }
+
 
     /// Bookkeeping shared by both transports once a connection is live.
     private func becomeReady(_ peer: ByteStream) {
@@ -863,6 +869,30 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         }
     }
 
+    /// Android over USB via AOA. See USBAccessory.swift.
+    ///
+    /// It can take seconds because the device leaves the bus and re-enumerates, and on
+    /// first plug the user has an accessory dialog to dismiss.
+    /// `dialGeneration` guards against a stale dial adopting late.
+    private func connectAndroidAccessory() {
+        dialGeneration += 1
+        let generation = dialGeneration
+        let connector = AndroidAccessoryConnector(queue: queue)
+        androidAccessoryConnector = connector
+        Task { await status("Putting the Android device into accessory mode…") }
+        connector.connect { [weak self] result in
+            guard let self, generation == self.dialGeneration, !self.stopped else { return }
+            switch result {
+            case .success(let peer):
+                self.peer = peer
+                self.becomeReady(peer)
+            case .failure(let error):
+                Log.info("accessory dial failed: \(error)")
+                Task { await self.status("USB: \(error.localizedDescription)") }
+                self.scheduleReconnect()
+            }
+        }
+    }
     private func scheduleReconnect() {
         guard !stopped else { return }
         if everConnected {

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -109,7 +109,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     private var stream: SCStream?
     private var encoder: VTCompressionSession?
-    private var connection: NWConnection?
+    /// Active transport connection. See ByteStream.swift.
+    private var peer: ByteStream?
     private var virtualDisplay: VirtualDisplay?
     private let queue = DispatchQueue(label: "sender.video")
     private let startCode: [UInt8] = [0, 0, 0, 1]
@@ -560,8 +561,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         cursorImageTimer = nil
         stream?.stopCapture { _ in }
         stream = nil
-        connection?.cancel()
-        connection = nil
+        peer?.cancel()
+        peer = nil
         if let encoder { VTCompressionSessionInvalidate(encoder) }
         encoder = nil
         virtualDisplay = nil   // releasing it removes the display
@@ -592,8 +593,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             self.disconnectedSince = Date()
             self.connectionReady = false
             self.dialGeneration += 1   // a dial still in flight must not adopt
-            self.connection?.cancel()
-            self.connection = nil
+            self.peer?.cancel()
+            self.peer = nil
             self.pendingSends = 0
             self.pipelineLock.lock()
             self.pendingEncodes = 0
@@ -729,7 +730,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     }
 
     /// Bookkeeping shared by both transports once a connection is live.
-    private func becomeReady(_ conn: NWConnection) {
+    private func becomeReady(_ peer: ByteStream) {
         Log.info("connection ready to \(endpointName)")
         connectionReady = true
         everConnected = true
@@ -748,7 +749,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         lastCursorPNGHash = 0
         lastCursorSent = (-1, -1, false)
         lastReceived = Date()  // fresh grace period for the watchdog
-        receiveControl(on: conn)
+        receiveControl(on: peer)
         Task { await self.status("Connected to \(self.endpointName)") }
     }
 
@@ -757,7 +758,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         options.noDelay = true   // latency matters more than throughput here
         let params = NWParameters(tls: nil, tcp: options)
         let conn = NWConnection(to: endpoint, using: params)
-        connection = conn
+        let peer = NetworkByteStream(conn)
+        self.peer = peer
         // A dial to a withdrawn Bonjour service (receiver asleep or app
         // closed) sits in .preparing forever — it neither fails nor resolves
         // when the service later returns, observed on macOS 26. Give every
@@ -767,7 +769,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         let generation = dialGeneration
         queue.asyncAfter(deadline: .now() + 5.0) { [weak self] in
             guard let self, generation == self.dialGeneration, !self.stopped,
-                  self.connection === conn, conn.state != .ready else { return }
+                  self.peer === peer, conn.state != .ready else { return }
             Log.info("dial timed out in \(conn.state) — redialing")
             self.scheduleReconnect()
         }
@@ -775,7 +777,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             guard let self else { return }
             switch state {
             case .ready:
-                self.becomeReady(conn)
+                self.becomeReady(peer)
             case .failed(let error):
                 Log.info("connection failed: \(error)")
                 self.connectionReady = false
@@ -819,7 +821,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                         conn.cancel()
                         return
                     }
-                    self.connection = conn
+                    let peer = NetworkByteStream(conn)
+                    self.peer = peer
                     conn.stateUpdateHandler = { [weak self] state in
                         guard let self else { return }
                         switch state {
@@ -833,7 +836,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                             break
                         }
                     }
-                    self.becomeReady(conn)
+                    self.becomeReady(peer)
                 }
             } catch {
                 queue.async {
@@ -876,8 +879,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         connectionReady = false
         dialGeneration += 1   // a USB dial still in flight must not adopt
         let generation = dialGeneration
-        connection?.cancel()
-        connection = nil
+        peer?.cancel()
+        peer = nil
         pendingSends = 0
         pipelineLock.lock()
         pendingEncodes = 0
@@ -1037,15 +1040,15 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     // MARK: - Control messages (phone -> Mac)
 
-    private func receiveControl(on conn: NWConnection) {
-        conn.receive(minimumIncompleteLength: 4, maximumLength: 4) { [weak self] data, _, _, error in
-            guard let self, error == nil, let data, data.count == 4 else { return }
+    private func receiveControl(on peer: ByteStream) {
+        peer.receive(exactly: 4) { [weak self] data in
+            guard let self, let data else { return }
             let len = Int(UInt32(bigEndian: data.withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }))
             guard len > 0, len < 1 << 20 else { return }
-            conn.receive(minimumIncompleteLength: len, maximumLength: len) { [weak self] payload, _, _, error in
-                guard let self, error == nil, let payload, payload.count == len else { return }
+            peer.receive(exactly: len) { [weak self] payload in
+                guard let self, let payload else { return }
                 self.handleControl(payload)
-                self.receiveControl(on: conn)
+                self.receiveControl(on: peer)
             }
         }
     }
@@ -1578,21 +1581,21 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     }
 
     private func sendJSONFrame(_ json: String) {
-        guard let connection, connectionReady else { return }
+        guard let peer, connectionReady else { return }
         let payload = Data(json.utf8)
         var header = UInt32(payload.count).bigEndian
         var frame = Data(bytes: &header, count: 4)
         frame.append(payload)
-        connection.send(content: frame, completion: .contentProcessed { _ in })
+        peer.send(frame) { _ in }
     }
 
     private func sendFramed(_ payload: Data) {
-        guard let connection, connectionReady else { return }
+        guard let peer, connectionReady else { return }
         var header = UInt32(payload.count).bigEndian
         var frame = Data(bytes: &header, count: 4)
         frame.append(payload)
         pendingSends += 1
-        connection.send(content: frame, completion: .contentProcessed { [weak self] error in
+        peer.send(frame) { [weak self] error in
             guard let self else { return }
             self.pendingSends -= 1
             if let error {
@@ -1610,7 +1613,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 self.statsWindowStart = Date()
                 Task { @MainActor in self.onStats?(frames, mbps) }
             }
-        })
+        }
     }
 
     // MARK: - Helpers

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -151,10 +151,13 @@ final class DeviceSession: ObservableObject, Identifiable {
         self.target = target
         self.name = name
         self.sender = sender
-        if case .usb(let udid) = target {
+        switch target {
+        case .usb(let udid):
             onUSB = true
             usbUDID = udid
-        } else {
+        case .accessory:
+            onUSB = true
+        case .wifi:
             onUSB = false
         }
     }
@@ -303,9 +306,13 @@ final class SenderController: ObservableObject {
             return direct
         }
         return sessions.first { s in
-            guard case .usb(let udid) = s.target else { return false }
+            switch s.target {
+            case .usb, .accessory: break
+            case .wifi: return false
+            }
             if let id = txtID(of: result), s.deviceID == id { return true }
-            if let udid, let device = usbDevices.first(where: { $0.udid == udid }),
+            if case .usb(let udid?) = s.target,
+               let device = usbDevices.first(where: { $0.udid == udid }),
                sameDevice(result, device) { return true }
             // Browse results routinely lack their TXT record and the USB
             // device is gone after a failover — the service name is then
@@ -424,17 +431,19 @@ final class SenderController: ObservableObject {
     /// sessions, the transports steal the receiver's single connection from
     /// each other forever. Keep the cable, drop the WiFi twin.
     private func dedupeSessions() {
-        let usbSessionIDs = Set(sessions.compactMap { s -> String? in
-            if case .usb = s.target { return s.deviceID }
-            return nil
+        let cabledDeviceIDs = Set(sessions.compactMap { s -> String? in
+            switch s.target {
+            case .usb, .accessory: return s.deviceID
+            case .wifi: return nil
+            }
         })
         let cabledNames = Set(usbDevices.compactMap { device in
             session(for: "usb:\(device.udid)") != nil ? device.name : nil
         })
         for s in sessions {
             guard case .wifi(let result) = s.target else { continue }
-            let duplicate = (s.deviceID.map { usbSessionIDs.contains($0) } ?? false)
-                || (txtID(of: result).map { usbSessionIDs.contains($0) } ?? false)
+            let duplicate = (s.deviceID.map { cabledDeviceIDs.contains($0) } ?? false)
+                || (txtID(of: result).map { cabledDeviceIDs.contains($0) } ?? false)
                 || (serviceName(of: result).map { cabledNames.contains($0) } ?? false)
             if duplicate {
                 Log.info("two sessions for one device — keeping the cable, dropping \(s.id)")

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -95,6 +95,7 @@ enum MainWindow {
 enum ConnectionTarget: Hashable {
     case usb(udid: String?)           // wired via built-in usbmuxd; nil = first device
     case wifi(NWBrowser.Result)       // discovered via Bonjour
+    case accessory                    // Android over USB via AOA
 
     /// Stable identity for sessions and persistence — survives Bonjour
     /// re-discovery (fresh NWBrowser.Result) and USB replugs (new DeviceID).
@@ -104,6 +105,7 @@ enum ConnectionTarget: Hashable {
         case .wifi(let result):
             if case .service(let name, _, _, _) = result.endpoint { return "wifi:\(name)" }
             return "wifi:unknown"
+        case .accessory: return "accessory"
         }
     }
 }
@@ -324,6 +326,11 @@ final class SenderController: ObservableObject {
            !usbDisabled.contains("usb:first"), session(for: "usb:first") == nil {
             connect(to: .usb(udid: nil))
         }
+        // Escape hatch until there's UI: `defaults write <bundle> accessory -bool YES`.
+        if UserDefaults.standard.bool(forKey: "accessory"),
+           !usbDisabled.contains("accessory"), session(for: "accessory") == nil {
+            connect(to: .accessory)
+        }
         for device in usbDevices {
             if let covering = activeSession(coveringUSB: device) {
                 // usbDisabled gates auto-connecting a device, not the
@@ -447,6 +454,8 @@ final class SenderController: ObservableObject {
             return udid == nil ? "Manual (\(host):\(port))" : "iPhone / iPad"
         case .wifi(let result):
             return serviceName(of: result) ?? "WiFi device"
+        case .accessory:
+            return "Android (USB)"
         }
     }
 
@@ -491,7 +500,7 @@ final class SenderController: ObservableObject {
 
         // Connecting a device clears its "don't auto-connect" state.
         switch target {
-        case .usb: usbDisabled.remove(id)
+        case .usb, .accessory: usbDisabled.remove(id)
         case .wifi: wifiRemembered.insert(id)
         }
 
@@ -506,6 +515,8 @@ final class SenderController: ObservableObject {
             } else {
                 transport = .usb(udid: udid, port: portNum)
             }
+        case .accessory:
+            transport = .accessory
         case .wifi(let result):
             transport = .tcp(result.endpoint)
         }
@@ -582,7 +593,7 @@ final class SenderController: ObservableObject {
     /// User-initiated disconnect: also opt the device out of auto-connect.
     func disconnect(_ session: DeviceSession) {
         switch session.target {
-        case .usb: usbDisabled.insert(session.id)
+        case .usb, .accessory: usbDisabled.insert(session.id)
         case .wifi: wifiRemembered.remove(session.id)
         }
         // A migrated session is also reachable the other way — opt that side

--- a/Mac/USBAccessory.swift
+++ b/Mac/USBAccessory.swift
@@ -1,0 +1,439 @@
+// AOA transport for Android over USB, no adb.
+//
+// The host puts the device into accessory mode with three vendor control
+// transfers; it drops off the bus and comes back with Google's vendor id
+// and a bulk IN/OUT pair — a byte stream, which is all this protocol needs.
+
+import Foundation
+import IOKit
+import IOUSBHost
+import os
+
+enum AOA {
+    /// Control requests, from the AOA spec.
+    static let getProtocol: UInt8 = 51
+    static let sendString: UInt8 = 52
+    static let start: UInt8 = 53
+
+    /// bmRequestType: vendor request addressed to the device itself.
+    static let vendorIn: UInt8 = 0xC0
+    static let vendorOut: UInt8 = 0x40
+
+    static let googleVendorID = 0x18D1
+    /// 2D00 = accessory only; 2D01 = accessory + adb (USB debugging on).
+    static let accessoryProductIDs: Set<Int> = [0x2D00, 0x2D01]
+
+    static let appleVendorID = 0x05AC
+
+    /// Sent as strings 0...5 during the handshake. Must match the Android
+    /// app's `res/xml/accessory_filter.xml` byte for byte, or the OS never
+    /// offers the app even though the handshake succeeds.
+    static let identity = [
+        "OpenDisplay",                                          // manufacturer
+        "OpenDisplay Receiver",                                 // model
+        "Second display over USB",                              // description
+        "1.0",                                                  // version
+        "https://github.com/josepacelli/opendisplay-android",   // URI
+        "0001",                                                 // serial
+    ]
+
+    /// Covers slow re-enumeration plus the user reading the accessory dialog
+    /// on first plug.
+    static let reenumerationTimeout: TimeInterval = 15
+
+    enum Failure: LocalizedError {
+        case noCandidate
+        case notSupported
+        case timedOut
+        case noInterface
+
+        var errorDescription: String? {
+            switch self {
+            case .noCandidate: "No USB device that could be an Android phone or tablet"
+            case .notSupported: "This device does not support USB accessory mode"
+            case .timedOut: "The device did not come back in accessory mode"
+            case .noInterface: "The accessory exposes no bulk endpoints"
+            }
+        }
+    }
+}
+
+/// `ByteStream` over bulk endpoints. Reads are packet-oriented, not exact —
+/// `pending` accumulates until `receive(exactly:)` has enough.
+final class AccessoryByteStream: ByteStream {
+    private let interface: IOUSBHostInterface
+    private let inPipe: IOUSBHostPipe
+    private let outPipe: IOUSBHostPipe
+    private let packetSize: Int
+
+    // Separate queues: a read parks waiting for data and must not block a
+    // pending write.
+    private let readQueue = DispatchQueue(label: "opendisplay.aoa.read")
+    private let writeQueue = DispatchQueue(label: "opendisplay.aoa.write")
+
+    /// Bytes read but not yet claimed. Touched only on `readQueue`.
+    private var pending = Data()
+
+    private let cancelled = OSAllocatedUnfairLock(initialState: false)
+
+    init(interface: IOUSBHostInterface,
+         inPipe: IOUSBHostPipe, outPipe: IOUSBHostPipe, packetSize: Int) {
+        self.interface = interface
+        self.inPipe = inPipe
+        self.outPipe = outPipe
+        self.packetSize = max(packetSize, 512)
+    }
+
+    func send(_ data: Data, completion: @escaping (Error?) -> Void) {
+        writeQueue.async { [weak self] in
+            guard let self, !self.isCancelled else {
+                completion(AOA.Failure.timedOut)
+                return
+            }
+            let buffer = NSMutableData(data: data)
+            var transferred = 0
+            do {
+                try self.outPipe.__sendIORequest(with: buffer,
+                                                 bytesTransferred: &transferred,
+                                                 completionTimeout: 5)
+                completion(nil)
+            } catch {
+                completion(error)
+            }
+        }
+    }
+
+    func receive(exactly count: Int, completion: @escaping (Data?) -> Void) {
+        readQueue.async { [weak self] in
+            guard let self else {
+                completion(nil)
+                return
+            }
+            while self.pending.count < count {
+                guard !self.isCancelled, self.pullPacket() else {
+                    completion(nil)
+                    return
+                }
+            }
+            let claimed = self.pending.prefix(count)
+            self.pending.removeFirst(count)
+            completion(Data(claimed))
+        }
+    }
+
+    /// One bulk read. False when the pipe is done — cable pulled, accessory
+    /// closed, or `cancel()`.
+    private func pullPacket() -> Bool {
+        let packet = NSMutableData(length: packetSize)!
+        var transferred = 0
+        do {
+            // No timeout: idle is normal. cancel() aborts this read.
+            try inPipe.__sendIORequest(with: packet, bytesTransferred: &transferred,
+                                       completionTimeout: 0)
+        } catch {
+            if !isCancelled { Log.info("accessory read ended: \(error)") }
+            return false
+        }
+        guard transferred > 0 else { return true }   // zero-length packet: benign
+        pending.append((packet as Data).prefix(transferred))
+        return true
+    }
+
+    private var isCancelled: Bool { cancelled.withLock { $0 } }
+
+    func cancel() {
+        let alreadyCancelled = cancelled.withLock { state -> Bool in
+            defer { state = true }
+            return state
+        }
+        guard !alreadyCancelled else { return }
+        // Abort unblocks a parked read; destroy() would otherwise hang on it.
+        try? inPipe.__abort(with: .synchronous)
+        try? outPipe.__abort(with: .synchronous)
+        interface.destroy()
+    }
+}
+
+/// Finds an Android device, walks it into accessory mode, and waits for it
+/// to re-enumerate. Stateful because the device leaves the bus after START —
+/// recovery is an IOKit match notification, which may never fire if the
+/// user dismisses the accessory dialog.
+final class AndroidAccessoryConnector {
+    private let queue: DispatchQueue
+    private var notifyPort: IONotificationPortRef?
+    private var matchIterator: io_iterator_t = 0
+    private var completion: ((Result<AccessoryByteStream, Error>) -> Void)?
+    private var timeout: DispatchWorkItem?
+
+    init(queue: DispatchQueue) {
+        self.queue = queue
+    }
+
+    /// Calls back exactly once, on `queue`.
+    func connect(completion: @escaping (Result<AccessoryByteStream, Error>) -> Void) {
+        self.completion = completion
+
+        // Already in accessory mode (previous run, or another host) — skip
+        // the handshake, it's a no-op on an accessory.
+        if let service = firstAccessory() {
+            defer { IOObjectRelease(service) }
+            finish(openStream(on: service))
+            return
+        }
+
+        guard let candidate = firstAOACapableDevice() else {
+            finish(.failure(AOA.Failure.noCandidate))
+            return
+        }
+        defer { IOObjectRelease(candidate) }
+
+        // Arm before the handshake — re-enumeration can be faster than we'd
+        // arm it afterwards.
+        watchForAccessory()
+
+        do {
+            try performHandshake(on: candidate)
+        } catch {
+            finish(.failure(error))
+        }
+    }
+
+    private func matchingDictionary(vendorID: Int? = nil) -> NSMutableDictionary? {
+        guard let matching = IOServiceMatching("IOUSBHostDevice") as NSMutableDictionary? else {
+            return nil
+        }
+        // idVendor goes under kIOPropertyMatchKey — at the top level it's
+        // silently accepted and never matches anything.
+        if let vendorID { matching[kIOPropertyMatchKey] = ["idVendor": vendorID] }
+        return matching
+    }
+
+    private func services(matching dictionary: NSMutableDictionary) -> [io_service_t] {
+        var iterator: io_iterator_t = 0
+        guard IOServiceGetMatchingServices(kIOMainPortDefault, dictionary, &iterator) == KERN_SUCCESS
+        else { return [] }
+        defer { IOObjectRelease(iterator) }
+        var found: [io_service_t] = []
+        while case let service = IOIteratorNext(iterator), service != 0 {
+            found.append(service)
+        }
+        return found
+    }
+
+    private func firstAccessory() -> io_service_t? {
+        guard let dictionary = matchingDictionary(vendorID: AOA.googleVendorID) else { return nil }
+        let all = services(matching: dictionary)
+        var match: io_service_t?
+        for service in all {
+            if match == nil, AOA.accessoryProductIDs.contains(Self.property(service, "idProduct")) {
+                match = service
+            } else {
+                IOObjectRelease(service)
+            }
+        }
+        return match
+    }
+
+    /// GET_PROTOCOL is the only way to know a device speaks AOA. Skips Apple
+    /// devices — they never answer.
+    private func firstAOACapableDevice() -> io_service_t? {
+        guard let dictionary = matchingDictionary() else { return nil }
+        var chosen: io_service_t?
+        for service in services(matching: dictionary) {
+            let vendor = Self.property(service, "idVendor")
+            if chosen != nil || vendor == AOA.appleVendorID || vendor <= 0 {
+                IOObjectRelease(service)
+                continue
+            }
+            if (try? protocolVersion(of: service)).map({ $0 >= 1 }) == true {
+                chosen = service
+            } else {
+                IOObjectRelease(service)
+            }
+        }
+        return chosen
+    }
+
+    private static func property(_ service: io_service_t, _ key: String) -> Int {
+        guard let value = IORegistryEntryCreateCFProperty(
+            service, key as CFString, kCFAllocatorDefault, 0
+        )?.takeRetainedValue() as? NSNumber else { return -1 }
+        return value.intValue
+    }
+
+    private static func request(_ type: UInt8, _ code: UInt8,
+                                index: UInt16 = 0, length: UInt16 = 0) -> IOUSBDeviceRequest {
+        IOUSBDeviceRequest(bmRequestType: type, bRequest: code,
+                           wValue: 0, wIndex: index, wLength: length)
+    }
+
+    private func protocolVersion(of service: io_service_t) throws -> UInt16 {
+        let device = try IOUSBHostDevice(__ioService: service, options: [],
+                                         queue: nil, interestHandler: nil)
+        defer { device.destroy() }
+        let data = NSMutableData(length: 2)!
+        var transferred = 0
+        try device.__send(Self.request(AOA.vendorIn, AOA.getProtocol, length: 2),
+                          data: data, bytesTransferred: &transferred, completionTimeout: 1)
+        return data.bytes.load(as: UInt16.self)
+    }
+
+    private func performHandshake(on service: io_service_t) throws {
+        let device = try IOUSBHostDevice(__ioService: service, options: [],
+                                         queue: nil, interestHandler: nil)
+        defer { device.destroy() }
+
+        for (index, value) in AOA.identity.enumerated() {
+            let bytes = NSMutableData(data: Data(value.utf8) + [0])   // null-terminated
+            var transferred = 0
+            try device.__send(
+                Self.request(AOA.vendorOut, AOA.sendString,
+                             index: UInt16(index), length: UInt16(bytes.length)),
+                data: bytes, bytesTransferred: &transferred, completionTimeout: 1)
+        }
+        Log.info("AOA: identity sent, requesting accessory mode")
+        // The device disappears from the bus on this one.
+        try device.__send(Self.request(AOA.vendorOut, AOA.start),
+                          data: nil as NSMutableData?,
+                          bytesTransferred: nil as UnsafeMutablePointer<Int>?,
+                          completionTimeout: 1)
+    }
+
+    private func watchForAccessory() {
+        guard let dictionary = matchingDictionary(vendorID: AOA.googleVendorID) else { return }
+        let port = IONotificationPortCreate(kIOMainPortDefault)
+        IONotificationPortSetDispatchQueue(port, queue)
+        notifyPort = port
+
+        let context = Unmanaged.passUnretained(self).toOpaque()
+        let callback: IOServiceMatchingCallback = { refcon, iterator in
+            guard let refcon else { return }
+            Log.info("AOA: match callback fired")
+            Unmanaged<AndroidAccessoryConnector>.fromOpaque(refcon)
+                .takeUnretainedValue()
+                .accessoryAppeared(iterator)
+        }
+        // IOServiceAddMatchingNotification consumes the dictionary reference;
+        // Swift's bridge hands it a +0 one, so passRetained is required or
+        // the notification silently never fires.
+        let retained = Unmanaged.passRetained(dictionary as CFDictionary).takeUnretainedValue()
+        let armed = IOServiceAddMatchingNotification(port, kIOFirstMatchNotification,
+                                                     retained, callback, context, &matchIterator)
+        Log.info("AOA: watching for 18D1 devices (arm=\(armed), iterator=\(matchIterator))")
+        // Draining the iterator is what arms the notification, and catches a
+        // device that showed up between the check above and here.
+        accessoryAppeared(matchIterator)
+
+        let deadline = DispatchWorkItem { [weak self] in
+            self?.finish(.failure(AOA.Failure.timedOut))
+        }
+        timeout = deadline
+        queue.asyncAfter(deadline: .now() + AOA.reenumerationTimeout, execute: deadline)
+    }
+
+    private func accessoryAppeared(_ iterator: io_iterator_t) {
+        var claimed: io_service_t?
+        var seen: [String] = []
+        while case let service = IOIteratorNext(iterator), service != 0 {
+            let pid = Self.property(service, "idProduct")
+            seen.append(String(format: "%04X", pid))
+            if claimed == nil, AOA.accessoryProductIDs.contains(pid) {
+                claimed = service
+            } else {
+                IOObjectRelease(service)
+            }
+        }
+        if !seen.isEmpty {
+            Log.info("AOA: match notification saw \(seen.joined(separator: ", "))")
+        }
+        guard let service = claimed else { return }
+        guard completion != nil else {            // already finished
+            IOObjectRelease(service)
+            return
+        }
+        Log.info("AOA: accessory re-enumerated")
+        openWhenInterfaceAppears(on: service, attemptsLeft: Self.interfaceAttempts)
+    }
+
+    /// The device's `IOUSBHostInterface` child is published a moment after
+    /// the device itself — retry briefly rather than fail, since a real
+    /// absence and not-yet-published look identical.
+    private func openWhenInterfaceAppears(on service: io_service_t, attemptsLeft: Int) {
+        let probe = Self.firstInterface(under: service)
+        if let probe { IOObjectRelease(probe) }
+        if probe == nil, attemptsLeft > 0 {
+            queue.asyncAfter(deadline: .now() + Self.interfaceRetryDelay) { [weak self] in
+                guard let self, self.completion != nil else {
+                    IOObjectRelease(service)
+                    return
+                }
+                self.openWhenInterfaceAppears(on: service, attemptsLeft: attemptsLeft - 1)
+            }
+            return
+        }
+        defer { IOObjectRelease(service) }
+        finish(openStream(on: service))
+    }
+
+    private static let interfaceAttempts = 20
+    private static let interfaceRetryDelay: TimeInterval = 0.1
+
+    private func openStream(on service: io_service_t) -> Result<AccessoryByteStream, Error> {
+        do {
+            // Open only the interface, not the device — opening both fights
+            // for the same exclusive claim and fails intermittently.
+            guard let interfaceService = Self.firstInterface(under: service) else {
+                return .failure(AOA.Failure.noInterface)
+            }
+            defer { IOObjectRelease(interfaceService) }
+
+            let interface = try IOUSBHostInterface(__ioService: interfaceService, options: [],
+                                                   queue: nil, interestHandler: nil)
+            // Accessory mode's one bulk IN/OUT pair, at the standard addresses.
+            let inPipe = try interface.copyPipe(withAddress: 0x81)
+            let outPipe = try interface.copyPipe(withAddress: 0x01)
+            Log.info("AOA: bulk pipes open — accessory transport ready")
+            return .success(AccessoryByteStream(interface: interface,
+                                                inPipe: inPipe, outPipe: outPipe,
+                                                packetSize: 512))
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    private static func firstInterface(under device: io_service_t) -> io_service_t? {
+        var iterator: io_iterator_t = 0
+        guard IORegistryEntryCreateIterator(device, kIOServicePlane,
+                                            IOOptionBits(kIORegistryIterateRecursively),
+                                            &iterator) == KERN_SUCCESS else { return nil }
+        defer { IOObjectRelease(iterator) }
+        while case let child = IOIteratorNext(iterator), child != 0 {
+            if IOObjectConformsTo(child, "IOUSBHostInterface") != 0 { return child }
+            IOObjectRelease(child)
+        }
+        return nil
+    }
+
+    /// Delivers the result once and tears down the watch — every exit path
+    /// goes through here so a late notification can't call back twice.
+    private func finish(_ result: Result<AccessoryByteStream, Error>) {
+        guard let handler = completion else { return }
+        completion = nil
+        timeout?.cancel()
+        timeout = nil
+        if matchIterator != 0 {
+            IOObjectRelease(matchIterator)
+            matchIterator = 0
+        }
+        if let notifyPort {
+            IONotificationPortDestroy(notifyPort)
+            self.notifyPort = nil
+        }
+        handler(result)
+    }
+
+    deinit {
+        if matchIterator != 0 { IOObjectRelease(matchIterator) }
+        if let notifyPort { IONotificationPortDestroy(notifyPort) }
+    }
+}

--- a/Mac/USBAccessory.swift
+++ b/Mac/USBAccessory.swift
@@ -25,16 +25,16 @@ enum AOA {
 
     static let appleVendorID = 0x05AC
 
-    /// Sent as strings 0...5 during the handshake. Must match the Android
-    /// app's `res/xml/accessory_filter.xml` byte for byte, or the OS never
-    /// offers the app even though the handshake succeeds.
+    /// Sent as strings 0...5 during the handshake. manufacturer/model is what
+    /// any Android app should implement  by matching those two in its
+    /// own accessory_filter.xml. The rest is free
     static let identity = [
-        "OpenDisplay",                                          // manufacturer
-        "OpenDisplay Receiver",                                 // model
-        "Second display over USB",                              // description
-        "1.0",                                                  // version
-        "https://github.com/josepacelli/opendisplay-android",   // URI
-        "0001",                                                 // serial
+        "OpenDisplay",                                              // manufacturer
+        "OpenDisplay Receiver",                                     // model
+        "Second display over USB",                                  // description
+        "1.0",                                                      // version
+        "https://github.com/peetzweg/opendisplay#compatible-apps",  // URI
+        "0001",                                                     // serial
     ]
 
     /// Covers slow re-enumeration plus the user reading the accessory dialog


### PR DESCRIPTION
This PR does two things: abstracts the transport behind a `ByteStream` protocol (WiFi/usbmux vs. USB accessory), then adds a USB accessory (AOA) transport for Android. Related to #224 .

No UI yet, so you need to enable with `defaults write com.peetzweg.opensidecar.mac.debug accessory -bool YES`.

I verified it in a Galaxy Tab S9 FE+.

The AOA identity strings (`Mac/USBAccessory.swift`) must match exactly the Android app's `accessory_filter.xml`, tying this PR to one specific implementation (josepacelli/opendisplay-android#33) which is not an official/first-party one. Maybe this should be discussed together with the Android client repo maintainer @josepacelli.

Also, I didn't implement a watcher for a new Android device connected after the app is running. The handshake is tried when OpenDisplay starts. At most we can reconnect to a previously connected Android AOA in the same section. We could iterate in every new usb devices connected from some MacOS notification, so it could be done.