### PR TITLE
feat(input): hardware keyboard passthrough & on-screen modifier sidebar (#6, #7)

### DIFF
--- a/Mac/InputInjector.swift
+++ b/Mac/InputInjector.swift
@@ -41,6 +41,7 @@ final class InputInjector {
     private let vendorPointerType: Int64 = 0x0802    // Grip Pen (what apps expect)
     private let capabilityMask: Int64 = 0x05C7       // pressure + tilt + rotation + buttons
     private var inRange = false
+    private var stickyModifiers: CGEventFlags = []
 
     // Pencil-only synthetic click counting — tablet events don't get click
     // state from the Window Server, so we mirror macOS double-click prefs here.
@@ -60,6 +61,33 @@ final class InputInjector {
 
     init(displayID: CGDirectDisplayID) {
         self.displayID = displayID
+    }
+
+    /// Sets sticky modifier flags sent from on-screen modifier sidebar (issue #7).
+    func setStickyModifiers(_ rawFlags: UInt) {
+        stickyModifiers = Self.eventFlags(for: rawFlags)
+    }
+
+    /// Injects keyboard key down/up events from connected hardware keyboards (issue #6).
+    func handleKey(hidUsage: UInt16, down: Bool, rawModifiers: UInt = 0, characters: String? = nil) {
+        guard let vk = Self.macKeyCode(for: hidUsage) else { return }
+        guard let event = CGEvent(keyboardEventSource: source, virtualKey: vk, keyDown: down) else { return }
+        var flags = Self.eventFlags(for: rawModifiers, sticky: stickyModifiers)
+        if down {
+            switch vk {
+            case 0x38, 0x3C: flags.insert(.maskShift)
+            case 0x3B, 0x3E: flags.insert(.maskControl)
+            case 0x3A, 0x3D: flags.insert(.maskAlternate)
+            case 0x37, 0x36: flags.insert(.maskCommand)
+            default: break
+            }
+        }
+        event.flags = flags
+        if let chars = characters, !chars.isEmpty, down {
+            let utf16 = Array(chars.utf16)
+            event.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: utf16)
+        }
+        event.post(tap: .cghidEventTap)
     }
 
     static func ensureAccessibilityPermission() -> Bool {
@@ -110,6 +138,9 @@ final class InputInjector {
         guard let event = CGEvent(mouseEventSource: source, mouseType: type,
                                   mouseCursorPosition: point, mouseButton: .left) else { return }
         event.setIntegerValueField(.mouseEventClickState, value: Int64(clickState))
+        if !stickyModifiers.isEmpty {
+            event.flags.insert(stickyModifiers)
+        }
         event.post(tap: .cghidEventTap)
     }
 
@@ -140,7 +171,7 @@ final class InputInjector {
         if phase == "down", !inRange {
             setProximity(entering: true, at: p)
         }
-        let (tiltX, tiltY) = deriveTilt(azimuth: azimuth, altitude: altitude)
+        let (tiltX, tiltY) = Self.tiltVector(altitude: altitude, azimuth: azimuth)
 
         switch phase {
         case "down":
@@ -279,9 +310,102 @@ final class InputInjector {
     /// is a unit vector in -1...1, so normalize rather than pass radians through
     /// (unnormalized, a flat pen reads 1.57 and apps that scale tilt by 90 report
     /// impossible angles).
-    private func deriveTilt(azimuth: Double, altitude: Double) -> (Double, Double) {
+    static func tiltVector(altitude: Double, azimuth: Double) -> (x: Double, y: Double) {
         let mag = min(max(0, Double.pi / 2 - altitude) / (Double.pi / 2), 1)
         return (sin(azimuth) * mag, cos(azimuth) * mag)
+    }
+
+    /// Converts UIKeyModifierFlags bitmask to macOS CGEventFlags.
+    static func eventFlags(for rawModifiers: UInt, sticky: CGEventFlags = []) -> CGEventFlags {
+        var flags: CGEventFlags = sticky
+        if rawModifiers & (1 << 17) != 0 { flags.insert(.maskShift) }
+        if rawModifiers & (1 << 18) != 0 { flags.insert(.maskControl) }
+        if rawModifiers & (1 << 19) != 0 { flags.insert(.maskAlternate) }
+        if rawModifiers & (1 << 20) != 0 { flags.insert(.maskCommand) }
+        if rawModifiers & (1 << 16) != 0 { flags.insert(.maskAlphaShift) }
+        return flags
+    }
+
+    /// Maps standard USB HID Keyboard Usage page (0x07) codes to macOS virtual keycodes (CGKeyCode).
+    static func macKeyCode(for hidUsage: UInt16) -> CGKeyCode? {
+        switch hidUsage {
+        // Letters (A-Z)
+        case 0x04: return 0x00 // A
+        case 0x05: return 0x0B // B
+        case 0x06: return 0x08 // C
+        case 0x07: return 0x02 // D
+        case 0x08: return 0x0E // E
+        case 0x09: return 0x03 // F
+        case 0x0A: return 0x05 // G
+        case 0x0B: return 0x04 // H
+        case 0x0C: return 0x22 // I
+        case 0x0D: return 0x26 // J
+        case 0x0E: return 0x28 // K
+        case 0x0F: return 0x25 // L
+        case 0x10: return 0x2E // M
+        case 0x11: return 0x2D // N
+        case 0x12: return 0x1F // O
+        case 0x13: return 0x23 // P
+        case 0x14: return 0x0C // Q
+        case 0x15: return 0x0F // R
+        case 0x16: return 0x01 // S
+        case 0x17: return 0x11 // T
+        case 0x18: return 0x20 // U
+        case 0x19: return 0x09 // V
+        case 0x1A: return 0x0D // W
+        case 0x1B: return 0x07 // X
+        case 0x1C: return 0x10 // Y
+        case 0x1D: return 0x06 // Z
+
+        // Digits (1-0)
+        case 0x1E: return 0x12 // 1
+        case 0x1F: return 0x13 // 2
+        case 0x20: return 0x14 // 3
+        case 0x21: return 0x15 // 4
+        case 0x22: return 0x17 // 5
+        case 0x23: return 0x16 // 6
+        case 0x24: return 0x1A // 7
+        case 0x25: return 0x1C // 8
+        case 0x26: return 0x19 // 9
+        case 0x27: return 0x1D // 0
+
+        // Functional & punctuation
+        case 0x28: return 0x24 // Return
+        case 0x29: return 0x35 // Escape
+        case 0x2A: return 0x33 // Delete (Backspace)
+        case 0x2B: return 0x30 // Tab
+        case 0x2C: return 0x31 // Space
+        case 0x2D: return 0x1B // Hyphen / Minus
+        case 0x2E: return 0x18 // Equal
+        case 0x2F: return 0x21 // Left Bracket
+        case 0x30: return 0x1E // Right Bracket
+        case 0x31: return 0x2A // Backslash
+        case 0x33: return 0x29 // Semicolon
+        case 0x34: return 0x27 // Quote
+        case 0x35: return 0x32 // Grave / Tilde
+        case 0x36: return 0x2B // Comma
+        case 0x37: return 0x2F // Period
+        case 0x38: return 0x2C // Slash
+        case 0x39: return 0x39 // Caps Lock
+
+        // Arrow navigation
+        case 0x4F: return 0x7C // Right Arrow
+        case 0x50: return 0x7B // Left Arrow
+        case 0x51: return 0x7D // Down Arrow
+        case 0x52: return 0x7E // Up Arrow
+
+        // Modifiers
+        case 0xE0: return 0x3B // Left Control
+        case 0xE1: return 0x38 // Left Shift
+        case 0xE2: return 0x3A // Left Option
+        case 0xE3: return 0x37 // Left Command
+        case 0xE4: return 0x3E // Right Control
+        case 0xE5: return 0x3C // Right Shift
+        case 0xE6: return 0x3D // Right Option
+        case 0xE7: return 0x36 // Right Command
+
+        default: return nil
+        }
     }
 
     private func screenPoint(nx: Double, ny: Double) -> CGPoint {

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -1799,6 +1799,17 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                let y = obj["y"] as? Double {
                 inputInjector?.handleProximity(entering: entering, x: x, y: y)
             }
+        case "key":
+            if let code = obj["code"] as? Int,
+               let down = obj["down"] as? Bool {
+                let mod = obj["mod"] as? UInt ?? 0
+                let char = obj["char"] as? String
+                inputInjector?.handleKey(hidUsage: UInt16(code), down: down, rawModifiers: mod, characters: char)
+            }
+        case "modSidebar":
+            if let flags = obj["flags"] as? UInt {
+                inputInjector?.setStickyModifiers(flags)
+            }
         case "kf":
             // The phone's decoder lost sync (e.g. it attached mid-GOP and
             // periodic keyframes are off) — force an IDR on the next frame.

--- a/MacTests/InputInjectorTests.swift
+++ b/MacTests/InputInjectorTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+import CoreGraphics
+
+final class InputInjectorTests: XCTestCase {
+
+    func testHIDUsageToMacKeyCodeMapping() {
+        // Letters
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x04), 0x00) // A
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x05), 0x0B) // B
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x06), 0x08) // C
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x07), 0x02) // D
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x1D), 0x06) // Z
+
+        // Numbers
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x1E), 0x12) // 1
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x27), 0x1D) // 0
+
+        // Functional
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x28), 0x24) // Return
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x29), 0x35) // Escape
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x2A), 0x33) // Delete
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x2B), 0x30) // Tab
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x2C), 0x31) // Space
+
+        // Arrows
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x4F), 0x7C) // Right
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x50), 0x7B) // Left
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x51), 0x7D) // Down
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x52), 0x7E) // Up
+
+        // Modifiers
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0xE0), 0x3B) // L-Ctrl
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0xE1), 0x38) // L-Shift
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0xE2), 0x3A) // L-Option
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0xE3), 0x37) // L-Cmd
+
+        // Unknown
+        XCTAssertNil(InputInjector.macKeyCode(for: 0xFFFF))
+    }
+
+    func testEventFlagsTranslation() {
+        let shiftRaw: UInt = 1 << 17
+        let ctrlRaw: UInt = 1 << 18
+        let optRaw: UInt = 1 << 19
+        let cmdRaw: UInt = 1 << 20
+
+        XCTAssertTrue(InputInjector.eventFlags(for: shiftRaw).contains(.maskShift))
+        XCTAssertTrue(InputInjector.eventFlags(for: ctrlRaw).contains(.maskControl))
+        XCTAssertTrue(InputInjector.eventFlags(for: optRaw).contains(.maskAlternate))
+        XCTAssertTrue(InputInjector.eventFlags(for: cmdRaw).contains(.maskCommand))
+
+        let combined = InputInjector.eventFlags(for: shiftRaw | cmdRaw)
+        XCTAssertTrue(combined.contains(.maskShift))
+        XCTAssertTrue(combined.contains(.maskCommand))
+        XCTAssertFalse(combined.contains(.maskAlternate))
+    }
+
+    func testStickyModifiersCombination() {
+        let sticky: CGEventFlags = [.maskCommand]
+        let shiftRaw: UInt = 1 << 17
+        let result = InputInjector.eventFlags(for: shiftRaw, sticky: sticky)
+        XCTAssertTrue(result.contains(.maskShift))
+        XCTAssertTrue(result.contains(.maskCommand))
+    }
+
+    func testKeyInjectionSmoke() {
+        let injector = InputInjector(displayID: CGMainDisplayID())
+        injector.handleKey(hidUsage: 0x04, down: true, rawModifiers: 0, characters: "a")
+        injector.handleKey(hidUsage: 0x04, down: false, rawModifiers: 0, characters: "a")
+
+        injector.setStickyModifiers(1 << 20) // Command
+        injector.handleKey(hidUsage: 0x06, down: true, rawModifiers: 0, characters: "c")
+        injector.handleKey(hidUsage: 0x06, down: false, rawModifiers: 0, characters: "c")
+    }
+
+    func testTiltMathVector() {
+        let upright = InputInjector.tiltVector(altitude: .pi / 2, azimuth: 0)
+        XCTAssertEqual(upright.x, 0.0, accuracy: 1e-6)
+        XCTAssertEqual(upright.y, 0.0, accuracy: 1e-6)
+
+        let flatUp = InputInjector.tiltVector(altitude: 0, azimuth: 0)
+        XCTAssertEqual(flatUp.x, 0.0, accuracy: 1e-6)
+        XCTAssertEqual(flatUp.y, 1.0, accuracy: 1e-6)
+
+        let flatRight = InputInjector.tiltVector(altitude: 0, azimuth: .pi / 2)
+        XCTAssertEqual(flatRight.x, 1.0, accuracy: 1e-6)
+        XCTAssertEqual(flatRight.y, 0.0, accuracy: 1e-6)
+
+        let overPitched = InputInjector.tiltVector(altitude: 2.0, azimuth: 0)
+        XCTAssertEqual(overPitched.x, 0.0, accuracy: 1e-6)
+        XCTAssertEqual(overPitched.y, 0.0, accuracy: 1e-6)
+    }
+
+    func testTouchAndScrollHandling() {
+        let injector = InputInjector(displayID: CGMainDisplayID())
+        injector.handleTouch(phase: "began", x: 0.5, y: 0.5)
+        injector.handleTouch(phase: "moved", x: 0.6, y: 0.6)
+        injector.handleTouch(phase: "ended", x: 0.6, y: 0.6)
+        injector.handleScroll(dx: 10, dy: -20)
+    }
+}

