### PR TITLE
fix: Honor the system capture stop and survive poisoned display identities

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -111,9 +111,12 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // the session — teardown plus auto-connect opt-out — so the app honors
     // the stop instead of fighting it.
     @MainActor var onCaptureStoppedByUser: (() -> Void)?
-    // Fired when the device's base display identity had to be abandoned
-    // (macOS saved hostile state for it — see setupExtend) and a bumped
-    // serial worked: carries the offset for the controller to persist.
+    // Fired when the device's display identity had to be abandoned (macOS
+    // saved hostile state for it — see setupExtend) and a bumped identity
+    // came online instead: carries the validated TOTAL offset from the
+    // device's base identity, for the controller to store as-is. Absolute,
+    // not a delta — repeated bumps in one session must not accumulate into
+    // an offset nothing ever validated.
     @MainActor var onDisplayIdentityBumped: ((UInt32) -> Void)?
 
     private var stream: SCStream?
@@ -132,6 +135,12 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // Stable per-device serial for the virtual display, so macOS can tell
     // multiple OpenDisplay monitors apart and persist their arrangement.
     private let displaySerial: UInt32
+    // How far this device's identity has already moved off its base serial
+    // and productID (identities macOS saved hostile state for are abandoned
+    // permanently — see setupExtend). Advanced in-session when a fallback
+    // identity is validated, so a rotation rebuild doesn't re-probe the
+    // poisoned one.
+    private var baseIdentityOffset: UInt32
 
     // ── Encoder parallelism limiter (maxPendingEncodes = 1) ─────────────────
     //
@@ -279,12 +288,13 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     init(transport: SenderTransport, name: String, mode: CaptureMode,
          quality: StreamQuality = .best, displaySerial: UInt32 = 0x0001,
-         awaitingWake: Bool = false) {
+         identityOffset: UInt32 = 0, awaitingWake: Bool = false) {
         self.transport = transport
         self.endpointName = name
         self.mode = mode
         self.quality = quality
         self.displaySerial = displaySerial
+        self.baseIdentityOffset = identityOffset
         self.awaitingWake = awaitingWake
         super.init()
     }
@@ -402,11 +412,18 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         var display: SCDisplay?
         var identityError = NSError(domain: "MacSender", code: 2,
                                     userInfo: [NSLocalizedDescriptionKey: "CGVirtualDisplay creation failed"])
