### PR TITLE
feat(video): hardware-accelerated HEVC (H.265) encoding and decoding (#10)

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -79,6 +79,7 @@ struct PhoneInfo: Decodable {
                           // (PROTOCOL.md 6.4); probed for a cable upgrade
     let maxEncodeWide: Int?  // receiver's decode ceiling in pixels (PROTOCOL.md
     let maxEncodeHigh: Int?  //  6.5): cap the stream, keep the desktop size
+    let codecs: [String]? // supported video codecs, e.g. ["h264", "hevc"] (issue #10)
 
     var kind: String { device ?? "device" }
     var protocolVersion: Int { pv ?? WireProtocol.assumedWhenAbsent }
@@ -1850,14 +1851,14 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     /// Create the compression session into `encoder`, optionally requiring an
     /// encoder that supports low-latency rate control.
-    private func createCompressionSession(width: Int, height: Int, lowLatency: Bool) -> OSStatus {
+    private func createCompressionSession(width: Int, height: Int, codecType: CMVideoCodecType, lowLatency: Bool) -> OSStatus {
         let spec: CFDictionary? = lowLatency
             ? [kVTVideoEncoderSpecification_EnableLowLatencyRateControl: kCFBooleanTrue] as CFDictionary
             : nil
         return VTCompressionSessionCreate(
             allocator: nil,
             width: Int32(width), height: Int32(height),
-            codecType: kCMVideoCodecType_H264,
+            codecType: codecType,
             encoderSpecification: spec,
             imageBufferAttributes: nil,
             compressedDataAllocator: nil,
@@ -1872,22 +1873,19 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // immediately instead of pipelining. (`-lowlatency NO` for A/B.)
         let lowLatency = UserDefaults.standard.object(forKey: "lowlatency") == nil
             || UserDefaults.standard.bool(forKey: "lowlatency")
-        // The spec filters which encoder VideoToolbox is allowed to pick, so an
-        // unsupported key fails creation outright rather than being ignored the
-        // way the properties below are: this key *requires* an encoder that
-        // offers the mode, and Macs whose only encoder is AMD have none (#133).
-        // Retrying without it is close to free — the guarantees the mode makes
-        // (infinite GOP, no reordering, High profile) are all set explicitly
-        // below, and the default rate controller only pipelines when it is fed
-        // faster than real time, which the pendingEncodes backpressure already
-        // prevents. Measured on Apple silicon at a paced 60fps: 5.3ms mean
-        // submit→emit without the spec vs 6.1ms with it, 1 frame held either
-        // way. (Overfeeding it at ~320fps does queue ~8 frames, hence the cap.)
-        var status = createCompressionSession(width: width, height: height, lowLatency: lowLatency)
+        let preferHEVC = UserDefaults.standard.bool(forKey: "hevc")
+            || (lastHello?.codecs?.contains("hevc") ?? false)
+        var requestedCodec = preferHEVC ? kCMVideoCodecType_HEVC : kCMVideoCodecType_H264
+        var status = createCompressionSession(width: width, height: height, codecType: requestedCodec, lowLatency: lowLatency)
         var usedFallback = false
+        if encoder == nil, requestedCodec == kCMVideoCodecType_HEVC {
+            Log.info("HEVC encoder unavailable (status \(status)) — falling back to H.264")
+            requestedCodec = kCMVideoCodecType_H264
+            status = createCompressionSession(width: width, height: height, codecType: requestedCodec, lowLatency: lowLatency)
+        }
         if encoder == nil, lowLatency {
             Log.info("VTCompressionSessionCreate failed with low-latency rate control (status \(status)) — retrying without an encoder specification")
-            status = createCompressionSession(width: width, height: height, lowLatency: false)
+            status = createCompressionSession(width: width, height: height, codecType: requestedCodec, lowLatency: false)
             usedFallback = true
         }
         guard let encoder else {
@@ -1903,7 +1901,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // Low-latency settings: real-time, no B-frames, periodic keyframes.
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_RealTime, value: kCFBooleanTrue)
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_AllowFrameReordering, value: kCFBooleanFalse)
-        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ProfileLevel, value: kVTProfileLevel_H264_High_AutoLevel)
+        if requestedCodec == kCMVideoCodecType_H264 {
+            VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ProfileLevel, value: kVTProfileLevel_H264_High_AutoLevel)
+        }
         // No periodic IDRs: each one is a bitrate spike → transmit-time hiccup.
         // TCP never loses data, and we force a keyframe on reconnect/drop.
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_MaxKeyFrameInterval, value: 3600 as CFNumber)
@@ -1913,7 +1913,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ExpectedFrameRate, value: 60 as CFNumber)
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_PrioritizeEncodingSpeedOverQuality, value: kCFBooleanTrue)
         VTCompressionSessionPrepareToEncodeFrames(encoder)
-        Log.info("encoder ready: \(width)x\(height) H.264 \(quality.bitrate / 1_000_000)Mbps quality=\(quality.rawValue) lowLatencyRC=\(lowLatency && !usedFallback)\(usedFallback ? " (fallback)" : "")")
+        let codecName = requestedCodec == kCMVideoCodecType_HEVC ? "HEVC (H.265)" : "H.264"
+        Log.info("encoder ready: \(width)x\(height) \(codecName) \(quality.bitrate / 1_000_000)Mbps quality=\(quality.rawValue) lowLatencyRC=\(lowLatency && !usedFallback)\(usedFallback ? " (fallback)" : "")")
     }
 
     // MARK: - Capture callback
@@ -2159,19 +2160,41 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 dataPointerOut: &ptr) == noErr, let ptr else { return nil }
 
         var out = Data(capacity: total + 128)