--- a/Shared/StreamReceiver.swift
+++ b/Shared/StreamReceiver.swift
@@ -939,6 +939,18 @@ final class StreamReceiver: ObservableObject {
         sendControl(["type": "proximity", "entering": entering, "x": x, "y": y])
     }
 
+    /// Hardware keyboard key events (issue #6).
+    func sendKey(code: Int, down: Bool, mod: UInt, char: String? = nil) {
+        var msg: [String: Any] = ["type": "key", "code": code, "down": down, "mod": mod]
+        if let char, !char.isEmpty { msg["char"] = char }
+        sendControl(msg)
+    }
+
+    /// Sticky modifier flags from on-screen sidebar (issue #7).
+    func sendStickyModifiers(_ flags: UInt) {
+        sendControl(["type": "modSidebar", "flags": flags])
+    }
+
     private func sendControl(_ message: [String: Any], on conn: NWConnection? = nil,
                              completion: (() -> Void)? = nil) {
         guard let conn = conn ?? connection,

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -86,6 +86,10 @@ struct ReceiverScreen: View {
                         }
                         .allowsHitTesting(false)   // never block touch input
                     }
+                    HStack {
+                        ModifierSidebarView(receiver: model.receiver)
+                        Spacer()
+                    }
                 } else {
                     IdleView(receiver: model.receiver, showSettings: $showSettings)
                 }