-        identities: for offset in 0..<UInt32(3) {
-            // A lingering serial belongs to a just-quit twin of the BASE
-            // identity; fresh fallback serials get a shorter window.
+        // Only a created-but-never-surfaced display proves the identity is
+        // poisoned. Creation refusing outright usually means a twin still
+        // holds the serial (just-quit instance, parallel debug build) —
+        // moving to a fallback identity is fine for THIS session, but the
+        // move must not be persisted over a merely-transient condition.
+        var sawPoisonedIdentity = false
+        identities: for probe in 0..<UInt32(3) {
+            let totalOffset = baseIdentityOffset &+ probe
+            // A lingering serial belongs to a just-quit twin of the CURRENT
+            // identity; fresh fallback identities get a shorter window.
             var created: VirtualDisplay?
-            for attempt in 0..<(offset == 0 ? 8 : 3) {
+            for attempt in 0..<(probe == 0 ? 8 : 3) {
                 if attempt > 0 { try await Task.sleep(for: .seconds(2)) }
                 // A Disconnect during the retry window tore the session down. Bail
                 // before creating/assigning the display: the serial the old display
@@ -416,9 +433,15 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 if stopped { return }
                 created = await MainActor.run {
                     let restoreOrigin = DisplayArrangement.origin(for: sizeInPoints, device: arrangementKey)
+                    // The productID moves with the serial: field data in #206
+                    // suggests some macOS versions key the hostile state on
+                    // the product, not the serial — bumping both escapes
+                    // either keying.
                     return VirtualDisplay(name: displayName,
                                           pointsWide: pointsWide, pointsHigh: pointsHigh,
-                                          sizeInMillimeters: mm, serialNum: serial &+ offset,
+                                          sizeInMillimeters: mm,
+                                          serialNum: serial &+ totalOffset,
+                                          productID: 0x4F53 &+ totalOffset,
                                           restoreOrigin: restoreOrigin,
                                           onOriginChange: { origin, currentSize in
                                               DisplayArrangement.save(origin: origin, size: currentSize,
@@ -426,7 +449,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                                           })
                 }
                 if created != nil { break }
-                Log.info("virtual display creation failed (serial +\(offset), attempt \(attempt + 1)) — retrying")
+                Log.info("virtual display creation failed (identity +\(totalOffset), attempt \(attempt + 1)) — retrying")
                 await status("Preparing virtual display…")
             }
             guard let candidate = created else { continue }
@@ -434,10 +457,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             do {
                 display = try await findSCDisplay(id: candidate.displayID)
                 vd = candidate
-                if offset > 0 {
-                    Log.info("display identity +\(offset) came online — the base serial is "
+                if probe > 0, sawPoisonedIdentity {
+                    Log.info("display identity +\(totalOffset) came online — the previous one is "
                         + "poisoned by saved system state; persisting the offset")
-                    Task { @MainActor in self.onDisplayIdentityBumped?(offset) }
+                    baseIdentityOffset = totalOffset   // rebuilds skip the dead probe
+                    Task { @MainActor in self.onDisplayIdentityBumped?(totalOffset) }
                 }
                 break identities
             } catch {
@@ -446,12 +470,20 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 // a different identity cannot help there.
                 if (error as NSError).domain == "MacSender", (error as NSError).code == 4 { throw error }
                 identityError = error as NSError
+                sawPoisonedIdentity = true
                 if stopped { return }
-                Log.info("virtual display (serial +\(offset)) never came online — trying a fresh identity")
+                Log.info("virtual display (identity +\(totalOffset)) never came online — trying a fresh identity")
                 await status("Display blocked by saved macOS state — trying a fresh identity…")
             }
         }
-        guard let vd, let display else { throw identityError }
+        guard let vd, let display else {
+            if sawPoisonedIdentity {
+                throw NSError(domain: "MacSender", code: 5, userInfo: [
+                    NSLocalizedDescriptionKey: "saved display state in macOS is blocking "
+                        + "OpenDisplay's displays — log out and back in (or restart the Mac), then reconnect"])
+            }
+            throw identityError
+        }
         inputInjector = InputInjector(displayID: vd.displayID)
         // Quality scaling: capture/encode below native when requested — the
         // display itself stays native so window layout is unaffected.
@@ -563,8 +595,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // must not burn fallback identities on it.
         if lastDisplayCount == 0 {
             throw NSError(domain: "MacSender", code: 4,
-                          userInfo: [NSLocalizedDescriptionKey: "macOS lists no capturable displays — "
-                              + "re-grant Screen Recording in System Settings, then relaunch"])
+                          userInfo: [NSLocalizedDescriptionKey: "macOS returned no capturable displays — "
+                              + "the screen may be locked; if this persists unlocked, re-grant "
+                              + "Screen Recording in System Settings and relaunch"])
         }
         throw NSError(domain: "MacSender", code: 3,
                       userInfo: [NSLocalizedDescriptionKey: "virtual display never appeared in SCShareableContent"])
@@ -607,6 +640,12 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         lastCursorPNGHash = 0      // rotation rebuilds: re-send the sprite
         lastCursorSent = (-1, -1, false)
         startCursorEcho()
+        // A capture that came back through any path (recovery, rotation,
+        // identity fallback) earns the full recovery budget again — without
+        // this, a pending recovery timer that finds the stream alive exits
+        // without ever resetting the counter, and the next unrelated death
+        // starts with as little as one round left.
+        queue.async { self.captureRecoveryFailures = 0 }
         Log.info("capture started: \(pixelsWide)x\(pixelsHigh) display \(display.displayID) generation \(generation) mode \(mode.rawValue) localCursor=\(localCursor)")
         let kind = lastHello?.kind ?? "device"
         await status("\(mode == .extend ? "Extending to" : "Mirroring to") \(kind) (\(pixelsWide)×\(pixelsHigh))")
@@ -723,7 +762,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // answers such defiance by saving display state that keeps this
         // identity from ever coming online again (#206). Hand it to the
         // controller to honor exactly like the in-app Disconnect.
-        if let scError = error as? SCStreamError, scError.code == .userStopped {
+        if let scError = error as? SCStreamError, scError.code == .userStopped,
+           consoleIsInteractive {
             Task { @MainActor in self.onCaptureStoppedByUser?() }
             return
         }
@@ -779,6 +819,19 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 self.queue.async { self.recoveryRoundEnded() }
             }
         }
+    }
+
+    /// SCK can report `.userStopped` for stops the user did not initiate
+    /// when the console goes non-interactive (screen lock, fast user
+    /// switch). Only a stop from an interactive console can be a deliberate
+    /// menu-bar "stop sharing"; everything else stays on the recovery path,
+    /// which was already how those transitions healed before this check
+    /// existed.
+    private var consoleIsInteractive: Bool {
+        guard let info = CGSessionCopyCurrentDictionary() as? [String: Any] else { return true }
+        let onConsole = info[kCGSessionOnConsoleKey as String] as? Bool ?? true
+        let locked = info["CGSSessionScreenIsLocked"] as? Bool ?? false
+        return onConsole && !locked
     }
 
     /// On `queue`: after a recovery round, re-arm the loop while capture is

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -106,6 +106,15 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // Fired on every hello — carries the receiver's install id so the
     // controller can deduplicate USB/WiFi sessions to the same device.
     @MainActor var onHello: ((PhoneInfo) -> Void)?
+    // Fired when the user stopped the capture from the system UI (menu-bar
+    // recording indicator / "Stop Extending"). The controller disconnects
+    // the session — teardown plus auto-connect opt-out — so the app honors
+    // the stop instead of fighting it.
+    @MainActor var onCaptureStoppedByUser: (() -> Void)?
+    // Fired when the device's base display identity had to be abandoned
+    // (macOS saved hostile state for it — see setupExtend) and a bumped
+    // serial worked: carries the offset for the controller to persist.
+    @MainActor var onDisplayIdentityBumped: ((UInt32) -> Void)?
 
     private var stream: SCStream?
     private var encoder: VTCompressionSession?
@@ -187,6 +196,15 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // not "app closed" — surface that instead of the usual hints. Cleared by
     // the first successful connection.
     private var awaitingWake: Bool
+
+    // A capture that keeps dying is not coming back on its own (capture
+    // authorization revoked, or saved display state blocks the identity) —
+    // retrying forever spams WindowServer with create/destroy cycles and,
+    // after a user-initiated stop, amounts to defying the user. Counted per
+    // failed recovery round, reset by a capture that comes back up. On
+    // `queue`.
+    private var captureRecoveryFailures = 0
+    private let maxCaptureRecoveryFailures = 5
 
     // Consecutive actively-refused dials on a previously connected session.
     // Refusal is unambiguous: the device is reachable but nothing listens,
@@ -370,38 +388,71 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // just-quit instance's display lingers in WindowServer for a moment
         // after the process dies. Retry through that window instead of
         // parking the session on "Failed" until a manual reconnect.
+        //
+        // macOS also keys SAVED display state on this identity, and that
+        // state can be hostile: the system UI's "Stop Extending" records a
+        // config under which the identity never comes online again —
+        // creation "succeeds" but the display joins neither the active
+        // display list nor shareable content (#206, #221). Unlike the saved
+        // mirror-set (#100) and 1x-mode variants, no post-creation
+        // enforcement can undo that, so an identity that never surfaces is
+        // abandoned for a fresh serial. The controller persists the working
+        // offset, so the device skips its poisoned identities from then on.
         var vd: VirtualDisplay?
-        for attempt in 0..<8 {
-            if attempt > 0 { try await Task.sleep(for: .seconds(2)) }
-            // A Disconnect during the retry window tore the session down. Bail
-            // before creating/assigning the display: the serial the old display
-            // held is likely free now, so a late attempt would *succeed* and
-            // resurrect the very zombie this retry exists to avoid. (Mirrors the
-            // `if stopped` checks in the permission-poll loops above.)
-            if stopped { return }
-            vd = await MainActor.run {
-                let restoreOrigin = DisplayArrangement.origin(for: sizeInPoints, device: arrangementKey)
-                return VirtualDisplay(name: displayName,
-                                      pointsWide: pointsWide, pointsHigh: pointsHigh,
-                                      sizeInMillimeters: mm, serialNum: serial,
-                                      restoreOrigin: restoreOrigin,
-                                      onOriginChange: { origin, currentSize in
-                                          DisplayArrangement.save(origin: origin, size: currentSize,
-                                                                  device: arrangementKey)
-                                      })
+        var display: SCDisplay?
+        var identityError = NSError(domain: "MacSender", code: 2,
+                                    userInfo: [NSLocalizedDescriptionKey: "CGVirtualDisplay creation failed"])
+        identities: for offset in 0..<UInt32(3) {
+            // A lingering serial belongs to a just-quit twin of the BASE
+            // identity; fresh fallback serials get a shorter window.
+            var created: VirtualDisplay?
+            for attempt in 0..<(offset == 0 ? 8 : 3) {
+                if attempt > 0 { try await Task.sleep(for: .seconds(2)) }
+                // A Disconnect during the retry window tore the session down. Bail
+                // before creating/assigning the display: the serial the old display
+                // held is likely free now, so a late attempt would *succeed* and
+                // resurrect the very zombie this retry exists to avoid. (Mirrors the
+                // `if stopped` checks in the permission-poll loops above.)
+                if stopped { return }
+                created = await MainActor.run {
+                    let restoreOrigin = DisplayArrangement.origin(for: sizeInPoints, device: arrangementKey)
+                    return VirtualDisplay(name: displayName,
+                                          pointsWide: pointsWide, pointsHigh: pointsHigh,
+                                          sizeInMillimeters: mm, serialNum: serial &+ offset,
+                                          restoreOrigin: restoreOrigin,
+                                          onOriginChange: { origin, currentSize in
+                                              DisplayArrangement.save(origin: origin, size: currentSize,
+                                                                      device: arrangementKey)
+                                          })
+                }
+                if created != nil { break }
+                Log.info("virtual display creation failed (serial +\(offset), attempt \(attempt + 1)) — retrying")
+                await status("Preparing virtual display…")
             }
-            if vd != nil { break }
-            Log.info("virtual display creation failed (attempt \(attempt + 1)) — retrying")
-            await status("Preparing virtual display…")
+            guard let candidate = created else { continue }
+            virtualDisplay = candidate
+            do {
+                display = try await findSCDisplay(id: candidate.displayID)
+                vd = candidate
+                if offset > 0 {
+                    Log.info("display identity +\(offset) came online — the base serial is "
+                        + "poisoned by saved system state; persisting the offset")
+                    Task { @MainActor in self.onDisplayIdentityBumped?(offset) }
+                }
+                break identities
+            } catch {
+                virtualDisplay = nil   // release the dead display and its serial
+                // No shareable displays at all is a permission-side failure —
+                // a different identity cannot help there.
+                if (error as NSError).domain == "MacSender", (error as NSError).code == 4 { throw error }
+                identityError = error as NSError
+                if stopped { return }
+                Log.info("virtual display (serial +\(offset)) never came online — trying a fresh identity")
+                await status("Display blocked by saved macOS state — trying a fresh identity…")
+            }
         }
-        guard let vd else {
-            throw NSError(domain: "MacSender", code: 2,
-                          userInfo: [NSLocalizedDescriptionKey: "CGVirtualDisplay creation failed"])
-        }
-        virtualDisplay = vd
+        guard let vd, let display else { throw identityError }
         inputInjector = InputInjector(displayID: vd.displayID)
-
-        let display = try await findSCDisplay(id: vd.displayID)
         // Quality scaling: capture/encode below native when requested — the
         // display itself stays native so window layout is unaffected.
         let captureW = (Int(Double(pointsWide * 2) * quality.scale)) & ~1
@@ -493,8 +544,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     /// The virtual display takes a moment to show up in shareable content.
     private func findSCDisplay(id: CGDirectDisplayID, expectedSize: CGSize? = nil) async throws -> SCDisplay {
+        var lastDisplayCount = 0
         for _ in 0..<20 {
             let content = try await SCShareableContent.current
+            lastDisplayCount = content.displays.count
             if let display = content.displays.first(where: {
                 $0.displayID == id
                     && (expectedSize == nil
@@ -504,6 +557,14 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 return display
             }
             try await Task.sleep(for: .milliseconds(250))
+        }
+        // An empty display list is a different disease from "ours is
+        // missing": capture authorization is broken app-wide, and callers
+        // must not burn fallback identities on it.
+        if lastDisplayCount == 0 {
+            throw NSError(domain: "MacSender", code: 4,
+                          userInfo: [NSLocalizedDescriptionKey: "macOS lists no capturable displays — "
+                              + "re-grant Screen Recording in System Settings, then relaunch"])
         }
         throw NSError(domain: "MacSender", code: 3,
                       userInfo: [NSLocalizedDescriptionKey: "virtual display never appeared in SCShareableContent"])
@@ -656,6 +717,16 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // already live. It must not tear down that replacement (#203).
         guard stream === self.stream else { return }
         Log.info("stream stopped with error: \(error)")
+        // The user stopped this capture from the system UI (the menu bar's
+        // recording indicator / "Stop Extending"). That is a disconnect, not
+        // a fault: restarting capture would defy the user — and macOS
+        // answers such defiance by saving display state that keeps this
+        // identity from ever coming online again (#206). Hand it to the
+        // controller to honor exactly like the in-app Disconnect.
+        if let scError = error as? SCStreamError, scError.code == .userStopped {
+            Task { @MainActor in self.onCaptureStoppedByUser?() }
+            return
+        }
         Task { await status("Capture stopped: \(error.localizedDescription)") }
         // E.g. display sleep can tear the virtual display down underneath the
         // stream — rebuild instead of sitting dead until an app restart.
@@ -697,9 +768,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                         Log.info("re-attach failed (\(error)) — falling back to full rebuild")
                         await self.reconfigure(hello)
                     }
-                    self.queue.async {
-                        if self.stream == nil { self.scheduleCaptureRecovery() }
-                    }
+                    self.queue.async { self.recoveryRoundEnded() }
                 }
                 return
             }
@@ -707,11 +776,28 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             Log.info("capture died — rebuilding pipeline")
             Task {
                 await self.reconfigure(hello)
-                self.queue.async {
-                    if self.stream == nil { self.scheduleCaptureRecovery() }
-                }
+                self.queue.async { self.recoveryRoundEnded() }
             }
         }
+    }
+
+    /// On `queue`: after a recovery round, re-arm the loop while capture is
+    /// still down — up to the cap, then declare the session gone. A capture
+    /// dead this many rounds is not coming back by itself, and ending the
+    /// session (display torn down, reconnect is the user's call) beats
+    /// hammering WindowServer with create/destroy cycles forever.
+    private func recoveryRoundEnded() {
+        guard stream == nil else {
+            captureRecoveryFailures = 0
+            return
+        }
+        captureRecoveryFailures += 1
+        guard captureRecoveryFailures < maxCaptureRecoveryFailures else {
+            Task { await status("Capture could not be restarted") }
+            reportGone("capture recovery failed \(captureRecoveryFailures)x — ending session")
+            return
+        }
+        scheduleCaptureRecovery()
     }
 
     // MARK: - Connection (with retry)

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -289,10 +289,12 @@ final class SenderController: ObservableObject {
     }
 
     /// The session (over either transport) already serving this USB device.
+    /// A failed session serves nothing — it must not block auto-connecting
+    /// the same physical device over the other transport.
     private func activeSession(coveringUSB device: UsbmuxDevice) -> DeviceSession? {
-        if let direct = session(for: "usb:\(device.udid)") { return direct }
+        if let direct = session(for: "usb:\(device.udid)"), !direct.failed { return direct }
         return sessions.first { s in
-            guard case .wifi(let result) = s.target else { return false }
+            guard !s.failed, case .wifi(let result) = s.target else { return false }
             if let id = installIDByUDID[device.udid],
                s.deviceID == id || txtID(of: result) == id { return true }
             return serviceName(of: result) != nil && device.name == serviceName(of: result)
@@ -300,12 +302,14 @@ final class SenderController: ObservableObject {
     }
 
     /// The session (over either transport) already serving this WiFi service.
+    /// Failed sessions are excluded for the same reason as above.
     private func activeSession(coveringWiFi result: NWBrowser.Result) -> DeviceSession? {
-        if let name = serviceName(of: result), let direct = session(for: "wifi:\(name)") {
+        if let name = serviceName(of: result), let direct = session(for: "wifi:\(name)"),
+           !direct.failed {
             return direct
         }
         return sessions.first { s in
-            guard case .usb(let udid) = s.target else { return false }
+            guard !s.failed, case .usb(let udid) = s.target else { return false }
             if let id = txtID(of: result), s.deviceID == id { return true }
             if let udid, let device = usbDevices.first(where: { $0.udid == udid }),
                sameDevice(result, device) { return true }
@@ -421,12 +425,15 @@ final class SenderController: ObservableObject {
     /// sessions, the transports steal the receiver's single connection from
     /// each other forever. Keep the cable, drop the WiFi twin.
     private func dedupeSessions() {
+        // Failed sessions hold no pipeline: a USB corpse must never win the
+        // "keep the cable" rule against a working WiFi session.
         let usbSessionIDs = Set(sessions.compactMap { s -> String? in
-            if case .usb = s.target { return s.deviceID }
+            if case .usb = s.target, !s.failed { return s.deviceID }
             return nil
         })
-        let cabledNames = Set(usbDevices.compactMap { device in
-            session(for: "usb:\(device.udid)") != nil ? device.name : nil
+        let cabledNames = Set(usbDevices.compactMap { device -> String? in
+            guard let s = session(for: "usb:\(device.udid)"), !s.failed else { return nil }
+            return device.name
         })
         for s in sessions {
             guard case .wifi(let result) = s.target else { continue }
@@ -468,13 +475,12 @@ final class SenderController: ObservableObject {
     }
 
     // A display identity macOS saved hostile state for (see
-    // MacSender.setupExtend) is abandoned permanently: the offset that came
-    // online instead is persisted per session id and folded into every
-    // future serial for that device.
-    private static func serialBumpKey(for id: String) -> String { "displaySerialBump.\(id)" }
-    private func effectiveSerial(for id: String) -> UInt32 {
-        Self.displaySerial(for: id)
-            &+ UInt32(clamping: UserDefaults.standard.integer(forKey: Self.serialBumpKey(for: id)))
+    // MacSender.setupExtend) is abandoned permanently: the validated offset
+    // from the device's base identity is persisted per session id and every
+    // future session starts from it.
+    private static func identityOffsetKey(for id: String) -> String { "displaySerialBump.\(id)" }
+    private func identityOffset(for id: String) -> UInt32 {
+        UInt32(clamping: UserDefaults.standard.integer(forKey: Self.identityOffsetKey(for: id)))
     }
 
     func connect(to target: ConnectionTarget, userInitiated: Bool = false,
@@ -531,7 +537,8 @@ final class SenderController: ObservableObject {
 
         let name = label(for: target)
         let sender = MacSender(transport: transport, name: name, mode: mode,
-                               quality: quality, displaySerial: effectiveSerial(for: id),
+                               quality: quality, displaySerial: Self.displaySerial(for: id),
+                               identityOffset: identityOffset(for: id),
                                awaitingWake: awaitingWake)
         let session = DeviceSession(id: id, target: target, name: name, sender: sender)
         if case .wifi(let result) = target {
@@ -588,12 +595,13 @@ final class SenderController: ObservableObject {
             Log.info("session \(session.id) capture stopped via the system UI — honoring as disconnect")
             self.disconnect(session)
         }
-        sender.onDisplayIdentityBumped = { [weak session] offset in
+        sender.onDisplayIdentityBumped = { [weak session] totalOffset in
+            // The sender reports the validated absolute offset — store it
+            // as-is. Adding would double-count when a rotation rebuild
+            // re-discovers the same poisoned identity within one session.
             guard let session else { return }
-            let key = Self.serialBumpKey(for: session.id)
-            let total = UserDefaults.standard.integer(forKey: key) + Int(offset)
-            UserDefaults.standard.set(total, forKey: key)
-            Log.info("display identity for \(session.id) moved to serial offset \(total) — "
+            UserDefaults.standard.set(Int(totalOffset), forKey: Self.identityOffsetKey(for: session.id))
+            Log.info("display identity for \(session.id) moved to offset \(totalOffset) — "
                 + "macOS saved hostile state for the old one")
         }
         sender.onPeerClosed = { [weak self, weak session] in

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -122,6 +122,10 @@ final class DeviceSession: ObservableObject, Identifiable {
     @Published var status = "Starting…"
     @Published var framesSent = 0
     @Published var mbps = 0.0
+    // The sender's start() threw: the pipeline is freed, only this row's
+    // error text remains. A failed session must never swallow a fresh
+    // connect for its device the way a live one does.
+    @Published var failed = false
     // Receiver's per-install identity (from hello) — the key for recognizing
     // the same physical device across USB and WiFi.
     var deviceID: String?
@@ -463,10 +467,25 @@ final class SenderController: ObservableObject {
         return hash == 0 ? 1 : hash
     }
 
+    // A display identity macOS saved hostile state for (see
+    // MacSender.setupExtend) is abandoned permanently: the offset that came
+    // online instead is persisted per session id and folded into every
+    // future serial for that device.
+    private static func serialBumpKey(for id: String) -> String { "displaySerialBump.\(id)" }
+    private func effectiveSerial(for id: String) -> UInt32 {
+        Self.displaySerial(for: id)
+            &+ UInt32(clamping: UserDefaults.standard.integer(forKey: Self.serialBumpKey(for: id)))
+    }
+
     func connect(to target: ConnectionTarget, userInitiated: Bool = false,
                  awaitingWake: Bool = false) {
         let id = target.sessionID
-        guard session(for: id) == nil else { return }
+        if let existing = session(for: id) {
+            // A failed session holds no pipeline — replace the corpse
+            // instead of letting it swallow the fresh attempt.
+            guard existing.failed else { return }
+            end(existing)
+        }
 
         // Never create a second session for the same physical device — the
         // receiver holds one connection, so a twin would steal it. But an
@@ -512,14 +531,17 @@ final class SenderController: ObservableObject {
 
         let name = label(for: target)
         let sender = MacSender(transport: transport, name: name, mode: mode,
-                               quality: quality, displaySerial: Self.displaySerial(for: id),
+                               quality: quality, displaySerial: effectiveSerial(for: id),
                                awaitingWake: awaitingWake)
         let session = DeviceSession(id: id, target: target, name: name, sender: sender)
         if case .wifi(let result) = target {
             session.wifiServiceName = serviceName(of: result)
         }
         sender.onStatus = { [weak session] text in
-            session?.status = text
+            // Retry loops re-announce the same status every second (e.g. the
+            // asleep wait) — only a change is worth the UI churn and the log line.
+            guard let session, session.status != text else { return }
+            session.status = text
             Log.info("status[\(id)]: \(text)")
         }
         sender.onHello = { [weak self, weak session] info in
@@ -558,6 +580,22 @@ final class SenderController: ObservableObject {
             self.end(session)
             self.connect(to: target, awaitingWake: true)
         }
+        sender.onCaptureStoppedByUser = { [weak self, weak session] in
+            // The user stopped the capture in the system UI — same intent as
+            // the in-app Disconnect, so it also opts the device out of
+            // auto-connect (or the next browse event would resurrect it).
+            guard let self, let session else { return }
+            Log.info("session \(session.id) capture stopped via the system UI — honoring as disconnect")
+            self.disconnect(session)
+        }
+        sender.onDisplayIdentityBumped = { [weak session] offset in
+            guard let session else { return }
+            let key = Self.serialBumpKey(for: session.id)
+            let total = UserDefaults.standard.integer(forKey: key) + Int(offset)
+            UserDefaults.standard.set(total, forKey: key)
+            Log.info("display identity for \(session.id) moved to serial offset \(total) — "
+                + "macOS saved hostile state for the old one")
+        }
         sender.onPeerClosed = { [weak self, weak session] in
             // The receiver app quit — a deliberate goodbye, so no reconnect
             // waits around. Reopening the app is a fresh start handled by
@@ -575,6 +613,11 @@ final class SenderController: ObservableObject {
             } catch {
                 Log.info("sender failed to start: \(error)")
                 session.status = "Failed: \(error.localizedDescription)"
+                // Free the half-built pipeline: a leaked virtual display
+                // would keep holding this device's serial, and a parked
+                // live-looking session would swallow every future connect.
+                session.failed = true
+                sender.stop()
             }
         }
     }
@@ -594,6 +637,15 @@ final class SenderController: ObservableObject {
 
     func disconnectAll() {
         sessions.forEach { disconnect($0) }
+    }
+
+    /// Restart a session that failed to start (its pipeline is already
+    /// freed): tear the corpse out and dial the same target fresh. The
+    /// socket-only Reconnect can't help there — nothing was ever built.
+    func retry(_ session: DeviceSession) {
+        let target = session.target
+        end(session)
+        connect(to: target, userInitiated: true)
     }
 
     private func end(_ session: DeviceSession) {
@@ -1016,12 +1068,18 @@ struct SessionRow: View {
                     .foregroundStyle(.secondary)
             }
             Button {
-                session.sender.forceReconnect()
+                if session.failed {
+                    controller.retry(session)
+                } else {
+                    session.sender.forceReconnect()
+                }
             } label: {
                 Image(systemName: "arrow.clockwise")
             }
             .controlSize(.small)
-            .help("Drop the connection and pair with the device again")
+            .help(session.failed
+                ? "Start this connection over"
+                : "Drop the connection and pair with the device again")
             Button("Disconnect") { controller.disconnect(session) }
                 .controlSize(.small)
         }

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -27,7 +27,8 @@ final class VirtualDisplay {
     /// `onOriginChange` reports where the display sits afterwards, so the
     /// caller can persist user drags.
     init?(name: String, pointsWide: Int, pointsHigh: Int, sizeInMillimeters: CGSize,
-          serialNum: UInt32 = 0x0001, restoreOrigin: CGPoint? = nil,
+          serialNum: UInt32 = 0x0001, productID: UInt32 = 0x4F53,
+          restoreOrigin: CGPoint? = nil,
           onOriginChange: ((CGPoint, CGSize) -> Void)? = nil) {
         self.pointsWide = pointsWide
         self.pointsHigh = pointsHigh
@@ -45,8 +46,10 @@ final class VirtualDisplay {
         descriptor.maxPixelsWide = UInt32(maxPointsPerAxis * 2)
         descriptor.maxPixelsHigh = UInt32(maxPointsPerAxis * 2)
         descriptor.sizeInMillimeters = sizeInMillimeters
-        descriptor.productID = 0x4F53   // "OS"
-        descriptor.vendorID = 0x5043    // "PC"
+        descriptor.productID = productID   // base 0x4F53 "OS"; moves with the
+                                           // serial when an identity is
+                                           // abandoned (see MacSender)
+        descriptor.vendorID = 0x5043       // "PC"
         descriptor.serialNum = serialNum
         descriptor.terminationHandler = { _, _ in
             Log.info("virtual display terminated by the system")


### PR DESCRIPTION
Fixes #230. Most likely also resolves #206 and #221 (same error, same persistence).

Stopping a session from the macOS system UI ("Stop Extending") makes WindowServer save a hostile config (`IndependentOutput`) for our deterministic display serial, and it re-applies that config on every recreate: the display never comes online again and every session fails with "virtual display never appeared in SCShareableContent". This PR makes the Mac app survive that state and stop provoking it.

**Why:** users who stop via the system indicator instead of the in-app Disconnect end up permanently unable to reconnect, across app restarts and even permission resets. Full diagnosis in #230.

**How:** `setupExtend` abandons an identity that never comes online and retries with serial+1, persisting the offset per device. `SCStreamError.userStopped` is now honored as a disconnect (with auto-connect opt-out) instead of auto-restarting capture against the user's intent, the capture recovery loop is bounded at 5 rounds, and a session whose `start()` threw frees its pipeline instead of leaking the display and swallowing every later connect. Judgment call: an identity bump is permanent per device; macOS-side arrangement starts fresh for the new serial, but our install-id keyed arrangement memory (#116) restores placement.

Verified on the poisoned machine: serial+0 times out, serial+1 extends in under a second, next launch extends in 0.6s via the persisted offset. Existing test suite passes (34).