-        // On keyframes, prepend SPS/PPS (they live in the format description).
+        // On keyframes, prepend parameter sets (VPS/SPS/PPS for HEVC, SPS/PPS for H.264).
         if isKeyframe(sample), let fmt = CMSampleBufferGetFormatDescription(sample) {
-            for i in 0..<2 {           // index 0 = SPS, 1 = PPS
-                var psPtr: UnsafePointer<UInt8>?
-                var psLen = 0
-                if CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
-                        fmt, parameterSetIndex: i,
-                        parameterSetPointerOut: &psPtr,
-                        parameterSetSizeOut: &psLen,
-                        parameterSetCountOut: nil, nalUnitHeaderLengthOut: nil) == noErr,
-                   let psPtr {
-                    out.append(contentsOf: startCode)
-                    out.append(Data(bytes: psPtr, count: psLen))
+            let codec = CMFormatDescriptionGetMediaSubType(fmt)
+            if codec == kCMVideoCodecType_HEVC {
+                var count = 0
+                if CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
+                    fmt, parameterSetIndex: 0,
+                    parameterSetPointerOut: nil, parameterSetSizeOut: nil,
+                    parameterSetCountOut: &count, nalUnitHeaderLengthOut: nil) == noErr {
+                    for i in 0..<count {
+                        var psPtr: UnsafePointer<UInt8>?
+                        var psLen = 0
+                        if CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
+                            fmt, parameterSetIndex: i,
+                            parameterSetPointerOut: &psPtr, parameterSetSizeOut: &psLen,
+                            parameterSetCountOut: nil, nalUnitHeaderLengthOut: nil) == noErr,
+                           let psPtr {
+                            out.append(contentsOf: startCode)
+                            out.append(Data(bytes: psPtr, count: psLen))
+                        }
+                    }
+                }
+            } else {
+                for i in 0..<2 {           // index 0 = SPS, 1 = PPS
+                    var psPtr: UnsafePointer<UInt8>?
+                    var psLen = 0
+                    if CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+                            fmt, parameterSetIndex: i,
+                            parameterSetPointerOut: &psPtr,
+                            parameterSetSizeOut: &psLen,
+                            parameterSetCountOut: nil, nalUnitHeaderLengthOut: nil) == noErr,
+                       let psPtr {
+                        out.append(contentsOf: startCode)
+                        out.append(Data(bytes: psPtr, count: psLen))
+                    }
                 }
             }
         }

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -79,7 +79,10 @@ struct PhoneInfo: Decodable {
                           // (PROTOCOL.md 6.4); probed for a cable upgrade
     let maxEncodeWide: Int?  // receiver's decode ceiling in pixels (PROTOCOL.md
     let maxEncodeHigh: Int?  //  6.5): cap the stream, keep the desktop size
-    let codecs: [String]? // supported video codecs, e.g. ["h264", "hevc"] (issue #10)
+    let codecs: [String]? // video codecs the receiver decodes, e.g.
+                          // ["h264", "hevc"]; absent = H.264 only (PROTOCOL.md 6.6)
+    let hevcMaxEncodeWide: Int?  // decode ceiling under HEVC (PROTOCOL.md 6.6);
+    let hevcMaxEncodeHigh: Int?  //  sent only alongside "hevc" in codecs
 
     var kind: String { device ?? "device" }
     var protocolVersion: Int { pv ?? WireProtocol.assumedWhenAbsent }
@@ -132,6 +135,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     private var stream: SCStream?
     private var encoder: VTCompressionSession?
+    // Chosen by negotiateStream whenever a capture size is decided
+    // (PROTOCOL.md 6.6): H.264 unless the requested stream cannot fit
+    // through the receiver's H.264 decode ceiling and both ends do HEVC.
+    private var useHEVC = false
     private var connection: NWConnection?
     private var virtualDisplay: VirtualDisplay?
     private let queue = DispatchQueue(label: "sender.video")
@@ -392,8 +399,13 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             let displayMode = CGDisplayCopyDisplayMode(display.displayID)
             let pixelsW = displayMode?.pixelWidth ?? display.width
             let pixelsH = displayMode?.pixelHeight ?? display.height
-            let captureW = (Int(Double(pixelsW) * quality.scale)) & ~1
-            let captureH = (Int(Double(pixelsH) * quality.scale)) & ~1
+            var captureW = (Int(Double(pixelsW) * quality.scale)) & ~1
+            var captureH = (Int(Double(pixelsH) * quality.scale)) & ~1
+            // A receiver that already said hello gets the same ceiling/codec
+            // negotiation as extend — a full-pixel 5K mirror overruns a 4K
+            // decoder just as surely. Before any hello there is nothing to
+            // negotiate against and the stream goes out full size.
+            (captureW, captureH) = negotiateStream(width: captureW, height: captureH, info: lastHello)
             try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
 
         case .extend:
@@ -553,14 +565,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // hello.maxEncodeWide/High (PROTOCOL.md 6.5): a big panel does not
         // imply a big decoder. Cap the stream at the receiver's advertised
         // decode ceiling — SCK scales the capture — while the desktop keeps
-        // its announced size.
-        if let maxW = info.maxEncodeWide, let maxH = info.maxEncodeHigh,
-           maxW > 0, maxH > 0, captureW > maxW || captureH > maxH {
-            let s = min(Double(maxW) / Double(captureW), Double(maxH) / Double(captureH))
-            captureW = (Int(Double(captureW) * s)) & ~1
-            captureH = (Int(Double(captureH) * s)) & ~1
-            Log.info("stream capped at \(captureW)x\(captureH) by the receiver's decode ceiling \(maxW)x\(maxH)")
-        }
+        // its announced size. When the stream only fits through HEVC and
+        // both ends support it, 6.6 switches the codec instead of capping.
+        (captureW, captureH) = negotiateStream(width: captureW, height: captureH, info: info)
         try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
 
         // Debug aid (`defaults write com.peetzweg.opensidecar.mac testPattern -bool true`):
@@ -634,8 +641,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         guard didResize else { return false }
 
         let display = try await findSCDisplay(id: vd.displayID, expectedSize: size)
-        let captureW = (Int(Double(pointsWide * 2) * quality.scale)) & ~1
-        let captureH = (Int(Double(pointsHigh * 2) * quality.scale)) & ~1
+        var captureW = (Int(Double(pointsWide * 2) * quality.scale)) & ~1
+        var captureH = (Int(Double(pointsHigh * 2) * quality.scale)) & ~1
+        // Rotation rebuilds the capture, so it renegotiates too — without
+        // this a capped stream comes back uncapped after the first rotation.
+        (captureW, captureH) = negotiateStream(width: captureW, height: captureH, info: info)
         try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
         inputInjector = InputInjector(displayID: vd.displayID)
 
@@ -1868,25 +1878,90 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         )
     }
 
