### PR TITLE
feat(ios): share the phone's connection log from Settings & Help

### DIFF
--- a/MacTests/LogSnapshotTests.swift
+++ b/MacTests/LogSnapshotTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+
+final class LogSnapshotTailTests: XCTestCase {
+    private func log(lines: Int) -> Data {
+        Data((0 ..< lines).map { "[00:00:0\($0 % 10)] line \($0)\n" }.joined().utf8)
+    }
+
+    func testAShortLogIsKeptWhole() {
+        let data = log(lines: 3)
+        XCTAssertEqual(LogSnapshot.tail(of: data, maxBytes: 4096), data)
+    }
+
+    func testTheNewestEntriesSurviveNotTheOldest() {
+        let data = log(lines: 200)
+        let kept = LogSnapshot.tail(of: data, maxBytes: 200)
+        let text = String(decoding: kept, as: UTF8.self)
+        XCTAssertTrue(text.hasSuffix("line 199\n"), text)
+        XCTAssertFalse(text.contains("line 0\n"), text)
+        XCTAssertLessThanOrEqual(kept.count, 200)
+    }
+
+    // A byte-offset cut lands mid-line. Half an entry reads as a corrupt file
+    // and sends the reader after the wrong problem, so it is dropped.
+    func testTheSnapshotStartsOnAWholeEntry() {
+        let data = Data("[00:00:01] first\n[00:00:02] second\n".utf8)
+        let kept = LogSnapshot.tail(of: data, maxBytes: 20)
+        XCTAssertEqual(String(decoding: kept, as: UTF8.self), "[00:00:02] second\n")
+    }
+
+    // Nothing guarantees the log has newlines in it at all (a peer could log one
+    // enormous line). Keeping raw bytes beats returning nothing.
+    func testASingleUnbrokenLineIsTruncatedRatherThanDropped() {
+        let data = Data(String(repeating: "x", count: 100).utf8)
+        XCTAssertEqual(LogSnapshot.tail(of: data, maxBytes: 10).count, 10)
+    }
+
+    func testAnEmptyLogAndAZeroCapAreBothHandled() {
+        XCTAssertEqual(LogSnapshot.tail(of: Data(), maxBytes: 4096), Data())
+        XCTAssertEqual(LogSnapshot.tail(of: log(lines: 5), maxBytes: 0), Data())
+    }
+}
+
+final class LogSnapshotComposeTests: XCTestCase {
+    private let context = LogSnapshot.Context(
+        appVersion: "1.16.1",
+        appBuild: "342",
+        model: "iPhone15,3",
+        systemVersion: "18.5",
+        deviceName: "Phil's iPhone"
+    )
+
+    func testTheHeaderNamesTheBuildAndTheDevice() {
+        let out = LogSnapshot.compose(context: context,
+                                      generatedAt: Date(timeIntervalSince1970: 0),
+                                      log: Data("[00:00:01] hello sent\n".utf8))
+        XCTAssertTrue(out.contains("1.16.1 (342)"), out)
+        XCTAssertTrue(out.contains("iPhone15,3, iOS 18.5"), out)
+        XCTAssertTrue(out.contains("Phil's iPhone"), out)
+        XCTAssertTrue(out.hasSuffix("[00:00:01] hello sent\n"), out)
+    }
+
+    // The absence of entries is itself a finding: it says logging never ran,
+    // which is a different bug from the one being reported.
+    func testAnEmptyLogStillProducesAReportableSnapshot() {
+        let out = LogSnapshot.compose(context: context,
+                                      generatedAt: Date(timeIntervalSince1970: 0),
+                                      log: Data())
+        XCTAssertTrue(out.contains("(no entries yet)"), out)
+        XCTAssertTrue(out.contains("iPhone15,3"), out)
+    }
+
+    func testTruncationIsAnnouncedOnlyWhenItHappened() {
+        let short = LogSnapshot.compose(context: context,
+                                        generatedAt: Date(timeIntervalSince1970: 0),
+                                        log: Data("[00:00:01] a\n".utf8))
+        XCTAssertFalse(short.contains("older entries dropped"), short)
+
+        let long = Data((0 ..< 500).map { "[00:00:00] line \($0)\n" }.joined().utf8)
+        let cut = LogSnapshot.compose(context: context,
+                                      generatedAt: Date(timeIntervalSince1970: 0),
+                                      log: long,
+                                      maxBytes: 1024)
+        XCTAssertTrue(cut.contains("older entries dropped"), cut)
+        XCTAssertTrue(cut.hasSuffix("line 499\n"), String(cut.suffix(80)))
+    }
+}
+
+final class LogSnapshotFileNameTests: XCTestCase {
+    private let date = Date(timeIntervalSince1970: 0)
+
+    func testDeviceNamesSurviveEveryFilesystemTheyPassThrough() {
+        let name = LogSnapshot.fileName(deviceName: "Phil's iPad Pro 🎉", date: date)
+        XCTAssertTrue(name.hasPrefix("OpenDisplay-Phil-s-iPad-Pro-"), name)
+        XCTAssertTrue(name.hasSuffix(".txt"), name)
+        XCTAssertFalse(name.contains("--"), name)
+    }
+
+    func testAnUnusableNameFallsBackToATimestampAlone() {
+        let name = LogSnapshot.fileName(deviceName: "///", date: date)
+        XCTAssertTrue(name.hasPrefix("OpenDisplay-"), name)
+        XCTAssertFalse(name.contains("OpenDisplay--"), name)
+        XCTAssertTrue(name.hasSuffix(".txt"), name)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -263,6 +263,21 @@ All live under **Privacy & Security** in System Settings (Mac) / Settings
 without them. If the prompt never appeared, toggle the entry manually or
 force-quit and reopen the app.
 
+### Getting the logs for a bug report
+
+Both apps keep a local log of connection events. Nothing is uploaded anywhere;
+the logs only leave a device when you share them.
+
+- **Mac:** click **Logs** in the app panel. Finder opens with
+  `~/Library/Logs/OpenDisplay` selected.
+- **iPhone/iPad:** shake the device (or tap **Settings & Help** when idle), then
+  open **Connection log**. Share hands the file to Mail, Messages or Files; copy
+  puts the text on the clipboard for pasting straight into an issue.
+
+The phone log is the half usually missing from a WiFi report: whether the
+receiver ever announced itself, whether its listener restarted, whether the
+decoder was failing. Attach both if you can.
+
 ## Roadmap
 
 Tracked as [roadmap issues](https://github.com/peetzweg/opendisplay/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap) — pick one up if you'd like to contribute!

--- a/Shared/LogSnapshot.swift
+++ b/Shared/LogSnapshot.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Builds the artifact someone attaches to a bug report: a short header naming
+/// the build and the device, then the tail of the log file.
+///
+/// Deliberately pure and platform-free. The caller supplies the bytes and the
+/// facts, so the formatting, the truncation boundary and the file naming are all
+/// testable without a device attached.
+enum LogSnapshot {
+    /// How much log a snapshot carries.
+    ///
+    /// Sized for the two things that matter: a report needs the window around
+    /// the failure, not the install's whole history, and a share sheet that
+    /// hands Mail a multi-megabyte attachment gets abandoned instead of sent.
+    /// The phone log is event-driven (connections, orientation, decoder
+    /// trouble), so 256 KB is thousands of entries.
+    static let maxBytes = 256 * 1024
+
+    /// The facts a log line can't carry. Collected by the caller, because
+    /// `UIDevice` and `Bundle` are the app's business and not this file's.
+    struct Context: Equatable {
+        var appVersion: String
+        var appBuild: String
+        /// Hardware identifier ("iPhone15,3"), not `UIDevice.model` ("iPhone").
+        /// The generation is what decides whether a decoder, thermal or
+        /// bandwidth theory is even plausible.
+        var model: String
+        var systemVersion: String
+        /// The name the user set for this device, which is also how it shows up
+        /// in the Mac's WiFi list, so a report can be tied to a Bonjour name.
+        var deviceName: String
+    }
+
+    /// The whole artifact: header, then the newest `maxBytes` of `log`.
+    static func compose(context: Context,
+                        generatedAt: Date,
+                        log: Data,
+                        maxBytes: Int = maxBytes) -> String {
+        let kept = tail(of: log, maxBytes: maxBytes)
+        var out = header(context: context, generatedAt: generatedAt)
+        if kept.count < log.count {
+            // Rounded up: a snapshot that reports "the newest 0 KB" of itself
+            // reads like a bug in the snapshot rather than a truncated log.
+            let kilobytes = (kept.count + 1023) / 1024
+            out += "(older entries dropped, keeping the newest \(kilobytes) KB)\n"
+        }
+        out += "\n"
+        // Lossy decode: the cut can land mid-character, and a snapshot with one
+        // replacement glyph in it beats no snapshot at all.
+        let text = String(decoding: kept, as: UTF8.self)
+        out += text.isEmpty ? "(no entries yet)\n" : text
+        if !out.hasSuffix("\n") { out += "\n" }
+        return out
+    }
+
+    static func header(context: Context, generatedAt: Date) -> String {
+        """
+        OpenDisplay diagnostics
+        Generated: \(timestamp.string(from: generatedAt))
+        App: \(context.appVersion) (\(context.appBuild))
+        Device: \(context.model), iOS \(context.systemVersion)
+        Name: \(context.deviceName)
+
+        """
+    }
+
+    /// The newest `maxBytes` of `data`, cut at a line boundary.
+    static func tail(of data: Data, maxBytes: Int = maxBytes) -> Data {
+        guard maxBytes > 0 else { return Data() }
+        guard data.count > maxBytes else { return Data(data) }
+        let window = data.suffix(maxBytes)
+        // The cut lands mid-line. Drop that partial line so the snapshot opens
+        // on a real entry with a real timestamp: a half line reads as
+        // corruption and invites the wrong conclusion about the log itself.
+        guard let newline = window.firstIndex(of: 0x0A) else { return Data(window) }
+        return Data(window[window.index(after: newline)...])
+    }
+
+    /// A filename that says what it is once it lands in someone else's inbox.
+    ///
+    /// `.txt` rather than `.log`: Mail, Messages and Files preview text inline,
+    /// while `.log` is routinely treated as an unknown binary, and an attachment
+    /// the recipient can't open is one they ask to have resent.
+    static func fileName(deviceName: String, date: Date) -> String {
+        let name = slug(deviceName)
+        let stamp = fileStamp.string(from: date)
+        return name.isEmpty ? "OpenDisplay-\(stamp).txt" : "OpenDisplay-\(name)-\(stamp).txt"
+    }
+
+    /// Device names carry apostrophes, spaces and emoji. Anything that isn't a
+    /// letter or a digit becomes a single dash so the name survives every
+    /// filesystem and mail client it passes through.
+    private static func slug(_ name: String) -> String {
+        let mapped = name.map { $0.isLetter || $0.isNumber ? $0 : "-" }
+        return String(mapped)
+            .split(separator: "-", omittingEmptySubsequences: true)
+            .joined(separator: "-")
+    }
+
+    private static let timestamp: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss ZZZZZ"
+        return f
+    }()
+
+    private static let fileStamp: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyyMMdd-HHmm"
+        return f
+    }()
+}

--- a/iOS/DiagnosticsLogView.swift
+++ b/iOS/DiagnosticsLogView.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+import UIKit
+
+/// The phone half of "send me your logs".
+///
+/// The Mac app has had a Logs button since it shipped; the phone wrote the same
+/// kind of log to Documents and had no way to get it out, so WiFi reports got
+/// diagnosed from the Mac's side plus inference. Every line the phone knows and
+/// the Mac doesn't (whether the receiver ever sent its hello, whether the
+/// listener restarted, whether the decoder was failing) lived here unreachable.
+struct DiagnosticsLogView: View {
+    /// Rendering a whole snapshot in one `Text` is what makes this screen
+    /// stutter, and nobody scrolls 256 KB on a phone anyway. The shared file
+    /// carries everything; the screen carries enough to read the last session.
+    private static let displayedLines = 400
+    private static let bottomAnchor = "bottom"
+
+    @AppStorage("deviceName") private var deviceName = UIDevice.current.name
+    @State private var snapshot: Snapshot = .loading
+    @State private var copied = false
+
+    private enum Snapshot {
+        case loading
+        /// `text` is the whole snapshot (what the copy button puts on the
+        /// clipboard); `display` is the trimmed version the screen draws. Both
+        /// are computed once at load, because the body re-evaluates on every
+        /// unrelated state change and splitting 256 KB into lines per redraw is
+        /// how a log screen ends up stuttering.
+        case ready(url: URL, text: String, display: String)
+        case failed
+    }
+
+    var body: some View {
+        content
+            .navigationTitle("Connection log")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                if case let .ready(url, text, _) = snapshot {
+                    ToolbarItem(placement: .primaryAction) {
+                        ShareLink(item: url) { Image(systemName: "square.and.arrow.up") }
+                    }
+                    ToolbarItem(placement: .primaryAction) {
+                        Button {
+                            UIPasteboard.general.string = text
+                            copied = true
+                        } label: {
+                            Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                        }
+                        .disabled(copied)
+                    }
+                }
+            }
+            .onAppear { load() }
+            .task(id: copied) {
+                guard copied else { return }
+                try? await Task.sleep(nanoseconds: 1_500_000_000)
+                copied = false
+            }
+    }
+
+    @ViewBuilder private var content: some View {
+        switch snapshot {
+        case .loading:
+            ProgressView()
+        case let .ready(_, _, display):
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(spacing: 0) {
+                        Text(display)
+                            .font(.system(.footnote, design: .monospaced))
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal)
+                        // Newest entries are at the bottom and are the ones
+                        // worth reading, so open there, not on the header.
+                        Color.clear
+                            .frame(height: 1)
+                            .id(Self.bottomAnchor)
+                    }
+                }
+                .onAppear { proxy.scrollTo(Self.bottomAnchor, anchor: .bottom) }
+            }
+        case .failed:
+            VStack(spacing: 8) {
+                Image(systemName: "doc.text.magnifyingglass")
+                    .font(.largeTitle)
+                    .foregroundStyle(.secondary)
+                Text("The log could not be read.")
+                Text("Restart OpenDisplay and try again.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .padding()
+        }
+    }
+
+    private func displayText(from text: String) -> String {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        guard lines.count > Self.displayedLines else { return text }
+        return "(showing the last \(Self.displayedLines) entries, the shared file has all of them)\n\n"
+            + lines.suffix(Self.displayedLines).joined(separator: "\n")
+    }
+
+    private func load() {
+        Log.snapshot(context: context) { url in
+            guard let url, let text = try? String(contentsOf: url, encoding: .utf8) else {
+                snapshot = .failed
+                return
+            }
+            snapshot = .ready(url: url, text: text, display: displayText(from: text))
+        }
+    }
+
+    private var context: LogSnapshot.Context {
+        let info = Bundle.main.infoDictionary
+        return LogSnapshot.Context(
+            appVersion: info?["CFBundleShortVersionString"] as? String ?? "dev",
+            appBuild: info?["CFBundleVersion"] as? String ?? "0",
+            model: hardwareModel(),
+            systemVersion: UIDevice.current.systemVersion,
+            deviceName: deviceName
+        )
+    }
+
+    /// "iPhone15,3" rather than `UIDevice.model`'s "iPhone". iOS hides the
+    /// marketing name from apps, and the generation is what decides whether a
+    /// decoder or bandwidth theory is plausible at all.
+    private func hardwareModel() -> String {
+        var system = utsname()
+        guard uname(&system) == 0 else { return "unknown" }
+        return withUnsafeBytes(of: &system.machine) { raw in
+            guard let base = raw.baseAddress else { return "unknown" }
+            return String(cString: base.assumingMemoryBound(to: CChar.self))
+        }
+    }
+}

