### PR TITLE
Automate the adb forward + host/port override for Android USB connections

### DIFF
--- a/Mac/AndroidAdbWatcher.swift
+++ b/Mac/AndroidAdbWatcher.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+@MainActor
+final class AndroidAdbWatcher {
+    private static let pollInterval: TimeInterval = 3
+    private static let port: UInt16 = 9000
+
+    private let adbPath: String
+    private let onChange: (Bool) -> Void
+    private var timer: Timer?
+    private var attachedSerial: String?
+
+    init?(onChange: @escaping (Bool) -> Void) {
+        guard let adbPath = Self.findAdb() else { return nil }
+        self.adbPath = adbPath
+        self.onChange = onChange
+        poll()
+        timer = Timer.scheduledTimer(withTimeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.poll() }
+        }
+    }
+
+    private func poll() {
+        let serial = Self.firstDeviceSerial(adbPath: adbPath)
+        guard serial != attachedSerial else { return }
+        attachedSerial = serial
+        guard let serial else {
+            Log.info("adb device detached")
+            onChange(false)
+            return
+        }
+        guard Self.forward(adbPath: adbPath, serial: serial, port: Self.port) else {
+            Log.info("adb forward tcp:\(Self.port) failed for \(serial)")
+            attachedSerial = nil
+            return
+        }
+        Log.info("adb device attached: \(serial), forwarded tcp:\(Self.port)")
+        onChange(true)
+    }
+
+    private static func findAdb() -> String? {
+        let candidates = [
+            "/opt/homebrew/bin/adb",
+            "/usr/local/bin/adb",
+            NSHomeDirectory() + "/Library/Android/sdk/platform-tools/adb",
+        ]
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    private static func firstDeviceSerial(adbPath: String) -> String? {
+        guard let output = run(adbPath, ["devices"]),
+              let header = output.range(of: "List of devices attached") else { return nil }
+        for line in output[header.upperBound...].split(separator: "\n") {
+            let fields = line.split(separator: "\t")
+            if fields.count == 2, fields[1] == "device" {
+                return String(fields[0])
+            }
+        }
+        return nil
+    }
+
+    private static func forward(adbPath: String, serial: String, port: UInt16) -> Bool {
+        run(adbPath, ["-s", serial, "forward", "tcp:\(port)", "tcp:\(port)"]) != nil
+    }
+
+    private static func run(_ path: String, _ arguments: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: path)
+        process.arguments = arguments
+        let stdout = Pipe()
+        process.standardOutput = stdout
+        process.standardError = Pipe()
+        do {
+            try process.run()
+        } catch {
+            Log.info("adb \(arguments.joined(separator: " ")) failed to launch: \(error)")
+            return nil
+        }
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/Mac/AndroidAdbWatcher.swift
+++ b/Mac/AndroidAdbWatcher.swift
@@ -48,13 +48,13 @@ final class AndroidAdbWatcher {
     }
 
     private static func firstDeviceSerial(adbPath: String) -> String? {
-        guard let output = run(adbPath, ["devices"]),
+        guard let output = run(adbPath, ["devices", "-l"]),
               let header = output.range(of: "List of devices attached") else { return nil }
         for line in output[header.upperBound...].split(separator: "\n") {
-            let fields = line.split(separator: "\t")
-            if fields.count == 2, fields[1] == "device" {
-                return String(fields[0])
-            }
+            let fields = line.split(separator: " ")
+            guard fields.count >= 2, fields[1] == "device",
+                  fields.contains(where: { $0.hasPrefix("usb:") }) else { continue }
+            return String(fields[0])
         }
         return nil
     }

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -194,6 +194,7 @@ final class SenderController: ObservableObject {
 
     private var browser: NWBrowser?
     private var usbWatcher: UsbmuxDeviceWatcher?
+    private var androidWatcher: AndroidAdbWatcher?
 
     // Connection policy — one session per physical device, and the cable
     // wins whenever it's available (lower, steadier latency than WiFi):
@@ -242,6 +243,19 @@ final class SenderController: ObservableObject {
             let detached = Set(self.usbDevices.map(\.udid)).subtracting(devices.map(\.udid))
             self.usbDevices = devices
             self.failover(detachedUDIDs: detached)
+            self.autoConnect()
+        }
+        androidWatcher = AndroidAdbWatcher { [weak self] connected in
+            guard let self else { return }
+            if connected {
+                self.host = "127.0.0.1"
+                self.port = "9000"
+                UserDefaults.standard.set(self.host, forKey: "host")
+                UserDefaults.standard.set(self.port, forKey: "port")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "host")
+                UserDefaults.standard.removeObject(forKey: "port")
+            }
             self.autoConnect()
         }
         Task { @MainActor in


### PR DESCRIPTION
## Summary

Addresses #234. usbmuxd has no idea Android devices exist, so the existing `-host`/`-port` escape hatch that makes USB work for Android clients today only kicks in after running three commands by hand every session:

```sh
adb forward tcp:9000 tcp:9000
defaults write com.peetzweg.opensidecar.mac host 127.0.0.1
defaults write com.peetzweg.opensidecar.mac port 9000
```

`AndroidAdbWatcher` (new, `Mac/AndroidAdbWatcher.swift`) automates exactly that. It polls `adb devices -l` — there's no push-notification API for it the way usbmuxd has `Listen` — and on a genuinely wired Android device appearing, runs the same `adb forward tcp:9000 tcp:9000` and sets the same `host`/`port` `UserDefaults` keys the manual workflow already used. `autoConnect()` picks it up exactly like it already does for the manual case, completely untouched.

`init?` returns `nil` if `adb` isn't found on the Mac (checks Homebrew, `/usr/local/bin`, and the default Android SDK path), so the watcher does nothing at zero cost when it isn't installed.

One correctness detail found while testing live: `adb devices` lists wireless-debugging targets the same way it lists USB ones, so a device reachable both ways got detected twice under two different identifiers and kept re-forwarding back and forth between them. Filtering on the `usb:` field that `adb devices -l` only sets on a genuine cable connection fixes that — see the second commit.

This is meant to complement #224/#225 (native USB Accessory/AOA support), not replace it — once that lands, this becomes unnecessary for anyone on the AOA-capable Android build. Until then, this closes the gap for everyone else.

## Test plan

- [x] `swiftc -typecheck` across the whole `Mac/` module — clean except the pre-existing `Sparkle` module (unresolvable outside Xcode's own SPM resolution)
- [x] Full `xcodebuild` build against real Xcode — succeeds
- [x] Confirmed live: plugged in a Galaxy Tab S9 FE+ running [opendisplay-android](https://github.com/josepacelli/opendisplay-android) — the app detected it, forwarded the port, and connected automatically with no terminal commands
- [x] Confirmed live: the same device also had wireless debugging enabled — before the second commit's fix, the watcher alternated between the two adb identifiers for it; after, it holds a single stable identifier
- [x] Confirmed live: full session — `hello`, virtual display created, encoder started, `Extending to Android (2880×1800)` — streamed successfully over the automated connection