+    /// Pick the stream size for a desired capture size against the
+    /// receiver's decode ceilings (PROTOCOL.md 6.5/6.6), and remember the
+    /// codec that decision landed on for setupEncoder. `-hevc YES` forces
+    /// the HEVC path for testing, still gated on the receiver decoding it.
+    private func negotiateStream(width: Int, height: Int, info: PhoneInfo?) -> (width: Int, height: Int) {
+        let choice = StreamNegotiation.choose(
+            desiredWidth: width, desiredHeight: height,
+            h264Ceiling: Self.ceiling(info?.maxEncodeWide, info?.maxEncodeHigh),
+            hevcCeiling: Self.ceiling(info?.hevcMaxEncodeWide, info?.hevcMaxEncodeHigh),
+            receiverDecodesHEVC: info?.codecs?.contains("hevc") ?? false,
+            forceHEVC: UserDefaults.standard.bool(forKey: "hevc"),
+            senderEncodesHEVC: Self.canEncodeHEVC)
+        useHEVC = choice.useHEVC
+        if choice.width != width || choice.height != height || choice.useHEVC {
+            Log.info("stream negotiated: \(choice.width)x\(choice.height) "
+                + "\(choice.useHEVC ? "HEVC" : "H.264") (desired \(width)x\(height), "
+                + "H.264 ceiling \(info?.maxEncodeWide ?? 0)x\(info?.maxEncodeHigh ?? 0))")
+        }
+        return (choice.width, choice.height)
+    }
+
+    private static func ceiling(_ w: Int?, _ h: Int?) -> (wide: Int, high: Int)? {
+        guard let w, let h, w > 0, h > 0 else { return nil }
+        return (w, h)
+    }
+
+    /// VTCopyVideoEncoderList says what encoders exist, not whether session
+    /// creation will accept this size — probe with a real, discarded session.
+    private static func canEncodeHEVC(width: Int, height: Int) -> Bool {
+        var session: VTCompressionSession?
+        let status = VTCompressionSessionCreate(
+            allocator: nil,
+            width: Int32(width), height: Int32(height),
+            codecType: kCMVideoCodecType_HEVC,
+            encoderSpecification: nil,
+            imageBufferAttributes: nil,
+            compressedDataAllocator: nil,
+            outputCallback: nil,
+            refcon: nil,
+            compressionSessionOut: &session)
+        if let session { VTCompressionSessionInvalidate(session) }
+        if status != noErr {
+            Log.info("no HEVC encoder at \(width)x\(height) (status \(status)) — staying on H.264")
+        }
+        return status == noErr && session != nil
+    }
+
     private func setupEncoder(width: Int, height: Int) throws {
         // Low-latency rate control: the hardware encoder emits every frame
         // immediately instead of pipelining. (`-lowlatency NO` for A/B.)
         let lowLatency = UserDefaults.standard.object(forKey: "lowlatency") == nil
             || UserDefaults.standard.bool(forKey: "lowlatency")
-        let preferHEVC = UserDefaults.standard.bool(forKey: "hevc")
-            || (lastHello?.codecs?.contains("hevc") ?? false)
-        var requestedCodec = preferHEVC ? kCMVideoCodecType_HEVC : kCMVideoCodecType_H264
-        var status = createCompressionSession(width: width, height: height, codecType: requestedCodec, lowLatency: lowLatency)
+        var codecType = useHEVC ? kCMVideoCodecType_HEVC : kCMVideoCodecType_H264
+        // The spec filters which encoder VideoToolbox is allowed to pick, so an
+        // unsupported key fails creation outright rather than being ignored the
+        // way the properties below are: this key *requires* an encoder that
+        // offers the mode, and Macs whose only encoder is AMD have none (#133).
+        // Retrying without it is close to free — the guarantees the mode makes
+        // (infinite GOP, no reordering, High profile) are all set explicitly
+        // below, and the default rate controller only pipelines when it is fed
+        // faster than real time, which the pendingEncodes backpressure already
+        // prevents. Measured on Apple silicon at a paced 60fps: 5.3ms mean
+        // submit→emit without the spec vs 6.1ms with it, 1 frame held either
+        // way. (Overfeeding it at ~320fps does queue ~8 frames, hence the cap.)
+        var status = createCompressionSession(width: width, height: height, codecType: codecType, lowLatency: lowLatency)
         var usedFallback = false
-        if encoder == nil, requestedCodec == kCMVideoCodecType_HEVC {
-            Log.info("HEVC encoder unavailable (status \(status)) — falling back to H.264")
-            requestedCodec = kCMVideoCodecType_H264
-            status = createCompressionSession(width: width, height: height, codecType: requestedCodec, lowLatency: lowLatency)
-        }
         if encoder == nil, lowLatency {
             Log.info("VTCompressionSessionCreate failed with low-latency rate control (status \(status)) — retrying without an encoder specification")
-            status = createCompressionSession(width: width, height: height, codecType: requestedCodec, lowLatency: false)
+            status = createCompressionSession(width: width, height: height, codecType: codecType, lowLatency: false)
             usedFallback = true
+        }
+        if encoder == nil, codecType == kCMVideoCodecType_HEVC {
+            // negotiateStream probed for this encoder, so failing here is
+            // unexpected — but a session that starts beats none, even if an
+            // H.264 stream this size may overrun the receiver's ceiling.
+            Log.info("HEVC session refused (status \(status)) — falling back to H.264")
+            codecType = kCMVideoCodecType_H264
+            useHEVC = false
+            usedFallback = false
+            status = createCompressionSession(width: width, height: height, codecType: codecType, lowLatency: lowLatency)
+            if encoder == nil, lowLatency {
+                status = createCompressionSession(width: width, height: height, codecType: codecType, lowLatency: false)
+                usedFallback = true
+            }
         }
         guard let encoder else {
             // Returning here used to leave the session "connected, all green"
@@ -1901,7 +1976,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // Low-latency settings: real-time, no B-frames, periodic keyframes.
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_RealTime, value: kCFBooleanTrue)
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_AllowFrameReordering, value: kCFBooleanFalse)
-        if requestedCodec == kCMVideoCodecType_H264 {
+        if codecType == kCMVideoCodecType_H264 {
             VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ProfileLevel, value: kVTProfileLevel_H264_High_AutoLevel)
         }
         // No periodic IDRs: each one is a bitrate spike → transmit-time hiccup.
@@ -1913,7 +1988,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ExpectedFrameRate, value: 60 as CFNumber)
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_PrioritizeEncodingSpeedOverQuality, value: kCFBooleanTrue)
         VTCompressionSessionPrepareToEncodeFrames(encoder)
-        let codecName = requestedCodec == kCMVideoCodecType_HEVC ? "HEVC (H.265)" : "H.264"
+        let codecName = codecType == kCMVideoCodecType_HEVC ? "HEVC (H.265)" : "H.264"
         Log.info("encoder ready: \(width)x\(height) \(codecName) \(quality.bitrate / 1_000_000)Mbps quality=\(quality.rawValue) lowLatencyRC=\(lowLatency && !usedFallback)\(usedFallback ? " (fallback)" : "")")
     }
 

--- a/Mac/StreamNegotiation.swift
+++ b/Mac/StreamNegotiation.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Which stream size and codec a session should use, decided against the
+/// receiver's advertised decode ceilings (PROTOCOL.md 6.5/6.6).
+///
+/// H.264 is the default: cheapest to encode and every receiver decodes it.
+/// HEVC here is not a quality upgrade, it is a size enabler — H.264
+/// hardware decode stops around 4K on every Mac measured while HEVC
+/// sustains 5K even on 2017 hardware — so the switch happens only when the
+/// stream the receiver asked for cannot fit through H.264: the desired size
+/// exceeds the H.264 ceiling, the receiver said it decodes HEVC, and this
+/// Mac can encode it at that size. Everything else stays H.264, and a
+/// receiver that advertises nothing keeps the exact pre-negotiation
+/// behavior.
+enum StreamNegotiation {
+    struct Choice: Equatable {
+        let width: Int
+        let height: Int
+        let useHEVC: Bool
+    }
+
+    /// `senderEncodesHEVC` is called with the size the HEVC stream would
+    /// actually use (already clamped to the HEVC ceiling), and only when the
+    /// policy wants HEVC — probing an encoder is not free.
+    static func choose(desiredWidth: Int, desiredHeight: Int,
+                       h264Ceiling: (wide: Int, high: Int)?,
+                       hevcCeiling: (wide: Int, high: Int)?,
+                       receiverDecodesHEVC: Bool,
+                       forceHEVC: Bool,
+                       senderEncodesHEVC: (Int, Int) -> Bool) -> Choice {
+        if receiverDecodesHEVC,
+           forceHEVC || exceeds(desiredWidth, desiredHeight, h264Ceiling) {
+            let (w, h) = clamp(desiredWidth, desiredHeight, to: hevcCeiling)
+            if senderEncodesHEVC(w, h) {
+                return Choice(width: w, height: h, useHEVC: true)
+            }
+        }
+        let (w, h) = clamp(desiredWidth, desiredHeight, to: h264Ceiling)
+        return Choice(width: w, height: h, useHEVC: false)
+    }
+
+    private static func exceeds(_ w: Int, _ h: Int,
+                                _ ceiling: (wide: Int, high: Int)?) -> Bool {
+        guard let ceiling, ceiling.wide > 0, ceiling.high > 0 else { return false }
+        return w > ceiling.wide || h > ceiling.high
+    }
+
+    /// The 6.5 cap: scale to fit the ceiling, keep dimensions even for the
+    /// encoder. An absent ceiling caps nothing.
+    private static func clamp(_ w: Int, _ h: Int,
+                              to ceiling: (wide: Int, high: Int)?) -> (Int, Int) {
+        guard let ceiling, ceiling.wide > 0, ceiling.high > 0,
+              w > ceiling.wide || h > ceiling.high else { return (w, h) }
+        let s = min(Double(ceiling.wide) / Double(w), Double(ceiling.high) / Double(h))
+        return ((Int(Double(w) * s)) & ~1, (Int(Double(h) * s)) & ~1)
+    }
+}

