### PR TITLE
fix(ios): Show a waiting notice instead of a silent black screen

### DIFF
--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -77,6 +77,20 @@ struct ReceiverScreen: View {
                                    useMetal: metalRenderer)
                         .id(metalRenderer)   // rebuild the layer tree on toggle
                         .ignoresSafeArea()
+                    // Connected but no frames coming: without this the screen
+                    // is silently black while the Mac sorts itself out (e.g.
+                    // the poisoned-identity recovery, #230).
+                    if model.receiver.awaitingVideo {
+                        VStack(spacing: 14) {
+                            ProgressView()
+                                .tint(.white)
+                            Text("Connected — waiting for video from the Mac…")
+                                .font(.callout)
+                                .foregroundStyle(.white.opacity(0.85))
+                        }
+                        .allowsHitTesting(false)   // never block touch input
+                        .transition(.opacity)
+                    }
                     if showAnalytics {
                         VStack {
                             Spacer()
@@ -90,6 +104,7 @@ struct ReceiverScreen: View {
                     IdleView(receiver: model.receiver, showSettings: $showSettings)
                 }
             }
+            .animation(.easeInOut(duration: 0.3), value: model.receiver.awaitingVideo)
             .onAppear { model.receiver.setOrientation(portrait: geo.size.height > geo.size.width) }
             .onChange(of: geo.size) { size in
                 model.receiver.setOrientation(portrait: size.height > size.width)

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -51,6 +51,13 @@ final class PhoneReceiver: ObservableObject {
     @Published var connected = false
     @Published var videoSize = CGSize.zero   // for touch coordinate mapping
     @Published var perf = PerfStats()
+    /// True while a Mac is connected but no frame has decoded for a couple of
+    /// seconds (or ever). Once a session has streamed, the receiver view is a
+    /// bare black canvas between frames — so a Mac that is connected but not
+    /// sending (e.g. while it works around a poisoned display identity, #230)
+    /// otherwise reads as a dead black screen with no explanation.
+    @Published var awaitingVideo = false
+    private var awaitingVideoNow = false   // queue-side mirror of the above
     // Compatibility signal from the connected Mac (issue #132). Nil = no signal.
     // Merged into the update gate by ReceiverScreen.
     @Published var peerSignal: PeerUpdateSignal?
@@ -471,8 +478,19 @@ final class PhoneReceiver: ObservableObject {
                 self.connection = nil
                 self.setConnected(false)
             }
+            // Frame drought while the link is up — surfaced by the UI so the
+            // screen isn't silently black. Cleared eagerly in enqueueFrame;
+            // this tick only needs to catch the onset.
+            self.setAwaitingVideo(self.connection?.state == .ready
+                && (self.lastFrameAt.map { Date().timeIntervalSince($0) > 2 } ?? true))
             self.scheduleWatchdog()
         }
+    }
+
+    private func setAwaitingVideo(_ value: Bool) {
+        guard awaitingVideoNow != value else { return }
+        awaitingVideoNow = value
+        DispatchQueue.main.async { self.awaitingVideo = value }
     }
 
     private func resetStreamState() {
@@ -779,6 +797,7 @@ final class PhoneReceiver: ObservableObject {
             if ms > 50 { stallsThisWindow += 1 }
         }
         lastFrameAt = now
+        setAwaitingVideo(false)
 
         // True end-to-end latency: Mac capture timestamp vs our clock mapped
         // onto the Mac's via the ping/pong offset.


### PR DESCRIPTION
The iPad half of the choppy recovery in the v1.17.0 field log: the user stared at an unexplained black screen while the Mac worked around a poisoned display identity (https://github.com/peetzweg/opendisplay/pull/232 is the Mac half).

**Why:** `videoSize` is set on the first SPS/PPS and never reset, so after the first stream of the process every reconnect shows the bare black video canvas immediately, before any frame arrives. Connected-but-not-sending states (identity probe, Mac-side stalls) are indistinguishable from a dead app.

**How:** deliberately *not* resetting `videoSize` on disconnect, since that would flash the full idle UI over the stream on every brief watchdog reconnect. Instead the receiver tracks a frame drought (connected, no decoded frame for >2s, checked on the existing watchdog tick and cleared eagerly on the next frame) and the streaming view fades in a spinner with "Connected — waiting for video from the Mac…". Purely additive: no state machine changes, the overlay never blocks touch, and it can only appear on the black canvas.

Builds clean for iOS; not yet exercised on a device, since triggering it needs a Mac that is connected but not sending.