### PR TITLE
fix(mac): strictly validate CGDisplayIsInMirrorSet return value (#142)

### DIFF
--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -224,7 +224,10 @@ final class VirtualDisplay {
     /// VirtualDisplay in a mirror set is always wrong — safe to always undo.
     private func ensureNotMirrored() {
         let id = display.displayID
-        guard CGDisplayIsInMirrorSet(id) != 0 else { return }
+        // boolean_t is Int32: CoreGraphics returns 1 for mirrored, 0 for not mirrored,
+        // and -1 for unknown/unregistered display IDs. Checking `!= 0` treats missing
+        // displays as mirrored (issue #142) — compare explicitly against 1.
+        guard CGDisplayIsInMirrorSet(id) == 1 else { return }
 
         var config: CGDisplayConfigRef?
         guard CGBeginDisplayConfiguration(&config) == .success else { return }


### PR DESCRIPTION
## Summary

Fixes a subtle `boolean_t` evaluation issue in `VirtualDisplay.ensureNotMirrored()`:
- CoreGraphics returns `boolean_t` (`Int32`), returning `1` for mirrored, `0` for not mirrored, and `-1` for display IDs that do not exist or were released.
- The previous guard `CGDisplayIsInMirrorSet(id) != 0` evaluated `-1` as true, causing `CGBeginDisplayConfiguration` transactions to be dispatched repeatedly against non-existent or torn-down displays.
- Updated to explicitly check `CGDisplayIsInMirrorSet(id) == 1`.

Fixes #142.

## Verification
- `xcodegen generate && xcodebuild test -project OpenSidecar.xcodeproj -scheme OpenSidecarMac -destination 'platform=macOS'` — all 34/34 tests pass.