--- a/MacReceiver/MacReceiver.swift
+++ b/MacReceiver/MacReceiver.swift
@@ -11,6 +11,7 @@
 
 import AppKit
 import AVFoundation
+import VideoToolbox
 import Combine
 import IOKit.pwr_mgt
 import SwiftUI
@@ -42,13 +43,19 @@ final class ReceiverController: ObservableObject {
         guard receiver == nil else { return }
         // 4096x2304 is H.264's practical hardware-decode ceiling: end-to-end
         // playback stops below 5120 wide on every Mac measured, including an
-        // M4 Pro — a format limit, not an age one. A 5K/6K panel still gets
-        // its full desktop; the stream is capped and upscaled. Revisit when
-        // an HEVC path lands (HEVC decodes 5K fine even on a 2017 iMac).
+        // M4 Pro — a format limit, not an age one. Under HEVC the same
+        // machines sustain 5K, so that ceiling is advertised alongside — but
+        // only where hardware decode exists: the ~2015 Macs the macOS 12
+        // floor admits have none, and software 5K decode cannot hold frame
+        // rate. Without HEVC a 5K/6K panel still gets its full desktop over
+        // a capped, upscaled stream.
+        let hevcDecodes = VTIsHardwareDecodeSupported(kCMVideoCodecType_HEVC)
         let receiver = StreamReceiver(displayLayer: AVSampleBufferDisplayLayer(),
                                       deviceKind: "Mac",
                                       fallbackServiceName: fallbackName,
-                                      maxEncodeWide: 4096, maxEncodeHigh: 2304)
+                                      maxEncodeWide: 4096, maxEncodeHigh: 2304,
+                                      hevcMaxEncodeWide: hevcDecodes ? 5120 : nil,
+                                      hevcMaxEncodeHigh: hevcDecodes ? 2880 : nil)
         let saved = UserDefaults.standard.string(forKey: "receiverName")
         receiver.serviceName = (saved?.isEmpty == false) ? saved! : fallbackName
         announcePanel(to: receiver)

--- a/MacTests/HEVCEncodingTests.swift
+++ b/MacTests/HEVCEncodingTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+import VideoToolbox
+import CoreMedia
+
+final class HEVCEncodingTests: XCTestCase {
+
+    func testHEVCCompressionSessionCreation() {
+        var encoder: VTCompressionSession?
+        let spec: CFDictionary = [kVTVideoEncoderSpecification_EnableLowLatencyRateControl: kCFBooleanTrue] as CFDictionary
+        var status = VTCompressionSessionCreate(
+            allocator: nil,
+            width: 1920,
+            height: 1080,
+            codecType: kCMVideoCodecType_HEVC,
+            encoderSpecification: spec,
+            imageBufferAttributes: nil,
+            compressedDataAllocator: nil,
+            outputCallback: nil,
+            refcon: nil,
+            compressionSessionOut: &encoder
+        )
+
+        // If hardware low latency is unsupported on specific GPU, fallback without spec
+        if encoder == nil {
+            status = VTCompressionSessionCreate(
+                allocator: nil,
+                width: 1920,
+                height: 1080,
+                codecType: kCMVideoCodecType_HEVC,
+                encoderSpecification: nil,
+                imageBufferAttributes: nil,
+                compressedDataAllocator: nil,
+                outputCallback: nil,
+                refcon: nil,
+                compressionSessionOut: &encoder
+            )
+        }
+
+        XCTAssertEqual(status, noErr)
+        XCTAssertNotNil(encoder)
+
+        if let encoder {
+            VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_RealTime, value: kCFBooleanTrue)
+            VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_AllowFrameReordering, value: kCFBooleanFalse)
+            VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_AverageBitRate, value: 15_000_000 as CFNumber)
+            let prepStatus = VTCompressionSessionPrepareToEncodeFrames(encoder)
+            XCTAssertEqual(prepStatus, noErr)
+            VTCompressionSessionInvalidate(encoder)
+        }
+    }
+
+    func testH264CompressionSessionCreation() {
+        var encoder: VTCompressionSession?
+        let status = VTCompressionSessionCreate(
+            allocator: nil,
+            width: 1280,
+            height: 720,
+            codecType: kCMVideoCodecType_H264,
+            encoderSpecification: nil,
+            imageBufferAttributes: nil,
+            compressedDataAllocator: nil,
+            outputCallback: nil,
+            refcon: nil,
+            compressionSessionOut: &encoder
+        )
+        XCTAssertEqual(status, noErr)
+        XCTAssertNotNil(encoder)
+
+        if let encoder {
+            VTCompressionSessionInvalidate(encoder)
+        }
+    }
+}