@@ -930,7 +934,10 @@ struct VideoLayerView: UIViewRepresentable {
             }
         }
 
+        override var canBecomeFirstResponder: Bool { true }
+
         override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+            if !isFirstResponder { becomeFirstResponder() }
             routeTouches("began", touches, event, ended: false)
         }
         override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -941,6 +948,43 @@ struct VideoLayerView: UIViewRepresentable {
         }
         override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
             routeTouches("cancelled", touches, event, ended: true)
+        }
+
+        override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+            guard let receiver else { super.pressesBegan(presses, with: event); return }
+            var handled = false
+            for press in presses {
+                if let key = press.key {
+                    receiver.sendKey(code: Int(key.keyCode.rawValue), down: true,
+                                     mod: UInt(key.modifierFlags.rawValue), char: key.characters)
+                    handled = true
+                }
+            }
+            if !handled { super.pressesBegan(presses, with: event) }
+        }
+
+        override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+            guard let receiver else { super.pressesEnded(presses, with: event); return }
+            var handled = false
+            for press in presses {
+                if let key = press.key {
+                    receiver.sendKey(code: Int(key.keyCode.rawValue), down: false,
+                                     mod: UInt(key.modifierFlags.rawValue), char: key.characters)
+                    handled = true
+                }
+            }
+            if !handled { super.pressesEnded(presses, with: event) }
+        }
+
+        override func pressesCancelled(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+            guard let receiver else { super.pressesCancelled(presses, with: event); return }
+            for press in presses {
+                if let key = press.key {
+                    receiver.sendKey(code: Int(key.keyCode.rawValue), down: false,
+                                     mod: UInt(key.modifierFlags.rawValue), char: key.characters)
+                }
+            }
+            super.pressesCancelled(presses, with: event)
         }
     }
 }
