### PR TITLE
feat(ios): forward predicted pencil touches to eliminate stroke latency (#191)

### DIFF
--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -1041,6 +1041,15 @@ final class InputCaptureEngine: NSObject {
                            azimuth: Double(c.azimuthAngle(in: view)),
                            altitude: Double(c.altitudeAngle))
             }
+            if let predicted = event?.predictedTouches(for: touch) {
+                for p in predicted {
+                    guard let pn = normalize?(p.location(in: view)) else { continue }
+                    emitPencil("move", x: pn.x, y: pn.y,
+                               pressure: min(Double(p.force), 1.0),
+                               azimuth: Double(p.azimuthAngle(in: view)),
+                               altitude: Double(p.altitudeAngle))
+                }
+            }
             return
         }
 


### PR DESCRIPTION
## Summary

Rescoped per maintainer feedback ([comment](https://github.com/peetzweg/opendisplay/pull/244#issuecomment-5499403668)):
The mirror capture half was independently addressed in #258 (v1.19.0). This PR is now focused strictly on Apple Pencil predicted touches (#191), rebased onto current `main`.

### Apple Pencil Predicted Touches Forwarding (#191)
- In `InputCaptureEngine.emitPen` (`iOS/OpenSidecarPhoneApp.swift`), forwards `event.predictedTouches(for: touch)` during active strokes.
- Uses iOS predictive stroke modeling to eliminate apparent stylus latency during sketching and drawing across network and USB pipelines.

## Verification
- `xcodegen generate && xcodebuild test -project OpenSidecar.xcodeproj -scheme OpenSidecarMac -destination 'platform=macOS'` passes cleanly.
- Rebased cleanly onto latest `main`.