### PR TITLE
fix(transport): seamless USB migration, disconnect grace failover & transport state polish (#141, #140, #139)

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -128,6 +128,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // not a delta — repeated bumps in one session must not accumulate into
     // an offset nothing ever validated.
     @MainActor var onDisplayIdentityBumped: ((UInt32) -> Void)?
+    @MainActor var onTransportConfirmed: ((SenderTransport) -> Void)?
 
     private var stream: SCStream?
     private var encoder: VTCompressionSession?
@@ -509,7 +510,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                                           })
                 }
                 if created != nil { break }
-                Log.info("virtual display creation failed (identity +\(totalOffset), attempt \(attempt + 1)) — retrying")
+                if attempt < (probe == 0 ? 7 : 2) {
+                    Log.info("virtual display creation failed (identity +\(totalOffset), attempt \(attempt + 1)) — retrying")
+                } else {
+                    Log.info("virtual display creation failed (identity +\(totalOffset), attempt \(attempt + 1)) — max attempts reached")
+                }
                 await status("Preparing virtual display…")
             }
             guard let candidate = created else { continue }
@@ -1051,7 +1056,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         } else {
             stopUpgradeProbing()   // already off WiFi — nothing better to find
         }
-        Task { await self.status("Connected to \(self.endpointName)") }
+        let activeTransport = self.transport
+        Task { @MainActor in
+            self.onTransportConfirmed?(activeTransport)
+            await self.status("Connected to \(self.endpointName)")
+        }
     }
 
     // MARK: - Cable upgrade (PROTOCOL.md 6.4)

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -262,6 +262,7 @@ final class SenderController: ObservableObject {
             DispatchQueue.main.async {
                 guard let self else { return }
                 self.discovered = Array(results)
+                self.failoverPendingSessions()
                 self.endSessionsWhoseServiceVanished()
                 self.autoConnect()
             }
@@ -385,6 +386,20 @@ final class SenderController: ObservableObject {
             guard let udid = session.usbUDID, detachedUDIDs.contains(udid),
                   let result = wifiService(for: session) else { continue }
             Log.info("cable detached for \(session.id) — failing over to WiFi")
+            session.wifiServiceName = serviceName(of: result)
+            session.sender.switchTransport(to: .tcp(result.endpoint))
+        }
+    }
+
+    /// Re-evaluates USB sessions whose cable was disconnected during their
+    /// grace period when their WiFi Bonjour service becomes visible.
+    private func failoverPendingSessions() {
+        guard autoConnectEnabled else { return }
+        let attachedUDIDs = Set(usbDevices.map(\.udid))
+        for session in sessions where session.onUSB {
+            guard let udid = session.usbUDID, !attachedUDIDs.contains(udid),
+                  let result = wifiService(for: session) else { continue }
+            Log.info("WiFi service appeared for detached cabled session \(session.id) — failing over to WiFi")
             session.wifiServiceName = serviceName(of: result)
             session.sender.switchTransport(to: .tcp(result.endpoint))
         }

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -453,12 +453,20 @@ final class SenderController: ObservableObject {
         })
         for s in sessions {
             guard case .wifi(let result) = s.target else { continue }
-            let duplicate = (s.deviceID.map { usbSessionIDs.contains($0) } ?? false)
-                || (txtID(of: result).map { usbSessionIDs.contains($0) } ?? false)
-                || (serviceName(of: result).map { cabledNames.contains($0) } ?? false)
-            if duplicate {
-                Log.info("two sessions for one device — keeping the cable, dropping \(s.id)")
-                end(s)
+            let matchingUSB = usbDevices.first { device in
+                sameDevice(result, device) && !usbDisabled.contains("usb:\(device.udid)")
+            }
+            if let matchingUSB, !s.onUSB {
+                Log.info("cable attached for duplicate session \(s.id) — migrating to USB")
+                upgradeToUSB(s, device: matchingUSB)
+            } else {
+                let duplicate = (s.deviceID.map { usbSessionIDs.contains($0) } ?? false)
+                    || (txtID(of: result).map { usbSessionIDs.contains($0) } ?? false)
+                    || (serviceName(of: result).map { cabledNames.contains($0) } ?? false)
+                if duplicate {
+                    Log.info("two sessions for one device — keeping the cable, dropping \(s.id)")
+                    end(s)
+                }
             }
         }
     }

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -370,8 +370,6 @@ final class SenderController: ObservableObject {
     private func upgradeToUSB(_ session: DeviceSession, device: UsbmuxDevice) {
         guard !session.onUSB, let portNum = UInt16(port) else { return }
         Log.info("cable attached for \(session.id) — migrating to USB")
-        session.onUSB = true
-        session.usbUDID = device.udid
         // The match may have been by name only — pin the strong identity so
         // future matching (and the next launch) recognizes the pair.
         if let id = session.deviceID { installIDByUDID[device.udid] = id }
@@ -387,7 +385,6 @@ final class SenderController: ObservableObject {
             guard let udid = session.usbUDID, detachedUDIDs.contains(udid),
                   let result = wifiService(for: session) else { continue }
             Log.info("cable detached for \(session.id) — failing over to WiFi")
-            session.onUSB = false
             session.wifiServiceName = serviceName(of: result)
             session.sender.switchTransport(to: .tcp(result.endpoint))
         }
@@ -554,6 +551,16 @@ final class SenderController: ObservableObject {
             guard let session, session.status != text else { return }
             session.status = text
             Log.info("status[\(id)]: \(text)")
+        }
+        sender.onTransportConfirmed = { [weak session] transport in
+            guard let session else { return }
+            switch transport {
+            case .usb(let udid, _):
+                session.onUSB = true
+                if let udid { session.usbUDID = udid }
+            case .tcp:
+                session.onUSB = false
+            }
         }
         sender.onHello = { [weak self, weak session] info in
             guard let self, let session else { return }


### PR DESCRIPTION
## Summary

This PR polishes transport switching and lifecycle migration between USB and WiFi:

### 1. Defer Transport Flag Flip Until Link Confirmed Ready (#141)
- Emits `onTransportConfirmed` in `MacSender.becomeReady` and defers updating `session.onUSB` until the link is ready.
- Fixes retry count logging so it avoids logging 'retrying' on the final attempt.

### 2. Re-evaluate USB to WiFi Failover During Disconnect Grace Period (#140)
- Adds `failoverPendingSessions()` invoked on Bonjour browse changes.
- Seamlessly triggers WiFi failover when a WiFi candidate appears while a disconnected USB session is within its grace window.

### 3. Seamless Live Session Migration on First Cable Attach (#139)
- In `dedupeSessions()`, migrates an active WiFi session to USB in-place via `switchTransport` instead of terminating it.
- Prevents destroying the virtual display or causing screen flash when plugging in a cable while streaming over WiFi.

## Verification
- `xcodegen generate && xcodebuild test -project OpenSidecar.xcodeproj -scheme OpenSidecarMac -destination 'platform=macOS'` — all 34/34 tests pass.
- `xcodebuild build -project OpenSidecar.xcodeproj -scheme OpenSidecariOS -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO` — builds cleanly.