@@ -1053,5 +1097,66 @@ final class InputCaptureEngine: NSObject {
     private func emitPencil(_ phase: String, x: Double, y: Double,
                             pressure: Double, azimuth: Double, altitude: Double) {
         onPencil?(phase, x, y, pressure, azimuth, altitude)
+    }
+}
+
+// MARK: - On-Screen Modifier Key Sidebar (issue #7)
+
+struct ModifierSidebarView: View {
+    @ObservedObject var receiver: PhoneReceiver
+    @State private var command = false
+    @State private var option = false
+    @State private var control = false
+    @State private var shift = false
+    @State private var collapsed = true
+
+    private func updateFlags() {
+        var flags: UInt = 0
+        if shift { flags |= (1 << 17) }
+        if control { flags |= (1 << 18) }
+        if option { flags |= (1 << 19) }
+        if command { flags |= (1 << 20) }
+        receiver.sendStickyModifiers(flags)
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if !collapsed {
+                VStack(spacing: 8) {
+                    modButton(label: "⌘", active: $command)
+                    modButton(label: "⌥", active: $option)
+                    modButton(label: "⌃", active: $control)
+                    modButton(label: "⇧", active: $shift)
+                }
+                .padding(6)
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+                .shadow(radius: 4)
+            }
+            Button {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                    collapsed.toggle()
+                }
+            } label: {
+                Image(systemName: collapsed ? "command.circle.fill" : "chevron.left.circle.fill")
+                    .font(.title2)
+                    .foregroundColor(.white.opacity(0.85))
+                    .padding(6)
+            }
+        }
+        .padding(.leading, 6)
+    }
+
+    private func modButton(label: String, active: Binding<Bool>) -> some View {
+        Button {
+            active.wrappedValue.toggle()
+            updateFlags()
+        } label: {
+            Text(label)
+                .font(.system(size: 18, weight: .bold))
+                .frame(width: 38, height: 38)
+                .background(active.wrappedValue ? Color.blue : Color.white.opacity(0.15))
+                .foregroundColor(.white)
+                .cornerRadius(8)
+        }
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -151,6 +151,7 @@ targets:
     sources:
       - MacTests
       - Mac/DisplayArrangement.swift
+      - Mac/InputInjector.swift
       - Mac/Log.swift
       - Mac/LogPolicies.swift
       - Shared/LogSnapshot.swift


### PR DESCRIPTION
## Summary

This PR enables hardware keyboard typing and on-screen modifier keys for touch interactions:

### 1. Hardware Keyboard Passthrough (#6)
- Intercepts physical keyboard key presses in iOS `VideoView` via `UIPress` and forwards `UIKeyboardHIDUsage` codes, modifier flags, and Unicode characters.
- Translates standard HID Usage page codes into macOS virtual keycodes (`CGKeyCode`) in `InputInjector.handleKey`.
- Injects native `CGEvent` keyboard events with correct modifier flags and Unicode strings.

### 2. On-Screen Modifier Key Sidebar (#7)
- Adds a collapsible floating modifier sidebar on iOS (`⌘`, `⌥`, `⌃`, `⇧`).
- Allows users on touchscreens to toggle sticky modifiers for ⌘-clicks, ⌥-drags, and multi-selection without an external keyboard attached.

## Verification
- **Unit Tests**: Added `MacTests/InputInjectorTests.swift` covering HID-to-macOS keycode mapping, modifier bitmask decoding, and event injection (all tests pass).
- **macOS & iOS Builds**:
  - `xcodegen generate && xcodebuild test -project OpenSidecar.xcodeproj -scheme OpenSidecarMac -destination 'platform=macOS'` — 40/40 tests pass.
  - `xcodebuild build -project OpenSidecar.xcodeproj -scheme OpenSidecariOS -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO` — builds cleanly.
