### PR TITLE
feat: iOS setting to fit the display into the safe area (avoid notch & rounded corners)

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -64,9 +64,12 @@ enum StreamQuality: String, CaseIterable {
 }
 
 struct PhoneInfo: Decodable {
-    let pixelsWide: Int   // landscape-oriented (long edge)
-    let pixelsHigh: Int
+    let pixelsWide: Int   // announced display rect (panel or a safe-area
+    let pixelsHigh: Int   // sub-rect), in the panel's current orientation
     let scale: Double
+    let panelWide: Int?   // full physical panel, long edge first — resize
+    let panelHigh: Int?   // headroom (older receivers omit it: the announced
+                          // rect IS the panel there, so it reserves enough)
     let device: String?   // "iPad" / "iPhone" (older receivers omit it)
     let id: String?       // per-install identity (older receivers omit it) —
                           // lets the controller match the same physical device
@@ -76,6 +79,14 @@ struct PhoneInfo: Decodable {
 
     var kind: String { device ?? "device" }
     var protocolVersion: Int { pv ?? WireProtocol.assumedWhenAbsent }
+
+    // The derived virtual-display mode (points at @2x, floored to even for
+    // the encoder). Rebuild decisions MUST compare these, not raw pixels:
+    // hellos can differ in pixels yet agree here — the receiver's init seed
+    // (raw nativeBounds) vs its refined announcement (floored to a multiple
+    // of 4) — and rebuilding for those changes nothing visible.
+    var pointsWide: Int { (pixelsWide / 2) & ~1 }
+    var pointsHigh: Int { (pixelsHigh / 2) & ~1 }
 }
 
 /// How the sender reaches the receiver. Reconnects re-dial from scratch, so
@@ -347,6 +358,25 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             let info = try await waitForHello()
             try await setupExtend(info)
 
+            // A hello that changed while the display was being built updated
+            // lastHello but triggered nothing: the rebuild path is gated on
+            // stream != nil, which only holds once setupExtend finishes.
+            // Reconcile here so a rotation — or the receiver refining its
+            // first announcement (safe-area fit resolves its window a beat
+            // after the listener starts) — isn't stale for the whole session.
+            // Compared at the derived mode, not raw pixels: the refinement
+            // often changes pixels without changing the mode. A failure here
+            // throws like a failed initial setup would, instead of parking
+            // the session with the pipeline torn down and no recovery armed.
+            if let latest = await latestHello(),
+               latest.pointsWide != info.pointsWide || latest.pointsHigh != info.pointsHigh {
+                Log.info("hello changed during setup — reconfiguring for \(latest.pixelsWide)x\(latest.pixelsHigh)")
+                guard await reconfigure(latest) else {
+                    throw NSError(domain: "MacSender", code: 6, userInfo: [
+                        NSLocalizedDescriptionKey: "display reconfiguration failed"])
+                }
+            }
+
             // Touch back-channel (Milestone 3). Needs Accessibility trust;
             // streaming works without it, so don't interrupt with a prompt —
             // the permission panel's Grant button asks when the user is ready.
@@ -371,8 +401,15 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
         // Phone panel is @3x; the virtual display runs @2x HiDPI, so points
         // = native pixels / 2 (rounded down to even for the encoder).
-        let pointsWide = (info.pixelsWide / 2) & ~1
-        let pointsHigh = (info.pixelsHigh / 2) & ~1
+        let pointsWide = info.pointsWide
+        let pointsHigh = info.pointsHigh
+        // Resize headroom: a safe-area sub-rect has orientation-dependent
+        // long edges (the insets differ per orientation), and turning the
+        // setting off re-announces the full panel — reserving only the
+        // current mode would force the destroy-and-recreate fallback (and
+        // its window scatter) on the first such change. The full panel
+        // bounds every possible announcement from this device.
+        let reservePoints = max((info.panelWide ?? 0) / 2, (info.panelHigh ?? 0) / 2)
         // Rough physical size so macOS picks a sane default UI scale.
         let mm = info.pixelsWide >= info.pixelsHigh
             ? CGSize(width: 147, height: 68)
@@ -440,6 +477,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                     return VirtualDisplay(name: displayName,
                                           pointsWide: pointsWide, pointsHigh: pointsHigh,
                                           sizeInMillimeters: mm,
+                                          reservePointsPerAxis: reservePoints,
                                           serialNum: serial &+ totalOffset,
                                           productID: 0x4F53 &+ totalOffset,
                                           restoreOrigin: restoreOrigin,
@@ -500,16 +538,38 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         }
     }
 
+    /// `lastHello` is owned by `queue` (written in the connection's receive
+    /// handler) and holds String refs, so an unsynchronized read while a new
+    /// hello is being decoded isn't merely stale — snapshot it on the queue.
+    private func latestHello() async -> PhoneInfo? {
+        await withCheckedContinuation { cont in
+            queue.async { cont.resume(returning: self.lastHello) }
+        }
+    }
+
     /// Tear down and rebuild when the phone announces new dimensions. Loops
     /// until the built display matches the latest hello, so rotations that
     /// arrive mid-rebuild aren't lost (and rapid flip-flops settle once).
