### PR TITLE
feat(web): add coverage showcase

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -278,12 +278,12 @@ export default function App() {
         <div className="wrap sec">
           <p className="eyebrow">Demo</p>
           <h2>See it in action.</h2>
-          <Showcase />
           <p className="sub">
             Using OpenDisplay in the wild?{" "}
             <a href="https://x.com/peetzweg">Tag @peetzweg on X</a> and your setup might
             end up here.
           </p>
+          <Showcase />
         </div>
       </section>
       </div>

--- a/src/components/Showcase.tsx
+++ b/src/components/Showcase.tsx
@@ -1,25 +1,9 @@
 import { useEffect, useRef, useState } from "react"
+import { COVERAGE } from "../content/coverage"
 
-// The demo section's media strip: the YouTube demo plus posts from people
-// using OpenDisplay in the wild. Posts render as self-contained static cards
-// (photos + avatars live in public/showcase/) instead of live X embeds —
-// widgets.js renders unreliably under ad blockers and browser privacy
-// features, and a third-party tracking script sits badly on a page that
-// advertises "no telemetry" anyway. To showcase a new post, add an entry to
-// ITEMS and drop its media into public/showcase/.
 type ShowcaseItem =
   | { kind: "youtube"; id: string; title: string }
-  | {
-      kind: "post"
-      url: string
-      author: string
-      handle: string
-      avatar: string
-      date: string
-      text: string[] // paragraphs/lines of the post, verbatim
-      translation?: string[] // English gloss, shown muted under non-English posts
-      image: { src: string; alt: string; width: number; height: number }
-    }
+  | (typeof COVERAGE)[number]
 
 const ITEMS: ShowcaseItem[] = [
   {
@@ -27,146 +11,25 @@ const ITEMS: ShowcaseItem[] = [
     id: "wyEUkMgH3zw",
     title: "OpenDisplay demo — use your iPad as a second monitor for your Mac",
   },
-  {
-    kind: "post",
-    url: "https://x.com/christophby/status/2075158401894547702",
-    author: "Christoph Byza",
-    handle: "@christophby",
-    avatar: "showcase/avatar-christophby.jpg",
-    date: "Jul 9, 2026",
-    text: [
-      "Using OpenDisplay to turn my iPad into a second monitor.",
-      "Honestly: 100x better than Apple Sidecar.",
-      "Amazing work @peetzweg 👏",
-      "- touch + portrait support",
-      "- works with different Apple IDs",
-    ],
-    image: {
-      src: "showcase/tweet-christophby.jpg",
-      alt: "A developer desk with an ultrawide monitor and an iPad in portrait on a stand serving as a second display, showing a mobile app preview",
-      width: 900,
-      height: 1200,
-    },
-  },
-  {
-    kind: "post",
-    url: "https://x.com/eduwass/status/2071902710597583300",
-    author: "Edu Wass",
-    handle: "@eduwass",
-    avatar: "showcase/avatar-eduwass.jpg",
-    date: "Jun 30, 2026",
-    text: [
-      "@peetzweg here's the setup I've been testing OpenSidecar on 😅",
-      "- LG Ultrawide",
-      "- Macbook Pro M1 (built-in screen)",
-      "- iPad Pro 12.9 x3",
-      "working like a champ",
-    ],
-    image: {
-      src: "showcase/tweet-eduwass.jpg",
-      alt: "Desk with an LG ultrawide, a MacBook Pro and three iPad Pros all running as displays",
-      width: 1200,
-      height: 675,
-    },
-  },
-  {
-    kind: "post",
-    url: "https://x.com/peetzweg/status/2074416821738815692",
-    author: "peetzweg/",
-    handle: "@peetzweg",
-    avatar: "showcase/avatar-peetzweg.jpg",
-    date: "Jul 7, 2026",
-    text: ["How the magic is happening today. Obviously using OpenDisplay for my Mactendo DS™ setup."],
-    image: {
-      src: "showcase/tweet-peetzweg.jpg",
-      alt: "MacBook with an iPhone perched above its screen as a second display — the Mactendo DS setup",
-      width: 1200,
-      height: 900,
-    },
-  },
-  {
-    kind: "post",
-    url: "https://x.com/Vincent_AINotes/status/2074137525669753178",
-    author: "Vincent",
-    handle: "@Vincent_AINotes",
-    avatar: "showcase/avatar-vincent.jpg",
-    date: "Jul 6, 2026",
-    text: [
-      "家里吃灰的 iPhone 或 iPad，居然还能给 Mac 当副屏。",
-      "OpenDisplay 装好后，Mac 会把它认成一块正经显示器，窗口能直接拖过去。插线能用，Wi-Fi 也能连，触控、双指滚动、横竖屏切换都有。",
-      "免费开源，也没有订阅。地址放下一条👇",
-    ],
-    translation: [
-      "The iPhone or iPad gathering dust at home can actually be a second screen for your Mac.",
-      "Once OpenDisplay is set up, the Mac sees it as a real monitor — just drag windows over. Works wired or over Wi-Fi, with touch, two-finger scroll, and portrait/landscape switching.",
-      "Free, open source, no subscription. Link in the next post 👇",
-    ],
-    image: {
-      src: "showcase/tweet-vincent.jpg",
-      alt: "An iPad running OpenDisplay beside a Mac mini, the app's device panel open showing Extend and Mirror options",
-      width: 900,
-      height: 1200,
-    },
-  },
-  {
-    kind: "post",
-    url: "https://x.com/ZIRIXdesign/status/2074053036591518069",
-    author: "ZIRIX",
-    handle: "@ZIRIXdesign",
-    avatar: "showcase/avatar-zirix.jpg",
-    date: "Jul 6, 2026",
-    text: [
-      "OpenDisplay这款软件确实很不错，可以将iphone作为mac的显示器来用，有些不支持随航的旧款iPad也可以使用，而且底层原理和系统自带的随航体验一样流畅，实测只要在同一局域网下没有距离限制，而且支持横竖屏自动切换，非常推荐！",
-    ],
-    translation: [
-      "OpenDisplay is genuinely great — you can use an iPhone as a Mac display, and even older iPads that don't support Sidecar work. It feels as smooth as Apple's built-in Sidecar; in my testing there's no distance limit as long as you're on the same LAN, and it auto-switches between portrait and landscape. Highly recommended!",
-    ],
-    image: {
-      src: "showcase/tweet-zirix.jpg",
-      alt: "An iPhone in landscape acting as a Mac display, sitting beside a Mac mini and a HomePod mini",
-      width: 900,
-      height: 1200,
-    },
-  },
-  {
-    kind: "post",
-    url: "https://x.com/kocpc/status/2074352423377031242",
-    author: "電腦王阿達",
-    handle: "@kocpc",
-    avatar: "showcase/avatar-kocpc.jpg",
-    date: "Jul 7, 2026",
-    text: [
-      "OpenDisplay 把 iPhone、iPad 變成 Mac 第二螢幕。",
-      "免費開源、可走有線或同 WiFi，臨時多一塊延伸螢幕很實用。",
-    ],
-    translation: [
-      "OpenDisplay turns an iPhone or iPad into a second screen for your Mac.",
-      "Free and open source, over a cable or the same Wi-Fi — a handy extra display in a pinch.",
-    ],
-    image: {
-      src: "showcase/tweet-kocpc.jpg",
-      alt: "Editorial graphic of an iPhone showing macOS as a second screen, captioned 'iPhone 變 Mac 第二螢幕'",
-      width: 1200,
-      height: 675,
-    },
-  },
+  ...COVERAGE,
 ]
 
-// X logomark, shown in the card corner as the "view on X" affordance.
-function XLogo() {
+function ExternalLinkIcon() {
   return (
-    <svg className="post-x" viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    <svg className="coverage-external" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42L17.59 5H14V3ZM5 5h6v2H7v10h10v-4h2v6H5V5Z" />
     </svg>
   )
 }
 
 export default function Showcase() {
   const trackRef = useRef<HTMLDivElement>(null)
+  const autoScrollFrame = useRef<number>(0)
+  const isAutoScrolling = useRef(false)
+  const pauseUntil = useRef(0)
   const [canPrev, setCanPrev] = useState(false)
   const [canNext, setCanNext] = useState(true)
 
-  // Keep the arrows honest: disable the one pointing at an edge we're on.
   useEffect(() => {
     const el = trackRef.current
     if (!el) return
@@ -175,18 +38,48 @@ export default function Showcase() {
       setCanNext(el.scrollLeft < el.scrollWidth - el.clientWidth - 8)
     }
     sync()
-    el.addEventListener("scroll", sync, { passive: true })
+    const onScroll = () => {
+      sync()
+      // Give manual scrolling room before the gentle tour resumes.
+      if (!isAutoScrolling.current) pauseUntil.current = performance.now() + 4000
+    }
+    el.addEventListener("scroll", onScroll, { passive: true })
     window.addEventListener("resize", sync)
     return () => {
-      el.removeEventListener("scroll", sync)
+      el.removeEventListener("scroll", onScroll)
       window.removeEventListener("resize", sync)
     }
   }, [])
 
+  useEffect(() => {
+    const el = trackRef.current
+    if (!el || window.matchMedia("(prefers-reduced-motion: reduce)").matches) return
+
+    let previous = performance.now()
+    const tick = (now: number) => {
+      const isPaused = now < pauseUntil.current || el.matches(":hover") || el.matches(":focus-within")
+      if (!isPaused) {
+        const max = el.scrollWidth - el.clientWidth
+        if (el.scrollLeft >= max - 1) {
+          isAutoScrolling.current = true
+          el.scrollTo({ left: 0, behavior: "auto" })
+          isAutoScrolling.current = false
+        } else {
+          isAutoScrolling.current = true
+          el.scrollLeft += (now - previous) * 0.012
+          isAutoScrolling.current = false
+        }
+      }
+      previous = now
+      autoScrollFrame.current = requestAnimationFrame(tick)
+    }
+    autoScrollFrame.current = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(autoScrollFrame.current)
+  }, [])
+
   const nudge = (dir: 1 | -1) => {
     const el = trackRef.current
-    if (!el) return
-    el.scrollBy({ left: dir * Math.round(el.clientWidth * 0.85), behavior: "smooth" })
+    if (el) el.scrollBy({ left: dir * Math.round(el.clientWidth * 0.85), behavior: "smooth" })
   }
 
   return (
@@ -206,41 +99,29 @@ export default function Showcase() {
               </div>
             </div>
           ) : (
-            <a key={item.url} className="showcase-item is-post" href={item.url}>
-              <div className="post-head">
-                <img className="post-avatar" src={item.avatar} alt="" width="48" height="48" loading="lazy" />
-                <div className="post-who">
-                  <span className="post-author">{item.author}</span>
-                  <span className="post-handle">{item.handle}</span>
-                </div>
-                <XLogo />
+            <a key={item.url} className={`showcase-item is-coverage${item.post ? " is-post" : ""}`} href={item.url} target="_blank" rel="noreferrer">
+              {item.post ? (
+                <>
+                  <div className="post-head">
+                    <span className="post-monogram" aria-hidden="true">{item.post.author.slice(0, 1)}</span>
+                    <div><strong>{item.post.author}</strong><span>@{item.post.handle}</span></div>
+                    <span className="post-x">𝕏</span>
+                  </div>
+                  <p className="post-quote">{item.post.text}</p>
+                  <span className="post-date">{item.post.date}</span>
+                </>
+              ) : item.image ? <img className="coverage-image" src={item.image} alt="" loading="lazy" /> : <div className="coverage-placeholder" aria-hidden="true" />}
+              <div className="coverage-body">
+                {!item.post && <><div className="coverage-site"><span>{item.site}</span><ExternalLinkIcon /></div><h3>{item.title}</h3><p>{item.description}</p></>}
+                <span className="coverage-cta">{item.site === "X" ? "View post ↗" : "Read coverage ↗"}</span>
               </div>
-              {item.text.map((line) => (
-                <p key={line} className="post-text">{line}</p>
-              ))}
-              {item.translation?.map((line) => (
-                <p key={line} className="post-trans" lang="en">{line}</p>
-              ))}
-              <img
-                className="post-photo"
-                src={item.image.src}
-                alt={item.image.alt}
-                width={item.image.width}
-                height={item.image.height}
-                loading="lazy"
-              />
-              <span className="post-date">{item.date} · View on X ↗</span>
             </a>
           )
         )}
       </div>
       <div className="showcase-nav">
-        <button type="button" aria-label="Scroll back" disabled={!canPrev} onClick={() => nudge(-1)}>
-          ←
-        </button>
-        <button type="button" aria-label="Scroll forward" disabled={!canNext} onClick={() => nudge(1)}>
-          →
-        </button>
+        <button type="button" aria-label="Scroll back" disabled={!canPrev} onClick={() => nudge(-1)}>←</button>
+        <button type="button" aria-label="Scroll forward" disabled={!canNext} onClick={() => nudge(1)}>→</button>
       </div>
     </div>
   )

--- a/src/content/coverage.ts
+++ b/src/content/coverage.ts
@@ -1,0 +1,78 @@
+// Curated from GitHub issue #220. Keep this as link metadata, not a hand-made
+// imitation of the source site: titles can be long, multilingual, or change
+// without breaking the layout. `tools/collect-coverage.mjs` refreshes fields
+// from Open Graph metadata when a publication supplies it.
+export type Coverage = {
+  kind: "coverage"
+  url: string
+  site: string
+  title: string
+  description: string
+  image?: string
+  post?: {
+    author: string
+    handle: string
+    date: string
+    text: string
+  }
+}
+
+export const COVERAGE: Coverage[] = [
+  {
+    kind: "coverage",
+    url: "https://www.macgadget.de/index.php/News/2026/08/12/OpenDisplay-iPhone-oder-iPad-als-Zusatzmonitor-fuer-den-Mac-nutzen",
+    site: "MacGadget",
+    title: "OpenDisplay: iPhone oder iPad als Zusatzmonitor für den Mac nutzen",
+    description: "News and background on Apple, Mac, iPhone and iPad.",
+  },
+  {
+    kind: "coverage",
+    url: "https://applech2.com/archives/20260809-opendisplay-support-apple-pencil-pressure.html",
+    site: "Applech2",
+    title: "iPadにMacの画面を映しセカンドモニターとして利用できるようにするアプリ「OpenDisplay」がApple Pencilの筆圧とチルト、ホバーに対応。",
+    description: "OpenDisplayはドイツのPhilip Poloczekさんがオープンソースで開発しているAppleデバイス用モニターアプリで、iPadにMacの画面を映し出しMacのセカンドモニターとして使用できるようにしてくれますが、このOpenDisplayがバージョン1.15.0でApple Pencilの機能に対応しています。",
+    image: "https://applech2.com/wp-content/uploads/2026/08/Opendisplay-support-Apple-Pencil-pressure-and-tilt-Hero-v2.webp",
+  },
+  {
+    kind: "coverage",
+    url: "https://www.ifun.de/opendisplay-kostenlose-sidecar-alternative-aus-deutschland-283401",
+    site: "ifun.de",
+    title: "OpenDisplay: kostenlose Sidecar-Alternative aus Deutschland",
+    description: "Wer ein iPhone oder iPad als zusätzlichen Bildschirm für den Mac verwenden möchte, ist bislang meist auf Apples Sidecar angewiesen. Mit OpenDisplay steht nun eine Alternative bereit, die einen anderen Ansatz verfolgt und dabei auf eine Reihe von Einschränkungen verzichtet, die Apples Lösung mit sich bringt.",
+    image: "https://images.ifun.de/wp-content/uploads/2026/07/opensidecar-feature.jpg",
+  },
+  {
+    kind: "coverage",
+    url: "https://www.sir-apfelot.de/opendisplay-70912/",
+    site: "Sir Apfelot",
+    title: "Statt Sidecar: OpenDisplay erweitert Mac-Display auf iPhone und iPad",
+    description: "Mit OpenDisplay lässt sich das iPhone oder iPad als zusätzliches Mac-Display nutzen. Dafür müssen die Geräte noch nichtmal den gleichen Apple Account nutzen.",
+    image: "https://www.sir-apfelot.de/wp-content/uploads/2026/07/opendisplay-sidecar-alternative.jpg",
+  },
+  {
+    kind: "coverage",
+    url: "https://www.appgefahren.de/opendisplay-kostenlose-open-source-app-nutzt-ipad-als-zweites-mac-display-403961.html",
+    site: "appgefahren.de",
+    title: "OpenDisplay: Kostenlose Open-Source-App nutzt iPad als zweites Mac-Display",
+    description: "Mit der OpenDisplay-App des unabhängigen Entwicklers Philip Polosczek lassen sich kostenlos iPads und iPhones als zweiter Bildschirm nutzen.",
+    image: "https://www.appgefahren.de/wp-content/uploads/2026/08/OpenDisplay-Mac-iPad.jpg",
+  },
+  ...[
+    ["https://x.com/z12789/status/2087988422824837490", "damo", "z12789", "August 13, 2026", "之前通过Mac OS sidecar 把iPad 作为副屏使用，但是只能横屏不能竖屏。最后发现免费方案 OpenDisplay 很好的解决了这个问题。"],
+    ["https://x.com/CamilleRoux/status/2080291868101812582", "Camille Roux", "CamilleRoux", "July 23, 2026", "OpenDisplay : utilisez votre iPhone ou iPad comme second écran pour votre Mac, en USB ou WiFi. Open source, gratuit, sans compte, sans dongle."],
+    ["https://x.com/aladagberk/status/2083230517537718553", "Berk Aladag", "aladagberk", "July 31, 2026", "Eski iPhone veya iPad'in çekmecede duruyorsa, onu Mac'in için gerçek bir ikinci monitöre dönüştürebilirsin. OpenDisplay; Apple Sidecar ve Duet Display'e ücretsiz, açık kaynaklı bir alternatif."],
+    ["https://x.com/oliviscusAI/status/2082506100021305653", "Oliver Prompts", "oliviscusAI", "July 29, 2026", "Apple's Sidecar only works if your iPad and Mac share the same Apple ID. Duet charges a subscription. OpenDisplay does it free, no account, no dongle."],
+    ["https://x.com/RocM301/status/2077288370334740496", "小鹏Digital", "RocM301", "July 15, 2026", "OpenDisplay还是蛮好玩的，使用的usb-c连接。iPad mini作为副屏延迟很好，保留了触摸体验。它不需要像系统内置的Sidecar那样要求同一个Apple ID。"],
+    ["https://x.com/RocM301/status/2076896134455566495", "小鹏Digital", "RocM301", "July 14, 2026", "闲置iPhone/iPad变Mac第二屏？OpenDisplay免费开源版来了！不用Sidecar限制、不用Duet订阅，直接USB或WiFi连，低延迟Retina画质还能触屏操作！"],
+    ["https://x.com/okdt/status/2086467678991180198", "オカダリョウタロウ", "okdt", "August 9, 2026", "OpenDisplay 使ってみてる。iPhone/iPadがMacの拡張ディスプレイになる。無料・アカウント不要、外部サーバー・テレメトリはないGPL-3.0のOSS。"],
+    ["https://x.com/MacGeneration/status/2079841743303057559", "MacGeneration", "MacGeneration", "July 22, 2026", "OpenDisplay : l’alternative gratuite à Sidecar qui supprime plusieurs limites d’Apple."],
+    ["https://x.com/GcZsmkv/status/2073793241083003241", "阿尼欧Tiffany", "GcZsmkv", "July 5, 2026", "🪄平替工具：免费且开源的将你的 iPhone 或 iPad 变成 Mac 的扩展显示器工具“OpenDisplay”，就像是Apple Sidecar（随航）功能的一个开源替代品。"],
+  ].map(([url, author, handle, date, text]) => ({
+    kind: "coverage" as const,
+    url,
+    site: "X",
+    title: `${author} on X`,
+    description: text,
+    post: { author, handle, date, text },
+  })),
+]

--- a/src/index.css
+++ b/src/index.css
@@ -167,30 +167,41 @@ h2 { font-size: clamp(1.5rem, 3vw, 2rem); line-height: 1.1; letter-spacing: -0.0
 .showcase-track::-webkit-scrollbar { display: none; }
 .showcase-item { flex: 0 0 auto; scroll-snap-align: start; }
 .showcase-item.is-video { width: min(84vw, 640px); }
-.showcase-item.is-post { width: min(84vw, 400px); }
-/* Post cards: self-contained, self-hosted renditions of community posts.
-   The whole card is one link to the post on X. */
-a.showcase-item.is-post { display: block; border: 1px solid var(--line);
-  padding: 18px 20px; text-decoration: none;
-  color: var(--fg); background: var(--bg); }
-a.showcase-item.is-post:hover { border-color: var(--line-strong); }
-.post-head { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
-.post-avatar { width: 44px; height: 44px; border-radius: 50%; display: block; }
-.post-who { display: flex; flex-direction: column; line-height: 1.3; min-width: 0; }
-.post-author { font-weight: 600; font-size: 0.95rem; }
-.post-handle { color: var(--muted); font-size: 0.86rem; }
-.post-x { width: 18px; height: 18px; fill: var(--faint); margin-left: auto; flex: none; }
-.showcase-item.is-post:hover .post-x { fill: var(--fg); }
-.post-text { font-size: 0.95rem; margin: 0; }
-.post-text + .post-text { margin-top: 0.5em; }
-.post-trans { font-size: 0.9rem; line-height: 1.45; margin: 12px 0 0;
-  color: var(--muted); font-style: italic; }
-.post-trans + .post-trans { margin-top: 0.5em; }
-.post-photo { display: block; width: 100%; height: auto;
-  margin: 14px 0 12px; border: 1px solid var(--line); }
-.post-date { font-family: var(--mono); font-size: 0.72rem; letter-spacing: 0.04em;
-  color: var(--faint); }
-.showcase-item.is-post:hover .post-date { color: var(--muted); }
+.showcase-item.is-coverage { width: min(84vw, 350px); }
+/* External links use their publication's own Open Graph title, description,
+   and image when available. This is intentionally a generic preview rather
+   than a fragile recreation of an article or X post. */
+a.showcase-item.is-coverage { display: flex; min-height: 312px; flex-direction: column;
+  border: 1px solid var(--line); text-decoration: none; color: var(--fg); background: var(--bg); }
+a.showcase-item.is-coverage:hover { border-color: var(--line-strong); }
+.coverage-image, .coverage-placeholder { display: block; width: 100%; height: 150px; object-fit: cover;
+  border-bottom: 1px solid var(--line); }
+.coverage-placeholder { background: linear-gradient(135deg, #eef7ff, #d7edff 48%, #f8fbfd); }
+.coverage-body { display: flex; flex: 1; flex-direction: column; padding: 18px 20px; }
+.coverage-site { display: flex; align-items: center; gap: 6px; color: var(--faint); font-family: var(--mono);
+  font-size: 0.7rem; letter-spacing: 0.08em; text-transform: uppercase; }
+.coverage-external { width: 13px; height: 13px; fill: currentColor; }
+.coverage-body h3 { font-size: 1rem; line-height: 1.28; letter-spacing: -0.01em; margin-top: 10px; }
+.coverage-body p { color: var(--muted); font-size: 0.86rem; line-height: 1.45; margin-top: 8px; }
+.coverage-cta { color: var(--muted); font-family: var(--mono); font-size: 0.72rem;
+  letter-spacing: 0.04em; margin-top: auto; padding-top: 16px; }
+a.showcase-item.is-coverage:hover .coverage-cta { color: var(--fg); }
+/* X posts use the public oEmbed copy at curation time. Keeping the original
+   language (and a contained excerpt) makes each recommendation recognisable
+   without pulling X's widget or trying to recreate its full interface. */
+a.showcase-item.is-post { min-height: 0; padding: 18px 20px 0; }
+.post-head { display: flex; align-items: center; gap: 10px; }
+.post-monogram { display: grid; flex: none; place-items: center; width: 38px; height: 38px;
+  border-radius: 50%; background: var(--accent); color: #fff; font-size: 0.95rem; font-weight: 700; }
+.post-head > div { display: flex; min-width: 0; flex-direction: column; line-height: 1.25; }
+.post-head strong { font-size: 0.9rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.post-head span:not(.post-monogram):not(.post-x) { color: var(--muted); font-size: 0.8rem; }
+.post-x { margin-left: auto; color: var(--faint); font-size: 1.1rem; }
+.post-quote { display: -webkit-box; margin-top: 16px; overflow: hidden; color: var(--fg);
+  font-size: 0.93rem; line-height: 1.5; -webkit-box-orient: vertical; -webkit-line-clamp: 6; }
+.post-date { margin-top: 12px; color: var(--faint); font-family: var(--mono); font-size: 0.7rem;
+  letter-spacing: 0.04em; }
+a.showcase-item.is-post .coverage-body { min-height: 52px; padding: 0; }
 .showcase-nav { display: flex; gap: 10px; margin-top: 16px; justify-content: flex-end;
   padding-inline: var(--bleed-pad); }
 .showcase-nav button { font-family: var(--mono); font-size: 1rem; line-height: 1;

--- a/tools/collect-coverage.mjs
+++ b/tools/collect-coverage.mjs
@@ -1,0 +1,31 @@
+// One-off metadata refresher. It is deliberately not part of `pnpm build`:
+// production builds must remain deterministic and must not depend on third-
+// party sites being reachable. Review the printed values before copying them
+// into src/content/coverage.ts.
+import { readFile } from "node:fs/promises"
+
+const decode = (value) => value.replace(/&amp;/g, "&").replace(/&quot;/g, '"').replace(/&#39;/g, "'")
+const valueFor = (html, property) => {
+  const escaped = property.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const match = html.match(new RegExp(`<meta[^>]+(?:property|name)=["']${escaped}["'][^>]+content=["']([^"']+)["']`, "i"))
+    ?? html.match(new RegExp(`<meta[^>]+content=["']([^"']+)["'][^>]+(?:property|name)=["']${escaped}["']`, "i"))
+  return match?.[1] ? decode(match[1]) : undefined
+}
+
+const source = await readFile(new URL("../src/content/coverage.ts", import.meta.url), "utf8")
+const urls = [...source.matchAll(/url: "(https:\/\/[^\"]+)"/g)].map(([, url]) => url).filter((url) => !url.includes("x.com"))
+
+for (const url of urls) {
+  try {
+    const response = await fetch(url, { headers: { "user-agent": "OpenDisplay coverage metadata refresher" } })
+    const html = await response.text()
+    console.log(JSON.stringify({
+      url,
+      title: valueFor(html, "og:title") ?? valueFor(html, "twitter:title"),
+      description: valueFor(html, "og:description") ?? valueFor(html, "description"),
+      image: valueFor(html, "og:image") ?? valueFor(html, "twitter:image"),
+    }, null, 2))
+  } catch (error) {
+    console.error(`Could not read ${url}: ${error.message}`)
+  }
+}


### PR DESCRIPTION
Closes #220.\n\nAdds the press and community coverage links from the issue, using Open Graph previews for articles and oEmbed-sourced author/text excerpts for X posts. The carousel now auto-scrolls gently, pauses on hover/focus or manual interaction, and respects reduced-motion preferences.\n\nVerified with: pnpm build