--- a/iOS/DiagnosticsLogView.swift
+++ b/iOS/DiagnosticsLogView.swift
@@ -97,13 +97,13 @@ struct DiagnosticsLogView: View {
     private func displayText(from text: String) -> String {
         let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
         guard lines.count > Self.displayedLines else { return text }
-        return "(showing the last \(Self.displayedLines) entries, the shared file has all of them)\n\n"
+        return "(showing the last \(Self.displayedLines) lines, the shared file has all of them)\n\n"
             + lines.suffix(Self.displayedLines).joined(separator: "\n")
     }
 
     private func load() {
-        Log.snapshot(context: context) { url in
-            guard let url, let text = try? String(contentsOf: url, encoding: .utf8) else {
+        Log.snapshot(context: context) { result in
+            guard let (url, text) = result else {
                 snapshot = .failed
                 return
             }

--- a/iOS/Log.swift
+++ b/iOS/Log.swift
@@ -1,13 +1,31 @@
 import Foundation
 
 /// Logs to NSLog (visible via `log stream` / simctl) and to a file in the
-/// app's Documents directory (readable via `simctl get_app_container data`).
+/// app's Documents directory.
+///
+/// The file exists so a WiFi or USB failure can be diagnosed from a bug report
+/// instead of guessed at: nobody filing an issue is going to attach a Mac to
+/// their phone and run `log stream`. `snapshot(context:completion:)` turns it
+/// into something shareable from Settings & Help.
 enum Log {
     private static let queue = DispatchQueue(label: "log")
     private static let fileURL: URL = {
         let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         return docs.appendingPathComponent("opensidecar-phone.log")
     }()
+
+    /// Cap on the live file, and what survives a trim.
+    ///
+    /// Entries are event-driven, but the ones that repeat (a decoder failing,
+    /// a listener restarting) can repeat for as long as the app is open, and
+    /// nothing ever cleared this file: an install that has seen a broken
+    /// session grows forever. Keeping the newest half means the trim discards
+    /// history rather than the recent past, which is the half a report needs.
+    /// The floor stays comfortably above `LogSnapshot.maxBytes` so a snapshot
+    /// taken right after a trim still has a full window in it.
+    private static let maxBytes: UInt64 = 1024 * 1024
+    private static let keepBytes = 512 * 1024
+
     private static let formatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "HH:mm:ss.SSS"
@@ -17,14 +35,70 @@ enum Log {
     static func info(_ message: String) {
         NSLog("[opensidecar] %@", message)
         let line = "[\(formatter.string(from: Date()))] \(message)\n"
+        guard let data = line.data(using: .utf8) else { return }
+        queue.async { append(data) }
+    }
+
+    /// Writes the shareable snapshot to a temp file and hands back its URL, or
+    /// nil if it could not be written.
+    ///
+    /// Runs on `queue`, so anything logged a moment ago is already on disk when
+    /// the file is read: the interesting line is usually the last one, and a
+    /// snapshot that races the write that motivated it is worthless. The
+    /// completion lands on the main queue for the caller's UI.
+    static func snapshot(context: LogSnapshot.Context,
+                         completion: @escaping (URL?) -> Void) {
         queue.async {
-            if let handle = try? FileHandle(forWritingTo: fileURL) {
-                handle.seekToEndOfFile()
-                handle.write(line.data(using: .utf8)!)
-                try? handle.close()
-            } else {
-                try? line.write(to: fileURL, atomically: true, encoding: .utf8)
-            }
+            let log = (try? Data(contentsOf: fileURL)) ?? Data()
+            let now = Date()
+            let text = LogSnapshot.compose(context: context, generatedAt: now, log: log)
+            let url = write(text, named: LogSnapshot.fileName(deviceName: context.deviceName,
+                                                             date: now))
+            DispatchQueue.main.async { completion(url) }
+        }
+    }
+
+    // MARK: - File
+
+    /// Serialized by `queue`: this opens and closes a handle per line rather
+    /// than holding one open, because a trim replaces the file and any handle
+    /// held across it would keep writing to the old, unlinked inode.
+    private static func append(_ data: Data) {
+        trimIfNeeded()
+        if let handle = try? FileHandle(forWritingTo: fileURL) {
+            handle.seekToEndOfFile()
+            handle.write(data)
+            try? handle.close()
+        } else {
+            try? data.write(to: fileURL, options: .atomic)
+        }
+    }
+
+    private static func trimIfNeeded() {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path)
+        guard let size = (attributes?[.size] as? NSNumber)?.uint64Value, size > maxBytes,
+              let existing = try? Data(contentsOf: fileURL) else { return }
+        let kept = LogSnapshot.tail(of: existing, maxBytes: keepBytes)
+        try? kept.write(to: fileURL, options: .atomic)
+    }
+
+    private static func write(_ text: String, named name: String) -> URL? {
+        let manager = FileManager.default
+        let directory = manager.temporaryDirectory
+            .appendingPathComponent("Diagnostics", isDirectory: true)
+        // Each share writes a fresh, timestamped file. Clearing the directory
+        // first keeps temp space from accumulating one snapshot per support
+        // request forever; nothing is presenting an older one at this point,
+        // since the share sheet only opens once this returns.
+        try? manager.removeItem(at: directory)
+        do {
+            try manager.createDirectory(at: directory, withIntermediateDirectories: true)
+            let url = directory.appendingPathComponent(name)
+            try text.write(to: url, atomically: true, encoding: .utf8)
+            return url
+        } catch {
+            NSLog("[opensidecar] could not write the log snapshot: %@", error.localizedDescription)
+            return nil
         }
     }
 }

--- a/iOS/Log.swift
+++ b/iOS/Log.swift
@@ -39,22 +39,23 @@ enum Log {
         queue.async { append(data) }
     }
 
-    /// Writes the shareable snapshot to a temp file and hands back its URL, or
-    /// nil if it could not be written.
+    /// Writes the shareable snapshot to a temp file and hands back its URL
+    /// plus the snapshot text, or nil if it could not be written. The text
+    /// rides along so the caller never re-reads the file it was just handed.
     ///
     /// Runs on `queue`, so anything logged a moment ago is already on disk when
     /// the file is read: the interesting line is usually the last one, and a
     /// snapshot that races the write that motivated it is worthless. The
     /// completion lands on the main queue for the caller's UI.
     static func snapshot(context: LogSnapshot.Context,
-                         completion: @escaping (URL?) -> Void) {
+                         completion: @escaping ((url: URL, text: String)?) -> Void) {
         queue.async {
             let log = (try? Data(contentsOf: fileURL)) ?? Data()
             let now = Date()
             let text = LogSnapshot.compose(context: context, generatedAt: now, log: log)
             let url = write(text, named: LogSnapshot.fileName(deviceName: context.deviceName,
                                                              date: now))
-            DispatchQueue.main.async { completion(url) }
+            DispatchQueue.main.async { completion(url.map { ($0, text) }) }
         }
     }
 

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -543,6 +543,18 @@ struct SettingsView: View {
                 }
 
                 Section {
+                    NavigationLink {
+                        DiagnosticsLogView()
+                    } label: {
+                        Label("Connection log", systemImage: "doc.text.magnifyingglass")
+                    }
+                } header: {
+                    Text("Diagnostics")
+                } footer: {
+                    Text("What this \(deviceKind) saw while connecting: sessions, restarts, decoder trouble. No screen content and nothing leaves the \(deviceKind) unless you share it. Attach it to a GitHub issue if a connection won't come up.")
+                }
+
+                Section {
                     Label("USB: plug in the cable, run the Mac app — it connects automatically through the wire (lowest latency).",
                           systemImage: "cable.connector")
                     Label("WiFi: both devices on the same network, then pick this \(deviceKind) in the Mac app's Connection menu.",

--- a/project.yml
+++ b/project.yml
@@ -96,6 +96,7 @@ targets:
       - Mac/DisplayArrangement.swift
       - Mac/Log.swift
       - Mac/LogPolicies.swift
+      - Shared/LogSnapshot.swift
     settings:
       base:
         # A hostless test bundle: the sources under test are compiled straight


### PR DESCRIPTION
Part of https://github.com/peetzweg/opendisplay/issues/137: the phone can now hand over its connection log from Settings & Help.

**Why:** the Mac app has had a Logs button since it shipped, but the phone wrote the same kind of log to its Documents directory with no way to get it out. https://github.com/peetzweg/opendisplay/issues/149 is what that costs. The line that separates "the receiver never tried" from "it tried and the data path was blocked" is `hello sent`, and it sat on the reporter's phone, unreachable, through several rounds of guessing from Mac-side logs.

**How:** a Connection log screen (Settings & Help, new Diagnostics section) shows the recent entries and shares or copies a snapshot: a header naming the build, hardware model and iOS version, then the newest 256 KB of the log. The truncation boundary, header and filename live in `Shared/LogSnapshot.swift` as pure functions, so they are unit-tested on the Mac target rather than only verifiable by hand on a device.

Two judgment calls worth flagging. The live log file was never cleared, it is already 200 KB on my phone, and the entries that repeat (a failing decoder, a restarting listener) repeat for as long as the app is open, so it is now capped at 1 MB and trimmed to its newest half. And a snapshot is `.txt` rather than `.log`, because mail clients preview text inline and treat `.log` as an unknown binary, which is how an attachment comes back with "can you resend that".

This does not close #137: no crash reporting, no Mac-side changes, and nothing to opt into since the file was always being written locally.

Verified on an iPhone 15 Pro. The screen renders, share and copy both work, and the snapshot pulled back off the device carries the header plus the `hello sent` line. 10 new tests, 34 green.