+    /// Returns false only when a rebuild was attempted and failed; skipping
+    /// (another rebuild in flight, session stopped, already at the target
+    /// mode) counts as success.
     private var reconfiguring = false
-    private func reconfigure(_ info: PhoneInfo) async {
-        guard !reconfiguring, !stopped else { return }
+    @discardableResult
+    private func reconfigure(_ info: PhoneInfo) async -> Bool {
+        guard !reconfiguring, !stopped else { return true }
         reconfiguring = true
         defer { reconfiguring = false }
         var target = info
         while !stopped {
+            // Already built and capturing at this mode — nothing to do. This
+            // absorbs redundant callers (the startup reconcile racing the
+            // debounced rebuild for the same hello). Never skip while capture
+            // is down: the recovery path reuses this function to rebuild a
+            // dead pipeline at unchanged dimensions.
+            if let vd = virtualDisplay, stream != nil,
+               vd.pointsWide == target.pointsWide, vd.pointsHigh == target.pointsHigh {
+                return true
+            }
             Log.info("reconfiguring for \(target.pixelsWide)x\(target.pixelsHigh)")
             // A cached frame is valid for a network reconnect to the same
             // display, but never for a rotation: it belongs to the retired
@@ -533,15 +593,16 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             } catch {
                 Log.info("reconfigure failed: \(error)")
                 await status("Rotation failed: \(error.localizedDescription)")
-                return
+                return false
             }
-            if let latest = lastHello,
-               latest.pixelsWide != target.pixelsWide || latest.pixelsHigh != target.pixelsHigh {
+            if let latest = await latestHello(),
+               latest.pointsWide != target.pointsWide || latest.pointsHigh != target.pointsHigh {
                 target = latest   // rotated again while we were rebuilding
                 continue
             }
-            return
+            return true
         }
+        return true
     }
 
     /// Apply the rotated mode to the existing virtual monitor and restart
@@ -551,8 +612,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private func resizeExistingDisplay(for info: PhoneInfo) async throws -> Bool {
         guard let vd = virtualDisplay else { return false }
 
-        let pointsWide = (info.pixelsWide / 2) & ~1
-        let pointsHigh = (info.pixelsHigh / 2) & ~1
+        let pointsWide = info.pointsWide
+        let pointsHigh = info.pointsHigh
         let arrangementKey = info.id ?? String(format: "serial-%08x", displaySerial)
         let size = CGSize(width: pointsWide, height: pointsHigh)
         let didResize = await MainActor.run {
@@ -647,7 +708,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // starts with as little as one round left.
         queue.async { self.captureRecoveryFailures = 0 }
         Log.info("capture started: \(pixelsWide)x\(pixelsHigh) display \(display.displayID) generation \(generation) mode \(mode.rawValue) localCursor=\(localCursor)")
-        let kind = lastHello?.kind ?? "device"
+        // Snapshot on the owning queue (see latestHello) — this runs off it,
+        // and hellos now arrive continuously during margin-slider rebuilds.
+        let kind = await latestHello()?.kind ?? "device"
         await status("\(mode == .extend ? "Extending to" : "Mirroring to") \(kind) (\(pixelsWide)×\(pixelsHigh))")
     }
 
@@ -792,7 +855,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             // CGRect.null, so it reads as "live" for a dead display too and the
             // rebuild fallback below would become unreachable.
             if let vd = self.virtualDisplay,
-               !CGDisplayBounds(vd.displayID).isEmpty {
+               !CGDisplayBounds(vd.displayID).isEmpty,
+               vd.pointsWide == hello.pointsWide, vd.pointsHigh == hello.pointsHigh {
                 Log.info("capture died — display still present, re-attaching capture only (#29)")
                 Task {
                     do {
@@ -812,7 +876,12 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 }
                 return
             }
-            // Display genuinely gone — full rebuild (preserves old behavior).
+            // Display gone — or alive at a stale mode: a hello arriving while
+            // capture is down triggers nothing (the rebuild path is gated on
+            // stream != nil) and the receiver won't repeat it (it dedupes by
+            // dimensions), so re-attaching as-is would strand the session at
+            // the old size for good. reconfigure resizes the surviving
+            // display in place, so the mismatch case costs no window scatter.
             Log.info("capture died — rebuilding pipeline")
             Task {
                 await self.reconfigure(hello)
@@ -1237,16 +1306,32 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                     helloContinuation = nil
                     continuation.resume(returning: info)
                 } else if mode == .extend, stream != nil, let previous,
-                          previous.pixelsWide != info.pixelsWide
-                          || previous.pixelsHigh != info.pixelsHigh {
+                          previous.pointsWide != info.pointsWide
+                          || previous.pointsHigh != info.pointsHigh {
                     // Phone rotated — rebuild after a short debounce so a
                     // flurry of orientation flips settles into one rebuild.
+                    // Compared at the derived mode (see PhoneInfo.pointsWide)
+                    // so pixel-only refinements don't rebuild a display they
+                    // wouldn't change.
                     Task {
                         try? await Task.sleep(for: .milliseconds(300))
-                        guard let current = self.lastHello,
-                              current.pixelsWide == info.pixelsWide,
-                              current.pixelsHigh == info.pixelsHigh else { return }
-                        await self.reconfigure(info)
+                        // Points, like the trigger above: a pixel-only
+                        // refinement inside the window must not cancel the
+                        // rebuild this task was armed for.
+                        guard let current = await self.latestHello(),
+                              current.pointsWide == info.pointsWide,
+                              current.pointsHigh == info.pointsHigh else { return }
+                        if await self.reconfigure(info) == false {
+                            // The startup path throws on this failure; here
+                            // nothing would re-arm and the session would look
+                            // live (pings flowing) with its pipeline torn
+                            // down — invisible to auto-connect and dedupe.
+                            // Hand it to the bounded capture-recovery loop:
+                            // stream is nil after the failure, so recovery's
+                            // guard passes; it re-attaches or rebuilds, and
+                            // ends the session after the retry budget.
+                            self.scheduleCaptureRecovery()
+                        }
                     }
                 }
             }
@@ -1326,8 +1411,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     }
 
     private func waitForHello() async throws -> PhoneInfo {
-        if let lastHello { return lastHello }
-        return try await withCheckedThrowingContinuation { continuation in
+        // No unsynchronized fast path: lastHello is owned by `queue` (see
+        // latestHello), and the queue-confined check below covers it anyway.
+        try await withCheckedThrowingContinuation { continuation in
             queue.async {
                 if let hello = self.lastHello {
                     continuation.resume(returning: hello)

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -27,6 +27,7 @@ final class VirtualDisplay {
     /// `onOriginChange` reports where the display sits afterwards, so the
     /// caller can persist user drags.
     init?(name: String, pointsWide: Int, pointsHigh: Int, sizeInMillimeters: CGSize,
+          reservePointsPerAxis: Int = 0,
           serialNum: UInt32 = 0x0001, productID: UInt32 = 0x4F53,
           restoreOrigin: CGPoint? = nil,
           onOriginChange: ((CGPoint, CGSize) -> Void)? = nil) {
@@ -35,7 +36,10 @@ final class VirtualDisplay {
         // Reserve the longer orientation on both axes. That lets a phone or
         // tablet change orientation by applying a new mode to this *same*
         // virtual monitor instead of removing it and stranding its windows.
-        maxPointsPerAxis = max(pointsWide, pointsHigh)
+        // `reservePointsPerAxis` raises the bound when the caller knows a
+        // larger mode may come later (a receiver announcing a safe-area
+        // sub-rect can announce up to its full panel on a settings change).
+        maxPointsPerAxis = max(pointsWide, pointsHigh, reservePointsPerAxis)
         self.restoreTarget = restoreOrigin
         self.restoreUntil = restoreOrigin == nil ? .distantPast : Date().addingTimeInterval(6)
         self.onOriginChange = onOriginChange
@@ -148,12 +152,19 @@ final class VirtualDisplay {
     /// `recover`, a missing @2x mode (macOS can replace the whole mode list
     /// when it restores saved display state) re-applies our settings to
     /// publish it again instead of failing silently forever.
+    ///
+    /// Both matches compare height as well as width: a safe-area sub-rect in
+    /// portrait derives the same point width as the full panel (the side
+    /// insets are zero there), so width alone would bless a stale restored
+    /// full-height mode as "correct" and leave the display mismatched with
+    /// the announced rect.
     @discardableResult
     private func selectHiDPIMode(recover: Bool = false) -> Bool {
         let opts = [kCGDisplayShowDuplicateLowResolutionModes: kCFBooleanTrue] as CFDictionary
         guard let modes = CGDisplayCopyAllDisplayModes(display.displayID, opts) as? [CGDisplayMode],
               let hidpi = modes.first(where: {
-                  $0.width == pointsWide && $0.pixelWidth == pointsWide * 2
+                  $0.width == pointsWide && $0.height == pointsHigh
+                      && $0.pixelWidth == pointsWide * 2
               }) else {
             if recover {
                 Log.info("@2x mode vanished from display \(display.displayID) — re-applying settings")
@@ -162,7 +173,8 @@ final class VirtualDisplay {
             return false
         }
         if let current = CGDisplayCopyDisplayMode(display.displayID),
-           current.width == hidpi.width, current.pixelWidth == hidpi.pixelWidth {
+           current.width == hidpi.width, current.height == hidpi.height,
+           current.pixelWidth == hidpi.pixelWidth {
             return true
         }
         var config: CGDisplayConfigRef?

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -245,7 +245,7 @@ Coordinates use the conventions of section 7.
 
 | `type` | Since | Fields | Purpose |
 |---|---|---|---|
-| `hello` | pv 1 | `pixelsWide`, `pixelsHigh`, `scale`, `device`?, `id`?, `pv`? | Identify the panel; (re)sent on connect and on rotation |
+| `hello` | pv 1 | `pixelsWide`, `pixelsHigh`, `scale`, `panelWide`?, `panelHigh`?, `device`?, `id`?, `pv`? | Identify the panel (or a sub-region of it); (re)sent on connect and whenever the announced dimensions change |
 | `ping` | pv 1 | `t` | Liveness + clock sync probe |
 | `touch` | pv 1 | `phase`, `x`, `y`, `t`? | Finger input |
 | `scroll` | pv 1 | `dx`, `dy` | Two-finger scroll |
@@ -261,10 +261,25 @@ connection, because the sender sizes its virtual display from it and can do
 nothing before it arrives.
 
 * `pixelsWide`, `pixelsHigh` (int): the panel size in **physical pixels**,
-  in the panel's **current orientation** (portrait swaps them).
+  in the panel's **current orientation** (portrait swaps them). A receiver
+  MAY announce a sub-region of its physical panel instead — the official
+  iOS app does this when the user opts to avoid the notch and rounded
+  corners — and MUST then display the video within that region and
+  normalize input against it. Senders treat the values as opaque
+  dimensions either way; no wire change is involved.
 * `scale` (number): the device's UI scale factor (2 or 3 on Apple
   hardware). The sender uses it to pick a sensible point-size for the
   virtual display.
+* `panelWide`, `panelHigh` (int, optional): the **full physical panel**
+  in pixels, long edge first, independent of orientation and of any
+  sub-region announced in `pixelsWide`/`pixelsHigh`. A sub-region's long
+  edge differs per orientation (safe-area insets are asymmetric), so a
+  sender that sizes resize headroom — e.g. a virtual display's maximum
+  mode — from the first announcement alone would have to destroy and
+  recreate the display when a later announcement is larger. These fields
+  bound every announcement the device can ever make. Absent on older
+  receivers, where `pixelsWide`/`pixelsHigh` **are** the full panel and
+  reserving from them is already sufficient.
 * `device` (string, optional): device kind for UI text, `"iPhone"` or
   `"iPad"` from the official receiver. Free-form.
 * `id` (string, optional): stable per-install UUID. MUST match the Bonjour
@@ -274,7 +289,8 @@ nothing before it arrives.
   1** (every pre-handshake install).
 
 A receiver MUST re-send `hello` on the live connection whenever its
-announced dimensions change (rotation). The sender rebuilds the display in
+announced dimensions change (rotation, or a display-area setting flip).
+The sender rebuilds the display in
 response; the official sender debounces this by 300 ms so an orientation
 flurry settles into one rebuild, and replies to *every* `hello` with a
 fresh `welcome` (receivers treat repeats idempotently).
@@ -395,7 +411,8 @@ sender).
 
 | What | Space | Units | Origin / sign |
 |---|---|---|---|
-| `hello.pixelsWide/High` | physical panel | pixels | current orientation |
+| `hello.pixelsWide/High` | panel, or a sub-region of it | pixels | current orientation |
+| `hello.panelWide/High` | physical panel | pixels | long edge first |
 | `hello.scale` | none | UI scale factor | n/a |
 | `touch.x/y`, `pencil.x/y`, `proximity.x/y` | video | normalized 0..1 | top-left, x right, y down |
 | `scroll.dx/dy` | video | **pixels** (not normalized) | natural-scrolling sign |

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -44,6 +44,12 @@ struct ReceiverScreen: View {
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage("showAnalytics") private var showAnalytics = false
     @AppStorage("metalRenderer") private var metalRenderer = false
+    // Safe-area fit: shrink the streamed display to the panel's safe area
+    // (plus an extra margin) so macOS content never hides under the notch
+    // or the rounded corners. The smaller size is announced in `hello`, so
+    // the Mac builds a matching virtual display — no letterboxing.
+    @AppStorage("safeAreaFit") private var safeAreaFit = false
+    @AppStorage("safeAreaMargin") private var safeAreaMargin = 8.0
     // First-run onboarding (issue #49): explain the Mac app is required.
     // Shown until either the user dismisses it or the device connects once.
     @AppStorage("hasConnectedBefore") private var hasConnectedBefore = false
@@ -67,6 +73,43 @@ struct ReceiverScreen: View {
         return nil
     }
 
+    // The UIWindow actually hosting this view, reported by WindowReader.
+    // Scanning UIApplication's scene windows could pick a system window —
+    // the remote keyboard window can report isKeyWindow while a text field
+    // is focused — and announce a rect nobody lays out.
+    @State private var hostWindow: UIWindow?
+
+    /// (Re)announce the panel size the Mac should build its display for:
+    /// the full panel, or — with safe-area fit on — the safe area minus the
+    /// extra margin, in the current orientation. Mirrors the video view's
+    /// layout above so the stream's aspect ratio matches the visible rect.
+    private func updatePanel() {
+        guard let window = hostWindow else {
+            // Cold-launch race: the hierarchy isn't attached to its window
+            // yet (WindowReader reports it moments later and re-announces).
+            // Announcing a guess would let a fast connection build a
+            // wrong-size Mac display (ReceiverModel already seeded the full
+            // native panel as a floor) — retry shortly instead.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { updatePanel() }
+            return
+        }
+        var size = window.bounds.size
+        if safeAreaFit {
+            let insets = window.safeAreaInsets
+            let margin = CGFloat(safeAreaMargin)
+            size.width -= insets.left + insets.right + 2 * margin
+            size.height -= insets.top + insets.bottom + 2 * margin
+        }
+        // Round down to a multiple of 4: the Mac floors to even *points*
+        // ((px / 2) & ~1) and captures at points × 2, so only multiples of
+        // 4 survive the round-trip — anything else re-letterboxes by a
+        // pixel or two and skews the announced aspect ratio.
+        let scale = UIScreen.main.nativeScale
+        let wide = Int(size.width * scale) & ~3
+        let high = Int(size.height * scale) & ~3
+        model.receiver.setPanelPixels(wide: wide, high: high, scale: Double(scale))
+    }
+
     var body: some View {
         GeometryReader { geo in
             ZStack {
@@ -76,7 +119,21 @@ struct ReceiverScreen: View {
                                    receiver: model.receiver,
                                    useMetal: metalRenderer)
                         .id(metalRenderer)   // rebuild the layer tree on toggle
-                        .ignoresSafeArea()
+                        // Safe-area fit keeps the video inside the safe area
+                        // (plus margin) instead of edge-to-edge. The insets
+                        // reach this view only because the outer modifier
+                        // below stops ignoring them when the setting is on;
+                        // the announced panel matches (updatePanel), so
+                        // aspect-fit fills the inset rect exactly and touch
+                        // mapping stays aligned.
+                        .padding(safeAreaFit ? CGFloat(safeAreaMargin) : 0)
+                        // Keyboard region always ignored: updatePanel reads
+                        // window.safeAreaInsets, which never include the
+                        // keyboard, so letting SwiftUI's keyboard avoidance
+                        // shrink the video would break the announced-rect
+                        // match while the device-name field is focused.
+                        .ignoresSafeArea(.keyboard)
+                        .ignoresSafeArea(edges: safeAreaFit ? [] : .all)
                     if showAnalytics {
                         VStack {
                             Spacer()
@@ -90,16 +147,31 @@ struct ReceiverScreen: View {
                     IdleView(receiver: model.receiver, showSettings: $showSettings)
                 }
             }
-            .onAppear { model.receiver.setOrientation(portrait: geo.size.height > geo.size.width) }
-            .onChange(of: geo.size) { size in
-                model.receiver.setOrientation(portrait: size.height > size.width)
-            }
+            .background(WindowReader { window in
+                hostWindow = window
+                if window != nil { updatePanel() }
+            })
+            .onAppear { updatePanel() }
+            .onChange(of: geo.size) { _ in updatePanel() }   // rotation
+            .onChange(of: safeAreaFit) { _ in updatePanel() }
+            .onChange(of: safeAreaMargin) { _ in updatePanel() }
             .sheet(isPresented: $showOnboarding) {
                 OnboardingView { onboardingDismissed = true }
             }
         }
-        .ignoresSafeArea(edges: isStreaming ? .all : [])
-        .statusBarHidden(isStreaming)
+        // Ignoring the safe area here consumes it for the entire subtree —
+        // descendants can't opt back in — so with safe-area fit on the
+        // insets must be preserved at this level for the video view's
+        // layout to see them. The black background still covers the glass
+        // edge-to-edge via its own ignoresSafeArea.
+        .ignoresSafeArea(edges: (isStreaming && !safeAreaFit) ? .all : [])
+        // Hidden whenever safe-area fit is on (not just while streaming):
+        // on devices whose top inset comes from the status bar rather than
+        // a notch (iPads, home-button iPhones), hiding it at stream start
+        // would change the insets after the pre-stream hello and force a
+        // second display rebuild. Keeping it hidden makes the announced
+        // panel identical before and during streaming.
+        .statusBarHidden(isStreaming || safeAreaFit)
         .persistentSystemOverlays(isStreaming ? .hidden : .automatic)
         .sheet(isPresented: $showSettings) {
             SettingsView(receiver: model.receiver)
@@ -129,7 +201,11 @@ struct ReceiverScreen: View {
         .onChange(of: scenePhase) { phase in
             Log.info("scenePhase -> \(String(describing: phase))")
             switch phase {
-            case .active: model.sceneDidActivate()
+            case .active:
+                model.sceneDidActivate()
+                // Orientation or insets may have changed while suspended
+                // (and this also backstops the cold-launch no-window retry).
+                updatePanel()
             case .background: model.sceneDidBackground()
             default: break
             }
@@ -490,6 +566,16 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @AppStorage("showAnalytics") private var showAnalytics = false
     @AppStorage("metalRenderer") private var metalRenderer = false
+    @AppStorage("safeAreaFit") private var safeAreaFit = false
+    @AppStorage("safeAreaMargin") private var safeAreaMargin = 8.0
+    // Slider draft: every committed margin permanently reconfigures the
+    // Mac's virtual display, so the live drag value stays local and commits
+    // debounced. The commit must NOT depend on onEditingChanged alone:
+    // stepped sliders never deliver the closing `false` on iOS 26 (known
+    // OS bug), VoiceOver adjustments bypass the drag lifecycle entirely,
+    // and a cancelled gesture (rotation, alert mid-drag) skips it too.
+    @State private var marginDraft = 8.0
+    @State private var marginCommit: Task<Void, Never>?
 
     private var version: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "dev"
@@ -519,6 +605,46 @@ struct SettingsView: View {
                     Text("Name")
                 } footer: {
                     Text("Shown in the Mac app's WiFi connection menu. iOS hides this \(deviceKind)'s real name from apps, so set it here once.")
+                }
+
+                Section {
+                    Toggle("Avoid notch & rounded corners", isOn: $safeAreaFit)
+                    if safeAreaFit {
+                        HStack {
+                            Text("Extra margin")
+                            Slider(value: $marginDraft, in: 0...24, step: 2) { editing in
+                                // Accelerator only — see the debounced
+                                // onChange below for why this can't be the
+                                // sole commit path.
+                                if !editing {
+                                    marginCommit?.cancel()
+                                    safeAreaMargin = marginDraft
+                                }
+                            }
+                            Text("\(Int(marginDraft)) pt")
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+                        .onAppear { marginDraft = safeAreaMargin }
+                        .onChange(of: marginDraft) { value in
+                            marginCommit?.cancel()
+                            marginCommit = Task { @MainActor in
+                                try? await Task.sleep(for: .milliseconds(400))
+                                guard !Task.isCancelled else { return }
+                                safeAreaMargin = value
+                            }
+                        }
+                        .onDisappear {
+                            // Row removed mid-interaction (fit toggled off,
+                            // sheet dismissed): commit what the user saw.
+                            marginCommit?.cancel()
+                            safeAreaMargin = marginDraft
+                        }
+                    }
+                } header: {
+                    Text("Display area")
+                } footer: {
+                    Text("Shrinks the streamed display to this \(deviceKind)'s safe area so macOS windows and the menu bar never hide under the notch or the rounded corners. Extra margin trims a little more off every edge. Changing this rebuilds the Mac-side display — windows may briefly rearrange, like rotating does.")
                 }
 
                 Section {
@@ -612,6 +738,36 @@ private struct DeviceNameField: View {
     }
 }
 
+// MARK: - Window reader
+
+/// Reports the UIWindow hosting this hierarchy (for updatePanel). UIKit's
+/// scene-window lists include system windows (remote keyboard, text
+/// effects), so "the key window" is not reliably the one the video is laid
+/// out in — the view's own `window` is.
+private struct WindowReader: UIViewRepresentable {
+    let onWindow: (UIWindow?) -> Void
+
+    func makeUIView(context: Context) -> Probe {
+        let view = Probe()
+        view.isUserInteractionEnabled = false
+        view.onWindow = onWindow
+        return view
+    }
+
+    func updateUIView(_ uiView: Probe, context: Context) {}
+
+    final class Probe: UIView {
+        var onWindow: ((UIWindow?) -> Void)?
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            let window = self.window
+            // Async: this fires during UIKit layout, and mutating SwiftUI
+            // state mid-update is undefined.
+            DispatchQueue.main.async { self.onWindow?(window) }
+        }
+    }
+}
+
 // MARK: - Model
 
 @MainActor
@@ -622,10 +778,12 @@ final class ReceiverModel: ObservableObject {
 
     init() {
         receiver = PhoneReceiver(displayLayer: AVSampleBufferDisplayLayer())
-        // Announce the native panel size to the Mac.
+        // Seed the full native panel size (landscape) so a hello is never
+        // empty; the view refines it with orientation and safe-area fit on
+        // first layout (ReceiverScreen.updatePanel), before connections start.
         let native = UIScreen.main.nativeBounds.size   // portrait pixels
-        receiver.setNativePanel(long: Int(max(native.width, native.height)),
-                                short: Int(min(native.width, native.height)),
+        receiver.setPanelPixels(wide: Int(max(native.width, native.height)),
+                                high: Int(min(native.width, native.height)),
                                 scale: Double(UIScreen.main.nativeScale))
         let savedName = UserDefaults.standard.string(forKey: "deviceName")
         receiver.serviceName = (savedName?.isEmpty == false) ? savedName! : UIDevice.current.name

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -140,15 +140,22 @@ final class PhoneReceiver: ObservableObject {
 
     let displayLayer: AVSampleBufferDisplayLayer
 
-    /// Native panel size in pixels + scale, announced to the Mac in a "hello"
-    /// message so it can size the virtual display. Orientation-dependent:
-    /// rotating the phone re-announces with swapped dimensions and the Mac
-    /// rebuilds the virtual display as a portrait/landscape monitor.
-    private var nativeLong = 0
-    private var nativeShort = 0
+    /// Panel size in pixels + scale, announced to the Mac in a "hello"
+    /// message so it can size the virtual display. The view layer reports
+    /// the current value: the full native panel by default, or a safe-area
+    /// sub-rect when the user opts to avoid the notch and rounded corners
+    /// ("safeAreaFit" setting). Any change (rotation, setting flip)
+    /// re-announces and the Mac rebuilds the virtual display to match.
     private(set) var devicePixelsWide = 0
     private(set) var devicePixelsHigh = 0
     var deviceScale: Double = 2
+    // Full physical panel (long edge first), orientation-independent and
+    // unaffected by the safe-area sub-rect. Announced alongside the display
+    // rect so the Mac can reserve resize headroom for the largest mode this
+    // device may ever switch to (sub-rect long edges differ per orientation,
+    // and turning the setting off announces the full panel again).
+    private let panelLongPixels: Int
+    private let panelShortPixels: Int
     // Name advertised over Bonjour for the Mac's WiFi picker. iOS 16+ returns
     // a generic "iPhone" from UIDevice.current.name (the user-assigned name
     // needs an entitlement Apple gates behind approval and personal teams
@@ -192,29 +199,29 @@ final class PhoneReceiver: ObservableObject {
         }
     }
 
-    func setNativePanel(long: Int, short: Int, scale: Double) {
-        nativeLong = long
-        nativeShort = short
-        deviceScale = scale
-        if devicePixelsWide == 0 {   // default landscape until the view reports
-            devicePixelsWide = long
-            devicePixelsHigh = short
+    /// Called from the main thread; hops to the receiver queue (like
+    /// setServiceName) because `connection` and the announced dimensions are
+    /// owned there — a hello built in the connection's ready handler must
+    /// never observe a half-updated width/height pair.
+    func setPanelPixels(wide: Int, high: Int, scale: Double) {
+        queue.async {
+            guard wide > 0, high > 0,
+                  wide != self.devicePixelsWide || high != self.devicePixelsHigh
+            else { return }
+            self.deviceScale = scale
+            self.devicePixelsWide = wide
+            self.devicePixelsHigh = high
+            Log.info("panel -> \(wide)x\(high) @\(scale)x")
+            if let connection = self.connection { self.sendHello(on: connection) }
         }
-    }
-
-    func setOrientation(portrait: Bool) {
-        let w = portrait ? nativeShort : nativeLong
-        let h = portrait ? nativeLong : nativeShort
-        guard w > 0, w != devicePixelsWide else { return }
-        devicePixelsWide = w
-        devicePixelsHigh = h
-        Log.info("orientation changed -> \(portrait ? "portrait" : "landscape") \(w)x\(h)")
-        if let connection { sendHello(on: connection) }
     }
 
     init(displayLayer: AVSampleBufferDisplayLayer) {
         self.displayLayer = displayLayer
         displayLayer.videoGravity = .resizeAspect
+        let native = UIScreen.main.nativeBounds.size   // portrait pixels
+        panelLongPixels = Int(max(native.width, native.height))
+        panelShortPixels = Int(min(native.width, native.height))
     }
 
     func start(port: UInt16 = 9000) {
@@ -500,6 +507,8 @@ final class PhoneReceiver: ObservableObject {
             "pixelsWide": devicePixelsWide,
             "pixelsHigh": devicePixelsHigh,
             "scale": deviceScale,
+            "panelWide": panelLongPixels,   // full panel, long edge first —
+            "panelHigh": panelShortPixels,  // resize headroom (see above)
             "device": UIDevice.current.userInterfaceIdiom == .pad ? "iPad" : "iPhone",
             "id": Self.installID,
             "pv": WireProtocol.version,   // issue #132 — absent on old receivers


### PR DESCRIPTION
> **Before you review:** this is a feature proposal I'd like to gauge interest on
> first. The implementation is complete, but it hasn't been tested on-device yet —
> if this is something you'd want in OpenDisplay, I'll put in the time to test it
> properly (see the testing notes at the bottom) and iterate on review feedback.
> If it doesn't fit your plans for the project, no hard feelings — just say so and
> I'll close the PR.

## What

Adds a "Display area" section to the iOS settings sheet:

- **Avoid notch & rounded corners** toggle (default off — the current edge-to-edge
  behavior is completely unchanged unless you opt in).
- **Extra margin** slider (0–24 pt, default 8 pt), shown while the toggle is on.
  The system safe-area insets don't cover the rounded corners on the long screen
  edges, so this trims a little more off every edge. The value commits debounced
  (with an editing-end accelerator and a removal backstop), because every committed
  value reconfigures the Mac-side display.

With the toggle on, macOS windows, title bars, and the menu bar never hide under
the notch / Dynamic Island or get clipped by the rounded glass corners.

## How it works

The core idea: shrink the **announced panel** instead of letterboxing on the device.

- With the setting on, the phone announces the safe-area sub-rect
  (`window.bounds − safeAreaInsets − 2×margin`, in physical pixels, floored to
  multiples of 4 so the Mac's even-point quantization round-trips exactly) in
  `hello` instead of the full panel. The Mac builds a virtual display that exactly
  matches the visible rect — pixel-perfect fill, no letterboxing, no non-integral
  scaling.
- The video is laid out inside the safe area plus margin. Since the view bounds
  match the announced aspect ratio, aspect-fit fills the rect exactly, and the
  bounds-relative touch/cursor/scroll mapping needed no changes at all.
- The hosting window is reported by the view hierarchy itself (a tiny
  `WindowReader`) rather than scanning scene windows, which can pick the system
  keyboard window. The announcement re-fires on window attach, rotation, setting
  changes, and scene activation; `setPanelPixels` is receiver-queue-confined and
  dedupes by dimensions.
- The status bar is hidden whenever the setting is on (not just while streaming),
  so status-bar-driven insets (iPads, home-button iPhones) don't change between
  the pre-stream `hello` and the streaming layout — avoiding a rebuild at every
  session start on those devices.

## Protocol

One **additive** change, no `pv` bump (per the additive-fields rule in
PROTOCOL.md): new optional `hello` fields `panelWide`/`panelHigh` carry the full
physical panel (long edge first). The Mac reserves the virtual display
descriptor's resize headroom from them — a sub-rect's long edge is
orientation-dependent, so reserving from the first announcement alone would force
a destroy-and-recreate (and the window scatter that comes with it) on the first
rotation or when the setting is turned off. Compatibility both ways: old
receivers omit the fields and get today's behavior; old senders ignore them.
PROTOCOL.md documents the sub-region semantics and the new fields.

## Mac-side hardening

The sender was built on invariants this feature breaks (announced size == physical
panel; orientation-invariant long edge; hellos only on connect/rotation), so a few
latent assumptions needed fixing to make the feature safe:

- The session start path now reconciles the latest `hello` after the initial
  `setupExtend` — a `hello` arriving mid-setup previously updated state but
  triggered nothing (the rebuild path is gated on a live stream).
- All rebuild decisions compare the derived display mode
  (`PhoneInfo.pointsWide/High`, the @2x even-floored points) instead of raw
  pixels, so pixel-only refinements never rebuild a display they wouldn't change.
- `reconfigure` early-outs when the display is already built and capturing at the
  target mode (capture recovery, which reuses it at unchanged dimensions, is
  exempt), reads `lastHello` only through a queue-confined snapshot (all other
  readers now do too), and reports failure: a failed startup reconcile throws like
  a failed initial setup, and a failed debounced rebuild hands off to the bounded
  capture-recovery loop instead of stranding a live-looking session with a
  torn-down pipeline.
- Capture recovery's re-attach branch now requires the surviving display's mode to
  match the latest `hello`; a mismatch falls through to an in-place resize (a
  `hello` landing while capture is down used to strand the session at the stale
  size for good, since the receiver dedupes announcements).
- `VirtualDisplay`'s HiDPI mode enforcement matches modes by width **and** height:
  a portrait sub-rect derives the same point width as the full panel, so
  width-only matching could bless a stale restored full-height mode.

## Notes & testing

- While streaming, the reclaimed notch strip shows black glass (status bar and
  home indicator stay hidden). With the setting on, the status bar is also hidden
  on the idle screen (see above for why).
- On iPads (no notch) the toggle degrades to roughly the margin plus the
  home-indicator strip.
- The margin slider deliberately avoids committing per step: stepped SwiftUI
  sliders don't deliver the closing `onEditingChanged(false)` on iOS 26, and
  VoiceOver adjustments bypass the drag lifecycle, so commits go through a
  debounced `onChange` with backstops.
- CI compiles the Mac target (all `MacSender`/`VirtualDisplay` changes). The iOS
  target isn't built by CI; manual testing should cover: toggling on/off
  mid-stream, rotation in both modes and both settings, dragging the margin
  slider (including via VoiceOver), and verifying touch/cursor alignment and that
  the macOS menu bar is fully visible with the setting on.