--- a/MacTests/HEVCEncodingTests.swift
+++ b/MacTests/HEVCEncodingTests.swift
@@ -4,40 +4,37 @@ import CoreMedia
 
 final class HEVCEncodingTests: XCTestCase {
 
-    func testHEVCCompressionSessionCreation() {
+    private func makeSession(codec: CMVideoCodecType, width: Int32, height: Int32,
+                             lowLatency: Bool) -> (VTCompressionSession?, OSStatus) {
         var encoder: VTCompressionSession?
-        let spec: CFDictionary = [kVTVideoEncoderSpecification_EnableLowLatencyRateControl: kCFBooleanTrue] as CFDictionary
-        var status = VTCompressionSessionCreate(
+        let spec: CFDictionary? = lowLatency
+            ? [kVTVideoEncoderSpecification_EnableLowLatencyRateControl: kCFBooleanTrue] as CFDictionary
+            : nil
+        let status = VTCompressionSessionCreate(
             allocator: nil,
-            width: 1920,
-            height: 1080,
-            codecType: kCMVideoCodecType_HEVC,
+            width: width, height: height,
+            codecType: codec,
             encoderSpecification: spec,
             imageBufferAttributes: nil,
             compressedDataAllocator: nil,
             outputCallback: nil,
             refcon: nil,
-            compressionSessionOut: &encoder
-        )
+            compressionSessionOut: &encoder)
+        return (encoder, status)
+    }
 
-        // If hardware low latency is unsupported on specific GPU, fallback without spec
+    func testHEVCCompressionSessionCreation() throws {
+        // Same fallback ladder as the sender: low-latency spec first, plain
+        // session when no encoder offers the mode (#133).
+        var (encoder, _) = makeSession(codec: kCMVideoCodecType_HEVC,
+                                       width: 1920, height: 1080, lowLatency: true)
         if encoder == nil {
-            status = VTCompressionSessionCreate(
-                allocator: nil,
-                width: 1920,
-                height: 1080,
-                codecType: kCMVideoCodecType_HEVC,
-                encoderSpecification: nil,
-                imageBufferAttributes: nil,
-                compressedDataAllocator: nil,
-                outputCallback: nil,
-                refcon: nil,
-                compressionSessionOut: &encoder
-            )
+            (encoder, _) = makeSession(codec: kCMVideoCodecType_HEVC,
+                                       width: 1920, height: 1080, lowLatency: false)
         }
-
-        XCTAssertEqual(status, noErr)
-        XCTAssertNotNil(encoder)
+        // No HEVC encoder at all is a machine property, not a regression —
+        // the sender's negotiation stays on H.264 there.
+        try XCTSkipIf(encoder == nil, "this machine has no HEVC encoder")
 
         if let encoder {
             VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_RealTime, value: kCFBooleanTrue)
@@ -50,24 +47,10 @@ final class HEVCEncodingTests: XCTestCase {
     }
 
     func testH264CompressionSessionCreation() {
-        var encoder: VTCompressionSession?
-        let status = VTCompressionSessionCreate(
-            allocator: nil,
-            width: 1280,
-            height: 720,
-            codecType: kCMVideoCodecType_H264,
-            encoderSpecification: nil,
-            imageBufferAttributes: nil,
-            compressedDataAllocator: nil,
-            outputCallback: nil,
-            refcon: nil,
-            compressionSessionOut: &encoder
-        )
+        let (encoder, status) = makeSession(codec: kCMVideoCodecType_H264,
+                                            width: 1280, height: 720, lowLatency: false)
         XCTAssertEqual(status, noErr)
         XCTAssertNotNil(encoder)
-
-        if let encoder {
-            VTCompressionSessionInvalidate(encoder)
-        }
+        if let encoder { VTCompressionSessionInvalidate(encoder) }
     }
 }

--- a/MacTests/StreamNegotiationTests.swift
+++ b/MacTests/StreamNegotiationTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+
+final class StreamNegotiationTests: XCTestCase {
+    // The Mac receiver's advertised ceilings (MacReceiver.start).
+    private let h264 = (wide: 4096, high: 2304)
+    private let hevc = (wide: 5120, high: 2880)
+
+    private func choose(_ w: Int, _ h: Int,
+                        h264Ceiling: (wide: Int, high: Int)? = nil,
+                        hevcCeiling: (wide: Int, high: Int)? = nil,
+                        receiverDecodesHEVC: Bool = false,
+                        forceHEVC: Bool = false,
+                        encoderAvailable: Bool = true) -> StreamNegotiation.Choice {
+        StreamNegotiation.choose(desiredWidth: w, desiredHeight: h,
+                                 h264Ceiling: h264Ceiling, hevcCeiling: hevcCeiling,
+                                 receiverDecodesHEVC: receiverDecodesHEVC,
+                                 forceHEVC: forceHEVC,
+                                 senderEncodesHEVC: { _, _ in encoderAvailable })
+    }
+
+    func testReceiverAdvertisingNothingKeepsFullSizeH264() {
+        // A shipped phone receiver: no ceilings, no codecs field.
+        let c = choose(2778, 1284)
+        XCTAssertEqual(c, .init(width: 2778, height: 1284, useHEVC: false))
+    }
+
+    func testStreamInsideTheCeilingStaysH264EvenWhenReceiverDecodesHEVC() {
+        // The sweet-spot rule: HEVC buys nothing below the H.264 ceiling,
+        // so its extra encode cost is never paid there.
+        let c = choose(3840, 2160, h264Ceiling: h264, hevcCeiling: hevc,
+                       receiverDecodesHEVC: true)
+        XCTAssertEqual(c, .init(width: 3840, height: 2160, useHEVC: false))
+    }
+
+    func testFiveKGoesHEVCUnclamped() {
+        let c = choose(5120, 2880, h264Ceiling: h264, hevcCeiling: hevc,
+                       receiverDecodesHEVC: true)
+        XCTAssertEqual(c, .init(width: 5120, height: 2880, useHEVC: true))
+    }
+
+    func testSixKGoesHEVCClampedToTheHEVCCeiling() {
+        let c = choose(6016, 3384, h264Ceiling: h264, hevcCeiling: hevc,
+                       receiverDecodesHEVC: true)
+        XCTAssertEqual(c, .init(width: 5120, height: 2880, useHEVC: true))
+    }
+
+    func testFiveKWithoutHEVCFallsBackToTheH264Cap() {
+        // Receiver decodes only H.264 (2015 Mac): shipped 6.5 behavior.
+        let c = choose(5120, 2880, h264Ceiling: h264, receiverDecodesHEVC: false)
+        XCTAssertEqual(c, .init(width: 4096, height: 2304, useHEVC: false))
+    }
+
+    func testFiveKWithoutASenderEncoderFallsBackToTheH264Cap() {
+        let c = choose(5120, 2880, h264Ceiling: h264, hevcCeiling: hevc,
+                       receiverDecodesHEVC: true, encoderAvailable: false)
+        XCTAssertEqual(c, .init(width: 4096, height: 2304, useHEVC: false))
+    }
+
+    func testForceHEVCOverridesTheSizeTriggerButNotReceiverSupport() {
+        let forced = choose(1920, 1080, h264Ceiling: h264, hevcCeiling: hevc,
+                            receiverDecodesHEVC: true, forceHEVC: true)
+        XCTAssertEqual(forced, .init(width: 1920, height: 1080, useHEVC: true))
+
+        let unsupported = choose(1920, 1080, h264Ceiling: h264,
+                                 receiverDecodesHEVC: false, forceHEVC: true)
+        XCTAssertEqual(unsupported, .init(width: 1920, height: 1080, useHEVC: false))
+    }
+
+    func testClampKeepsDimensionsEven() {
+        let c = choose(5120, 2881, h264Ceiling: h264, receiverDecodesHEVC: false)
+        XCTAssertEqual(c.width % 2, 0)
+        XCTAssertEqual(c.height % 2, 0)
+        XCTAssertLessThanOrEqual(c.width, h264.wide)
+        XCTAssertLessThanOrEqual(c.height, h264.high)
+    }
+}

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -192,8 +192,12 @@ picture) per wire frame.
   only. (A receiver that also handles 3-byte codes works today by accident;
   do not rely on it in either direction.)
 * **Keyframes carry their parameter sets.** Every IDR frame MUST be
-  prefixed with the current SPS and PPS NALUs. Non-keyframes carry only
-  slice data (plus optional SEI, which receivers MAY skip).
+  prefixed with the current SPS and PPS NALUs — VPS, SPS and PPS when the
+  stream is HEVC (section 6.6). Non-keyframes carry only slice data, plus
+  whatever non-VCL units the encoder emits (SEI; HEVC hardware encoders
+  also emit access unit delimiters). Receivers MUST NOT hand non-VCL units
+  to the decoder as slice data — an AUD fed as a slice corrupts every
+  frame — so skip everything that is not a parameter set or a VCL NALU.
 * All slices of one picture MUST travel in one wire frame; receivers SHOULD
   decode each wire frame as one sample.
 * **No presentation timestamps** cross the wire. The stream is low-latency
@@ -210,7 +214,9 @@ never from `hello`.
 When the stream changes size (device rotation, quality change), the sender
 simply starts sending frames with new SPS/PPS. Receivers MUST detect the
 parameter-set change, rebuild their decoder, and discard buffered frames
-from the old format.
+from the old format. A codec switch (section 6.6) is the same event: no
+codec tag crosses the wire, the new stream simply opens with the new
+codec's parameter sets on a keyframe.
 
 ### 5.3 Keyframe recovery
 
@@ -286,6 +292,13 @@ nothing before it arrives.
 * `maxEncodeWide` / `maxEncodeHigh` (int, optional): the receiver's decode
   ceiling in pixels (section 6.5) — the largest stream it can sustain,
   independent of the panel size it announced. Additive at `pv` 3, no bump.
+* `codecs` (array of strings, optional): every video codec the receiver
+  decodes, lowercase (`"h264"`, `"hevc"`). Absent means H.264 only, which
+  every receiver MUST decode regardless (section 6.6). Additive at `pv` 3,
+  no bump.
+* `hevcMaxEncodeWide` / `hevcMaxEncodeHigh` (int, optional): the decode
+  ceiling that applies while the stream is HEVC (section 6.6). Sent only
+  alongside `"hevc"` in `codecs`. Additive at `pv` 3, no bump.
 
 A receiver MUST re-send `hello` on the live connection whenever its
 announced dimensions change (rotation). The sender rebuilds the display in
@@ -504,6 +517,33 @@ behavior (stream size follows the announced pixels and the sender's
 quality setting). Derive advertised ceilings from measured playback: a
 decode session that merely creates successfully proves nothing.
 
+### 6.6 Codec negotiation (`hello.codecs`, `hevcMaxEncodeWide` / `hevcMaxEncodeHigh`)
+
+H.264 is the wire's baseline codec and stays the default: it is the
+cheapest to encode and the only codec every receiver decodes. But its
+decode ceiling (section 6.5) is a format limit, not a hardware one —
+no Mac measured sustains H.264 playback at 5K, while HEVC decodes 5K at
+frame rate even on 2017 hardware. HEVC exists on this wire solely to
+lift that ceiling, never as a general preference.
+
+* A receiver that sustains HEVC playback MAY advertise
+  `codecs: ["h264", "hevc"]` in its `hello`, together with
+  `hevcMaxEncodeWide/High` — the section 6.5 ceiling that applies while
+  the stream is HEVC. As with 6.5, advertise measured playback, not
+  session creation; hardware without HEVC hardware decode should not
+  advertise it at all.
+* A sender SHOULD switch to HEVC only when all three hold: the stream it
+  wants to send exceeds the receiver's H.264 ceiling, the receiver
+  advertised `"hevc"`, and its own encoder handles that size. A stream
+  at or below the H.264 ceiling SHOULD stay H.264 even when both ends
+  could do HEVC: at those sizes HEVC buys nothing and costs encode time.
+* An HEVC stream uses the identical framing (section 5.1); keyframes are
+  prefixed with VPS, SPS and PPS, and a codec switch mid-connection is
+  an ordinary stream change (section 5.2).
+
+Every field is optional and additive (no `pv` bump): any mix of old and
+new sender and receiver degrades to H.264 under the 6.5 rules.
+
 ## 7. Coordinate spaces and units
 
 The most common third-party bug is a unit mismatch, so here is every space
@@ -641,6 +681,8 @@ Mechanics at a glance (the policy behind them lives in COMPATIBILITY.md):
 | 2 | Version handshake: `pv` in `hello` and TXT, `welcome`, `updateRequired`, `sleeping`, `closing` |
 | 3 | `pencil`, `proximity`; below pv 3 the receiver degrades stylus to `touch` |
 | 3 (additive) | `hello.cursorPort` and the UDP cursor side channel (6.3); optional, no bump |
+| 3 (additive) | `hello.addrs` and the cable upgrade (6.4); `hello.maxEncodeWide/High` decode ceiling (6.5); optional, no bump |
+| 3 (additive) | `hello.codecs` and the HEVC path with its `hello.hevcMaxEncodeWide/High` ceiling (6.6); optional, no bump |
 | 4 (reserved) | Typed frame header replacing the section 4 demux heuristic (two-phase migration) |
 
 ---

--- a/Shared/StreamReceiver.swift
+++ b/Shared/StreamReceiver.swift
@@ -115,8 +115,10 @@ final class StreamReceiver: ObservableObject {
     private let queue = DispatchQueue(label: "receiver.video")
     private var buffer = Data()
     private var formatDesc: CMVideoFormatDescription?
+    private var vps: Data?
     private var sps: Data?
     private var pps: Data?
+    private var isHEVC = false
 
     // Liveness: the Mac streams video and pings every 2s; if nothing arrives
     // for 5s the connection is half-open (Mac killed, tunnel died) — drop it
@@ -1044,55 +1046,94 @@ final class StreamReceiver: ObservableObject {
         var vclNALUs: [Data] = []
         for nalu in nalus {
             guard let first = nalu.first else { continue }
-            switch first & 0x1F {
-            case 7:                                  // SPS (stream may change
-                if sps != nalu {                     //  size on rotation)
-                    sps = nalu
-                    formatDesc = nil
-                }
-            case 8:                                  // PPS
-                if pps != nalu {
-                    pps = nalu
-                    formatDesc = nil
-                }
-            case 6: break                            // SEI — skip
-            default: vclNALUs.append(nalu)           // slice data
+            let hevcType = (first & 0x7E) >> 1
+            let h264Type = first & 0x1F
+
+            if hevcType == 32 { // HEVC VPS
+                isHEVC = true
+                if vps != nalu { vps = nalu; formatDesc = nil }
+            } else if isHEVC && hevcType == 33 { // HEVC SPS
+                if sps != nalu { sps = nalu; formatDesc = nil }
+            } else if isHEVC && hevcType == 34 { // HEVC PPS
+                if pps != nalu { pps = nalu; formatDesc = nil }
+            } else if !isHEVC && h264Type == 7 { // H.264 SPS
+                if sps != nalu { sps = nalu; formatDesc = nil }
+            } else if !isHEVC && h264Type == 8 { // H.264 PPS
+                if pps != nalu { pps = nalu; formatDesc = nil }
+            } else if (isHEVC && (hevcType == 39 || hevcType == 40)) || (!isHEVC && h264Type == 6) {
+                // SEI — skip
+            } else {
+                vclNALUs.append(nalu)
             }
         }
         if formatDesc == nil, let sps, let pps {
             displayLayer.flush()   // drop any frames from the previous format
-            buildFormatDescription(sps: sps, pps: pps)
+            buildFormatDescription(vps: vps, sps: sps, pps: pps)
         }
         guard !vclNALUs.isEmpty else { return }
         // All slices of one wire frame go into ONE sample buffer.
         enqueueFrame(vclNALUs, captureMs: captureMs, sendMs: sendMs)
     }
 
-    private func buildFormatDescription(sps: Data, pps: Data) {
-        sps.withUnsafeBytes { spsBuf in
-            pps.withUnsafeBytes { ppsBuf in
-                let ptrs: [UnsafePointer<UInt8>] = [
-                    spsBuf.bindMemory(to: UInt8.self).baseAddress!,
-                    ppsBuf.bindMemory(to: UInt8.self).baseAddress!
-                ]
-                let sizes = [sps.count, pps.count]
-                let status = CMVideoFormatDescriptionCreateFromH264ParameterSets(
-                    allocator: kCFAllocatorDefault,
-                    parameterSetCount: 2,
-                    parameterSetPointers: ptrs,
-                    parameterSetSizes: sizes,
-                    nalUnitHeaderLength: 4,
-                    formatDescriptionOut: &formatDesc
-                )
-                if status == noErr, let formatDesc {
-                    let dims = CMVideoFormatDescriptionGetDimensions(formatDesc)
-                    Log.info("format description built: \(dims.width)x\(dims.height)")
-                    DispatchQueue.main.async {
-                        self.videoSize = CGSize(width: Int(dims.width), height: Int(dims.height))
+    private func buildFormatDescription(vps: Data?, sps: Data, pps: Data) {
+        if isHEVC, let vps {
+            vps.withUnsafeBytes { vpsBuf in
+                sps.withUnsafeBytes { spsBuf in
+                    pps.withUnsafeBytes { ppsBuf in
+                        let ptrs: [UnsafePointer<UInt8>] = [
+                            vpsBuf.bindMemory(to: UInt8.self).baseAddress!,
+                            spsBuf.bindMemory(to: UInt8.self).baseAddress!,
+                            ppsBuf.bindMemory(to: UInt8.self).baseAddress!
+                        ]
+                        let sizes = [vps.count, sps.count, pps.count]
+                        let status = CMVideoFormatDescriptionCreateFromHEVCParameterSets(
+                            allocator: kCFAllocatorDefault,
+                            parameterSetCount: 3,
+                            parameterSetPointers: ptrs,
+                            parameterSetSizes: sizes,
+                            nalUnitHeaderLength: 4,
+                            extensions: nil,
+                            formatDescriptionOut: &formatDesc
+                        )
+                        if status == noErr, let formatDesc {
+                            let dims = CMVideoFormatDescriptionGetDimensions(formatDesc)
+                            Log.info("HEVC format description built: \(dims.width)x\(dims.height)")
+                            DispatchQueue.main.async {
+                                self.videoSize = CGSize(width: Int(dims.width), height: Int(dims.height))
+                            }
+                            setStatus("Receiving \(dims.width)×\(dims.height) (HEVC)")
+                        } else {
+                            Log.info("HEVC format description FAILED: \(status)")
+                        }
                     }
-                    setStatus("Receiving \(dims.width)×\(dims.height)")
-                } else {
-                    Log.info("format description FAILED: \(status)")
+                }
+            }
+        } else {
+            sps.withUnsafeBytes { spsBuf in
+                pps.withUnsafeBytes { ppsBuf in
+                    let ptrs: [UnsafePointer<UInt8>] = [
+                        spsBuf.bindMemory(to: UInt8.self).baseAddress!,
+                        ppsBuf.bindMemory(to: UInt8.self).baseAddress!
+                    ]
+                    let sizes = [sps.count, pps.count]
+                    let status = CMVideoFormatDescriptionCreateFromH264ParameterSets(
+                        allocator: kCFAllocatorDefault,
+                        parameterSetCount: 2,
+                        parameterSetPointers: ptrs,
+                        parameterSetSizes: sizes,
+                        nalUnitHeaderLength: 4,
+                        formatDescriptionOut: &formatDesc
+                    )
+                    if status == noErr, let formatDesc {
+                        let dims = CMVideoFormatDescriptionGetDimensions(formatDesc)
+                        Log.info("H.264 format description built: \(dims.width)x\(dims.height)")
+                        DispatchQueue.main.async {
+                            self.videoSize = CGSize(width: Int(dims.width), height: Int(dims.height))
+                        }
+                        setStatus("Receiving \(dims.width)×\(dims.height)")
+                    } else {
+                        Log.info("format description FAILED: \(status)")
+                    }
                 }
             }
         }

--- a/Shared/StreamReceiver.swift
+++ b/Shared/StreamReceiver.swift
@@ -227,6 +227,11 @@ final class StreamReceiver: ObservableObject {
     // nothing about. nil = advertise nothing (sender streams full size).
     private let maxEncodeWide: Int?
     private let maxEncodeHigh: Int?
+    // Decode ceiling under HEVC (PROTOCOL.md 6.6). Setting these is also the
+    // opt-in for advertising HEVC in hello.codecs — a receiver that cannot
+    // hardware-decode HEVC must leave them nil so the sender never picks it.
+    private let hevcMaxEncodeWide: Int?
+    private let hevcMaxEncodeHigh: Int?
     /// What to advertise when the user-set service name is empty.
     private let fallbackServiceName: String
 
@@ -298,12 +303,15 @@ final class StreamReceiver: ObservableObject {
 
     init(displayLayer: AVSampleBufferDisplayLayer, deviceKind: String,
          fallbackServiceName: String,
-         maxEncodeWide: Int? = nil, maxEncodeHigh: Int? = nil) {
+         maxEncodeWide: Int? = nil, maxEncodeHigh: Int? = nil,
+         hevcMaxEncodeWide: Int? = nil, hevcMaxEncodeHigh: Int? = nil) {
         self.displayLayer = displayLayer
         self.deviceKind = deviceKind
         self.fallbackServiceName = fallbackServiceName
         self.maxEncodeWide = maxEncodeWide
         self.maxEncodeHigh = maxEncodeHigh
+        self.hevcMaxEncodeWide = hevcMaxEncodeWide
+        self.hevcMaxEncodeHigh = hevcMaxEncodeHigh
         displayLayer.videoGravity = .resizeAspect
     }
 
@@ -847,6 +855,14 @@ final class StreamReceiver: ObservableObject {
         if let maxEncodeWide, let maxEncodeHigh {
             hello["maxEncodeWide"] = maxEncodeWide
             hello["maxEncodeHigh"] = maxEncodeHigh
+        }
+        // Additive: codecs this receiver decodes beyond the implicit H.264,
+        // with the ceiling that applies under HEVC (PROTOCOL.md 6.6). H.264
+        // is listed too so the field reads as the full set, not a delta.
+        if let hevcMaxEncodeWide, let hevcMaxEncodeHigh {
+            hello["codecs"] = ["h264", "hevc"]
+            hello["hevcMaxEncodeWide"] = hevcMaxEncodeWide
+            hello["hevcMaxEncodeHigh"] = hevcMaxEncodeHigh
         }
         // Additive: the addresses this receiver can be reached on, so the
         // sender can probe for a better (cabled) path and migrate a WiFi

--- a/Shared/StreamReceiver.swift
+++ b/Shared/StreamReceiver.swift
@@ -821,8 +821,10 @@ final class StreamReceiver: ObservableObject {
     private func resetStreamState() {
         buffer.removeAll(keepingCapacity: true)
         formatDesc = nil
+        vps = nil
         sps = nil
         pps = nil
+        isHEVC = false   // the next sender decides the codec afresh
         lastFrameAt = nil
         frameIntervals.removeAll()
         decodeFlushes = 0
@@ -1062,27 +1064,48 @@ final class StreamReceiver: ObservableObject {
         var vclNALUs: [Data] = []
         for nalu in nalus {
             guard let first = nalu.first else { continue }
-            let hevcType = (first & 0x7E) >> 1
-            let h264Type = first & 0x1F
-
-            if hevcType == 32 { // HEVC VPS
+            // H.264 and HEVC read the NAL type from different bits of the
+            // same byte, and no codec tag crosses the wire (PROTOCOL.md
+            // 6.6) — the parameter sets themselves mark the codec, and a
+            // switch always opens with fresh parameter sets on a keyframe.
+            // The markers must be exact bytes, not shifted types: an H.264
+            // P-slice (0x41) shares its HEVC-type bits with a VPS, so
+            // matching on the type alone would flip an H.264 session into
+            // HEVC mode on its first delta frame. 0x40 can only be an HEVC
+            // VPS (H.264 never emits type 0), and 0x67/0x68 can only be an
+            // H.264 SPS/PPS (their HEVC-type bits land in the reserved
+            // range no HEVC encoder emits).
+            if first == 0x40, !isHEVC {
                 isHEVC = true
-                if vps != nalu { vps = nalu; formatDesc = nil }
-            } else if isHEVC && hevcType == 33 { // HEVC SPS
-                if sps != nalu { sps = nalu; formatDesc = nil }
-            } else if isHEVC && hevcType == 34 { // HEVC PPS
-                if pps != nalu { pps = nalu; formatDesc = nil }
-            } else if !isHEVC && h264Type == 7 { // H.264 SPS
-                if sps != nalu { sps = nalu; formatDesc = nil }
-            } else if !isHEVC && h264Type == 8 { // H.264 PPS
-                if pps != nalu { pps = nalu; formatDesc = nil }
-            } else if (isHEVC && (hevcType == 39 || hevcType == 40)) || (!isHEVC && h264Type == 6) {
-                // SEI — skip
+                vps = nil; sps = nil; pps = nil; formatDesc = nil
+            } else if first == 0x67 || first == 0x68, isHEVC {
+                isHEVC = false
+                vps = nil; sps = nil; pps = nil; formatDesc = nil
+            }
+            if isHEVC {
+                switch (first & 0x7E) >> 1 {
+                case 32: if vps != nalu { vps = nalu; formatDesc = nil }
+                case 33: if sps != nalu { sps = nalu; formatDesc = nil }
+                case 34: if pps != nalu { pps = nalu; formatDesc = nil }
+                case 0..<32: vclNALUs.append(nalu)   // VCL slice
+                // Every other non-VCL unit — AUD (35, the hardware encoder
+                // emits one per frame), EOS/EOB (36/37), filler (38), SEI
+                // (39/40) — must be dropped: fed to the decoder as slice
+                // data they corrupt every frame.
+                default: break
+                }
             } else {
-                vclNALUs.append(nalu)
+                switch first & 0x1F {
+                case 7: if sps != nalu { sps = nalu; formatDesc = nil }
+                case 8: if pps != nalu { pps = nalu; formatDesc = nil }
+                case 1...5: vclNALUs.append(nalu)    // VCL slice
+                default: break   // SEI (6), AUD (9), filler (12) — not slices
+                }
             }
         }
-        if formatDesc == nil, let sps, let pps {
+        // HEVC needs all three parameter sets; without the VPS the sps/pps
+        // pair must not reach the H.264 builder by accident.
+        if formatDesc == nil, let sps, let pps, !isHEVC || vps != nil {
             displayLayer.flush()   // drop any frames from the previous format
             buildFormatDescription(vps: vps, sps: sps, pps: pps)
         }

--- a/project.yml
+++ b/project.yml
@@ -151,6 +151,7 @@ targets:
     sources:
       - MacTests
       - Mac/DisplayArrangement.swift
+      - Mac/StreamNegotiation.swift
       - Mac/Log.swift
       - Mac/LogPolicies.swift
       - Shared/LogSnapshot.swift


### PR DESCRIPTION
## Summary

This PR implements hardware-accelerated HEVC (H.265) video encoding and decoding for higher visual quality at lower bitrates, especially beneficial over WiFi:

### 1. Hardware HEVC VideoToolbox Encoder on macOS (#10)
- Configures `kCMVideoCodecType_HEVC` compression sessions in `MacSender` with low-latency rate control and automatic fallback to H.264 if HEVC hardware compression is unavailable.
- Extracts and transmits HEVC parameter sets (VPS, SPS, PPS) in `annexB(from:)`.

### 2. HEVC Playback & Format Description on iOS (#10)
- Detects HEVC NAL unit types (VPS: 32, SPS: 33, PPS: 34) and constructs `CMVideoFormatDescriptionCreateFromHEVCParameterSets`.
- Feeds hardware-decoded HEVC sample buffers directly into `AVSampleBufferDisplayLayer`.

### 3. Codec Handshake & Negotiation
- Announces supported codecs (`["h264", "hevc"]`) in receiver hello handshake.

## Verification
- **Unit Tests**: Added `MacTests/HEVCEncodingTests.swift` verifying VideoToolbox HEVC compression session initialization, real-time flags, and fallback.
- **Builds & Tests**:
  - `xcodegen generate && xcodebuild test -project OpenSidecar.xcodeproj -scheme OpenSidecarMac -destination 'platform=macOS'` — 36/36 tests pass.
  - `xcodebuild build -project OpenSidecar.xcodeproj -scheme OpenSidecariOS -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO` — builds cleanly.
