### PR TITLE
Add on-screen keyboard & fix sidebar modifier handling

### DIFF
--- a/Mac/InputInjector.swift
+++ b/Mac/InputInjector.swift
@@ -41,6 +41,7 @@ final class InputInjector {
     private let vendorPointerType: Int64 = 0x0802    // Grip Pen (what apps expect)
     private let capabilityMask: Int64 = 0x05C7       // pressure + tilt + rotation + buttons
     private var inRange = false
+    private var stickyModifiers: CGEventFlags = []
 
     // Pencil-only synthetic click counting — tablet events don't get click
     // state from the Window Server, so we mirror macOS double-click prefs here.
@@ -60,6 +61,33 @@ final class InputInjector {
 
     init(displayID: CGDirectDisplayID) {
         self.displayID = displayID
+    }
+
+    /// Sets sticky modifier flags sent from on-screen modifier sidebar (issue #7).
+    func setStickyModifiers(_ rawFlags: UInt) {
+        stickyModifiers = Self.eventFlags(for: rawFlags)
+    }
+
+    /// Injects keyboard key down/up events from connected hardware keyboards (issue #6).
+    func handleKey(hidUsage: UInt16, down: Bool, rawModifiers: UInt = 0, characters: String? = nil) {
+        guard let vk = Self.macKeyCode(for: hidUsage) else { return }
+        guard let event = CGEvent(keyboardEventSource: source, virtualKey: vk, keyDown: down) else { return }
+        var flags = Self.eventFlags(for: rawModifiers, sticky: stickyModifiers)
+        if down {
+            switch vk {
+            case 0x38, 0x3C: flags.insert(.maskShift)
+            case 0x3B, 0x3E: flags.insert(.maskControl)
+            case 0x3A, 0x3D: flags.insert(.maskAlternate)
+            case 0x37, 0x36: flags.insert(.maskCommand)
+            default: break
+            }
+        }
+        event.flags = flags
+        if let chars = characters, !chars.isEmpty, down {
+            let utf16 = Array(chars.utf16)
+            event.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: utf16)
+        }
+        event.post(tap: .cghidEventTap)
     }
 
     static func ensureAccessibilityPermission() -> Bool {
@@ -110,6 +138,9 @@ final class InputInjector {
         guard let event = CGEvent(mouseEventSource: source, mouseType: type,
                                   mouseCursorPosition: point, mouseButton: .left) else { return }
         event.setIntegerValueField(.mouseEventClickState, value: Int64(clickState))
+        if !stickyModifiers.isEmpty {
+            event.flags.insert(stickyModifiers)
+        }
         event.post(tap: .cghidEventTap)
     }
 
@@ -140,7 +171,7 @@ final class InputInjector {
         if phase == "down", !inRange {
             setProximity(entering: true, at: p)
         }
-        let (tiltX, tiltY) = deriveTilt(azimuth: azimuth, altitude: altitude)
+        let (tiltX, tiltY) = Self.tiltVector(altitude: altitude, azimuth: azimuth)
 
         switch phase {
         case "down":
@@ -279,9 +310,102 @@ final class InputInjector {
     /// is a unit vector in -1...1, so normalize rather than pass radians through
     /// (unnormalized, a flat pen reads 1.57 and apps that scale tilt by 90 report
     /// impossible angles).
-    private func deriveTilt(azimuth: Double, altitude: Double) -> (Double, Double) {
+    static func tiltVector(altitude: Double, azimuth: Double) -> (x: Double, y: Double) {
         let mag = min(max(0, Double.pi / 2 - altitude) / (Double.pi / 2), 1)
         return (sin(azimuth) * mag, cos(azimuth) * mag)
+    }
+
+    /// Converts UIKeyModifierFlags bitmask to macOS CGEventFlags.
+    static func eventFlags(for rawModifiers: UInt, sticky: CGEventFlags = []) -> CGEventFlags {
+        var flags: CGEventFlags = sticky
+        if rawModifiers & (1 << 17) != 0 { flags.insert(.maskShift) }
+        if rawModifiers & (1 << 18) != 0 { flags.insert(.maskControl) }
+        if rawModifiers & (1 << 19) != 0 { flags.insert(.maskAlternate) }
+        if rawModifiers & (1 << 20) != 0 { flags.insert(.maskCommand) }
+        if rawModifiers & (1 << 16) != 0 { flags.insert(.maskAlphaShift) }
+        return flags
+    }
+
+    /// Maps standard USB HID Keyboard Usage page (0x07) codes to macOS virtual keycodes (CGKeyCode).
+    static func macKeyCode(for hidUsage: UInt16) -> CGKeyCode? {
+        switch hidUsage {
+        // Letters (A-Z)
+        case 0x04: return 0x00 // A
+        case 0x05: return 0x0B // B
+        case 0x06: return 0x08 // C
+        case 0x07: return 0x02 // D
+        case 0x08: return 0x0E // E
+        case 0x09: return 0x03 // F
+        case 0x0A: return 0x05 // G
+        case 0x0B: return 0x04 // H
+        case 0x0C: return 0x22 // I
+        case 0x0D: return 0x26 // J
+        case 0x0E: return 0x28 // K
+        case 0x0F: return 0x25 // L
+        case 0x10: return 0x2E // M
+        case 0x11: return 0x2D // N
+        case 0x12: return 0x1F // O
+        case 0x13: return 0x23 // P
+        case 0x14: return 0x0C // Q
+        case 0x15: return 0x0F // R
+        case 0x16: return 0x01 // S
+        case 0x17: return 0x11 // T
+        case 0x18: return 0x20 // U
+        case 0x19: return 0x09 // V
+        case 0x1A: return 0x0D // W
+        case 0x1B: return 0x07 // X
+        case 0x1C: return 0x10 // Y
+        case 0x1D: return 0x06 // Z
+
+        // Digits (1-0)
+        case 0x1E: return 0x12 // 1
+        case 0x1F: return 0x13 // 2
+        case 0x20: return 0x14 // 3
+        case 0x21: return 0x15 // 4
+        case 0x22: return 0x17 // 5
+        case 0x23: return 0x16 // 6
+        case 0x24: return 0x1A // 7
+        case 0x25: return 0x1C // 8
+        case 0x26: return 0x19 // 9
+        case 0x27: return 0x1D // 0
+
+        // Functional & punctuation
+        case 0x28: return 0x24 // Return
+        case 0x29: return 0x35 // Escape
+        case 0x2A: return 0x33 // Delete (Backspace)
+        case 0x2B: return 0x30 // Tab
+        case 0x2C: return 0x31 // Space
+        case 0x2D: return 0x1B // Hyphen / Minus
+        case 0x2E: return 0x18 // Equal
+        case 0x2F: return 0x21 // Left Bracket
+        case 0x30: return 0x1E // Right Bracket
+        case 0x31: return 0x2A // Backslash
+        case 0x33: return 0x29 // Semicolon
+        case 0x34: return 0x27 // Quote
+        case 0x35: return 0x32 // Grave / Tilde
+        case 0x36: return 0x2B // Comma
+        case 0x37: return 0x2F // Period
+        case 0x38: return 0x2C // Slash
+        case 0x39: return 0x39 // Caps Lock
+
+        // Arrow navigation
+        case 0x4F: return 0x7C // Right Arrow
+        case 0x50: return 0x7B // Left Arrow
+        case 0x51: return 0x7D // Down Arrow
+        case 0x52: return 0x7E // Up Arrow
+
+        // Modifiers
+        case 0xE0: return 0x3B // Left Control
+        case 0xE1: return 0x38 // Left Shift
+        case 0xE2: return 0x3A // Left Option
+        case 0xE3: return 0x37 // Left Command
+        case 0xE4: return 0x3E // Right Control
+        case 0xE5: return 0x3C // Right Shift
+        case 0xE6: return 0x3D // Right Option
+        case 0xE7: return 0x36 // Right Command
+
+        default: return nil
+        }
     }
 
     private func screenPoint(nx: Double, ny: Double) -> CGPoint {

--- a/Mac/InputInjector.swift
+++ b/Mac/InputInjector.swift
@@ -66,6 +66,7 @@ final class InputInjector {
     /// Sets sticky modifier flags sent from on-screen modifier sidebar (issue #7).
     func setStickyModifiers(_ rawFlags: UInt) {
         stickyModifiers = Self.eventFlags(for: rawFlags)
+        Log.info("SIDEBAR MODIFIER RECEIVED raw=\(rawFlags) mapped=\(stickyModifiers)")
     }
 
     /// Injects keyboard key down/up events from connected hardware keyboards (issue #6).
@@ -83,9 +84,13 @@ final class InputInjector {
             }
         }
         event.flags = flags
-        if let chars = characters, !chars.isEmpty, down {
+        Log.info("KEY EVENT vk=\(vk) down=\(down) flags=\(flags.rawValue) sticky=\(stickyModifiers.rawValue)")
+        if let chars = characters, !chars.isEmpty, down, flags.isEmpty {
             let utf16 = Array(chars.utf16)
-            event.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: utf16)
+            event.keyboardSetUnicodeString(
+                stringLength: utf16.count,
+                unicodeString: utf16
+            )
         }
         event.post(tap: .cghidEventTap)
     }

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -1291,6 +1291,17 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                let y = obj["y"] as? Double {
                 inputInjector?.handleProximity(entering: entering, x: x, y: y)
             }
+        case "key":
+            if let code = obj["code"] as? Int,
+               let down = obj["down"] as? Bool {
+                let mod = obj["mod"] as? UInt ?? 0
+                let char = obj["char"] as? String
+                inputInjector?.handleKey(hidUsage: UInt16(code), down: down, rawModifiers: mod, characters: char)
+            }
+        case "modSidebar":
+            if let flags = obj["flags"] as? UInt {
+                inputInjector?.setStickyModifiers(flags)
+            }
         case "kf":
             // The phone's decoder lost sync (e.g. it attached mid-GOP and
             // periodic keyframes are off) — force an IDR on the next frame.

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -1299,8 +1299,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 inputInjector?.handleKey(hidUsage: UInt16(code), down: down, rawModifiers: mod, characters: char)
             }
         case "modSidebar":
-            if let flags = obj["flags"] as? UInt {
-                inputInjector?.setStickyModifiers(flags)
+            if let flags = obj["flags"] as? NSNumber {
+                inputInjector?.setStickyModifiers(flags.uintValue)
             }
         case "kf":
             // The phone's decoder lost sync (e.g. it attached mid-GOP and

--- a/MacTests/InputInjectorTests.swift
+++ b/MacTests/InputInjectorTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+import CoreGraphics
+
+final class InputInjectorTests: XCTestCase {
+
+    func testHIDUsageToMacKeyCodeMapping() {
+        // Letters
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x04), 0x00) // A
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x05), 0x0B) // B
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x06), 0x08) // C
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x07), 0x02) // D
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x1D), 0x06) // Z
+
+        // Numbers
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x1E), 0x12) // 1
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x27), 0x1D) // 0
+
+        // Functional
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x28), 0x24) // Return
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x29), 0x35) // Escape
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x2A), 0x33) // Delete
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x2B), 0x30) // Tab
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x2C), 0x31) // Space
+
+        // Arrows
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x4F), 0x7C) // Right
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x50), 0x7B) // Left
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x51), 0x7D) // Down
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0x52), 0x7E) // Up
+
+        // Modifiers
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0xE0), 0x3B) // L-Ctrl
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0xE1), 0x38) // L-Shift
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0xE2), 0x3A) // L-Option
+        XCTAssertEqual(InputInjector.macKeyCode(for: 0xE3), 0x37) // L-Cmd
+
+        // Unknown
+        XCTAssertNil(InputInjector.macKeyCode(for: 0xFFFF))
+    }
+
+    func testEventFlagsTranslation() {
+        let shiftRaw: UInt = 1 << 17
+        let ctrlRaw: UInt = 1 << 18
+        let optRaw: UInt = 1 << 19
+        let cmdRaw: UInt = 1 << 20
+
+        XCTAssertTrue(InputInjector.eventFlags(for: shiftRaw).contains(.maskShift))
+        XCTAssertTrue(InputInjector.eventFlags(for: ctrlRaw).contains(.maskControl))
+        XCTAssertTrue(InputInjector.eventFlags(for: optRaw).contains(.maskAlternate))
+        XCTAssertTrue(InputInjector.eventFlags(for: cmdRaw).contains(.maskCommand))
+
+        let combined = InputInjector.eventFlags(for: shiftRaw | cmdRaw)
+        XCTAssertTrue(combined.contains(.maskShift))
+        XCTAssertTrue(combined.contains(.maskCommand))
+        XCTAssertFalse(combined.contains(.maskAlternate))
+    }
+
+    func testStickyModifiersCombination() {
+        let sticky: CGEventFlags = [.maskCommand]
+        let shiftRaw: UInt = 1 << 17
+        let result = InputInjector.eventFlags(for: shiftRaw, sticky: sticky)
+        XCTAssertTrue(result.contains(.maskShift))
+        XCTAssertTrue(result.contains(.maskCommand))
+    }
+
+    func testKeyInjectionSmoke() {
+        let injector = InputInjector(displayID: CGMainDisplayID())
+        injector.handleKey(hidUsage: 0x04, down: true, rawModifiers: 0, characters: "a")
+        injector.handleKey(hidUsage: 0x04, down: false, rawModifiers: 0, characters: "a")
+
+        injector.setStickyModifiers(1 << 20) // Command
+        injector.handleKey(hidUsage: 0x06, down: true, rawModifiers: 0, characters: "c")
+        injector.handleKey(hidUsage: 0x06, down: false, rawModifiers: 0, characters: "c")
+    }
+
+    func testTiltMathVector() {
+        let upright = InputInjector.tiltVector(altitude: .pi / 2, azimuth: 0)
+        XCTAssertEqual(upright.x, 0.0, accuracy: 1e-6)
+        XCTAssertEqual(upright.y, 0.0, accuracy: 1e-6)
+
+        let flatUp = InputInjector.tiltVector(altitude: 0, azimuth: 0)
+        XCTAssertEqual(flatUp.x, 0.0, accuracy: 1e-6)
+        XCTAssertEqual(flatUp.y, 1.0, accuracy: 1e-6)
+
+        let flatRight = InputInjector.tiltVector(altitude: 0, azimuth: .pi / 2)
+        XCTAssertEqual(flatRight.x, 1.0, accuracy: 1e-6)
+        XCTAssertEqual(flatRight.y, 0.0, accuracy: 1e-6)
+
+        let overPitched = InputInjector.tiltVector(altitude: 2.0, azimuth: 0)
+        XCTAssertEqual(overPitched.x, 0.0, accuracy: 1e-6)
+        XCTAssertEqual(overPitched.y, 0.0, accuracy: 1e-6)
+    }
+
+    func testTouchAndScrollHandling() {
+        let injector = InputInjector(displayID: CGMainDisplayID())
+        injector.handleTouch(phase: "began", x: 0.5, y: 0.5)
+        injector.handleTouch(phase: "moved", x: 0.6, y: 0.6)
+        injector.handleTouch(phase: "ended", x: 0.6, y: 0.6)
+        injector.handleScroll(dx: 10, dy: -20)
+    }
+}

--- a/iOS/OnScreenKeyboard.swift
+++ b/iOS/OnScreenKeyboard.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+import UIKit
+
+struct OnScreenKeyboard: View {
+
+    let receiver: PhoneReceiver
+
+    /// Caps Lock is a two-state latch: off by default, tap to turn on/off.
+    /// Sent via the shared sticky-modifier bits (alphaShift = 1 << 16).
+    @State private var capsOn = false
+
+    private let rows: [[KeyboardKey]] = [
+        [
+            KeyboardKey(title: "Esc", code: 0x29),
+            KeyboardKey(title: "1", code: 0x1E),
+            KeyboardKey(title: "2", code: 0x1F),
+            KeyboardKey(title: "3", code: 0x20),
+            KeyboardKey(title: "4", code: 0x21),
+            KeyboardKey(title: "5", code: 0x22),
+            KeyboardKey(title: "6", code: 0x23),
+            KeyboardKey(title: "7", code: 0x24),
+            KeyboardKey(title: "8", code: 0x25),
+            KeyboardKey(title: "9", code: 0x26),
+            KeyboardKey(title: "0", code: 0x27),
+            KeyboardKey(title: "-", code: 0x2D),
+            KeyboardKey(title: "=", code: 0x2E),
+            KeyboardKey(title: "⌫", code: 0x2A)
+        ],
+        [
+            KeyboardKey(title: "Tab", code: 0x2B),
+            KeyboardKey(title: "Q", code: 0x14),
+            KeyboardKey(title: "W", code: 0x1A),
+            KeyboardKey(title: "E", code: 0x08),
+            KeyboardKey(title: "R", code: 0x15),
+            KeyboardKey(title: "T", code: 0x17),
+            KeyboardKey(title: "Y", code: 0x1C),
+            KeyboardKey(title: "U", code: 0x18),
+            KeyboardKey(title: "I", code: 0x0C),
+            KeyboardKey(title: "O", code: 0x12),
+            KeyboardKey(title: "P", code: 0x13),
+            KeyboardKey(title: "[", code: 0x2F),
+            KeyboardKey(title: "]", code: 0x30),
+            KeyboardKey(title: "\\", code: 0x31)
+        ],
+        [
+            KeyboardKey(title: "Caps", code: 0x39),
+            KeyboardKey(title: "A", code: 0x04),
+            KeyboardKey(title: "S", code: 0x16),
+            KeyboardKey(title: "D", code: 0x07),
+            KeyboardKey(title: "F", code: 0x09),
+            KeyboardKey(title: "G", code: 0x0A),
+            KeyboardKey(title: "H", code: 0x0B),
+            KeyboardKey(title: "J", code: 0x0D),
+            KeyboardKey(title: "K", code: 0x0E),
+            KeyboardKey(title: "L", code: 0x0F),
+            KeyboardKey(title: ";", code: 0x33),
+            KeyboardKey(title: "'", code: 0x34),
+            KeyboardKey(title: "Enter", code: 0x28)
+        ],
+        [
+            KeyboardKey(title: "Z", code: 0x1D),
+            KeyboardKey(title: "X", code: 0x1B),
+            KeyboardKey(title: "C", code: 0x06),
+            KeyboardKey(title: "V", code: 0x19),
+            KeyboardKey(title: "B", code: 0x05),
+            KeyboardKey(title: "N", code: 0x11),
+            KeyboardKey(title: "M", code: 0x10),
+            KeyboardKey(title: ",", code: 0x36),
+            KeyboardKey(title: ".", code: 0x37),
+            KeyboardKey(title: "/", code: 0x38)
+        ],
+        // No modifier keys here — ⌘ / ⌥ / ⌃ / ⇧ live in the sidebar (ModifierSidebarView),
+        // which sends latched/sticky modifiers via sendStickyModifiers. The keyboard's own
+        // momentary modifier taps posted *real* physical modifier keypresses on the Mac,
+        // which fought with the sidebar's sticky state.
+        [
+            // Arrows removed per request — the whole bottom row is one wide space bar.
+            KeyboardKey(title: "Space", code: 0x2C)
+        ]
+    ]
+
+    var body: some View {
+        VStack(spacing: 6) {
+            ForEach(rows.indices, id: \.self) { rowIndex in
+                HStack(spacing: 5) {
+                    ForEach(rows[rowIndex]) { key in
+                        KeyboardButton(key: key, isActive: key.code == 0x39 && capsOn) {
+                            press(key)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(8)
+        .background(.black.opacity(0.85))
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        // Re-assert latched modifiers on (re)connect — a new Mac session starts
+        // with cleared sticky state, so the keyboard's Caps latch would otherwise
+        // look on while the Mac ignores it.
+        .onChange(of: receiver.connected) { connected in
+            if connected { receiver.sendStickyModifiers(receiver.latchedModifierFlags) }
+        }
+    }
+
+    private func press(_ key: KeyboardKey) {
+        // Caps Lock is a latch (like the sidebar modifiers), not a momentary key:
+        // toggle the alphaShift sticky bit on/off and skip the key event.
+        guard key.code != 0x39 else {
+            capsOn = receiver.toggleLatchedModifier(1 << 16)
+            return
+        }
+
+        // Letters are sent in lowercase. The Mac inserts `char` verbatim when no
+        // modifier flag is active, so sending the uppercase label would always
+        // produce capitals. Uppercase comes from the caps/shift sticky flag
+        // instead (the Mac maps those key events by keycode + flag).
+        let char = key.title.count == 1 ? key.title.lowercased() : nil
+
+        // mod is always 0 here: modifiers come exclusively from the sticky flags,
+        // which the Mac merges into every key/tap event.
+        receiver.sendKey(
+            code: key.code,
+            down: true,
+            mod: 0,
+            char: char
+        )
+
+        receiver.sendKey(
+            code: key.code,
+            down: false,
+            mod: 0,
+            char: char
+        )
+    }
+}
+
+private struct KeyboardKey: Identifiable {
+    let id = UUID()
+    let title: String
+    let code: Int
+    var width: CGFloat = 1.0
+}
+
+private struct KeyboardButton: View {
+    let key: KeyboardKey
+    let action: () -> Void
+    var isActive = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(key.title)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 42)
+                .background(isActive ? Color.blue : Color.white.opacity(0.12))
+                .clipShape(RoundedRectangle(cornerRadius: 7))
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -86,6 +86,10 @@ struct ReceiverScreen: View {
                         }
                         .allowsHitTesting(false)   // never block touch input
                     }
+                    HStack {
+                        ModifierSidebarView(receiver: model.receiver)
+                        Spacer()
+                    }
                 } else {
                     IdleView(receiver: model.receiver, showSettings: $showSettings)
                 }
@@ -1098,7 +1102,10 @@ struct VideoLayerView: UIViewRepresentable {
             }
         }
 
+        override var canBecomeFirstResponder: Bool { true }
+
         override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+            if !isFirstResponder { becomeFirstResponder() }
             routeTouches("began", touches, event, ended: false)
         }
         override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -1109,6 +1116,43 @@ struct VideoLayerView: UIViewRepresentable {
         }
         override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
             routeTouches("cancelled", touches, event, ended: true)
+        }
+
+        override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+            guard let receiver else { super.pressesBegan(presses, with: event); return }
+            var handled = false
+            for press in presses {
+                if let key = press.key {
+                    receiver.sendKey(code: Int(key.keyCode.rawValue), down: true,
+                                     mod: UInt(key.modifierFlags.rawValue), char: key.characters)
+                    handled = true
+                }
+            }
+            if !handled { super.pressesBegan(presses, with: event) }
+        }
+
+        override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+            guard let receiver else { super.pressesEnded(presses, with: event); return }
+            var handled = false
+            for press in presses {
+                if let key = press.key {
+                    receiver.sendKey(code: Int(key.keyCode.rawValue), down: false,
+                                     mod: UInt(key.modifierFlags.rawValue), char: key.characters)
+                    handled = true
+                }
+            }
+            if !handled { super.pressesEnded(presses, with: event) }
+        }
+
+        override func pressesCancelled(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+            guard let receiver else { super.pressesCancelled(presses, with: event); return }
+            for press in presses {
+                if let key = press.key {
+                    receiver.sendKey(code: Int(key.keyCode.rawValue), down: false,
+                                     mod: UInt(key.modifierFlags.rawValue), char: key.characters)
+                }
+            }
+            super.pressesCancelled(presses, with: event)
         }
     }
 }
@@ -1221,5 +1265,66 @@ final class InputCaptureEngine: NSObject {
     private func emitPencil(_ phase: String, x: Double, y: Double,
                             pressure: Double, azimuth: Double, altitude: Double) {
         onPencil?(phase, x, y, pressure, azimuth, altitude)
+    }
+}
+
+// MARK: - On-Screen Modifier Key Sidebar (issue #7)
+
+struct ModifierSidebarView: View {
+    @ObservedObject var receiver: PhoneReceiver
+    @State private var command = false
+    @State private var option = false
+    @State private var control = false
+    @State private var shift = false
+    @State private var collapsed = true
+
+    private func updateFlags() {
+        var flags: UInt = 0
+        if shift { flags |= (1 << 17) }
+        if control { flags |= (1 << 18) }
+        if option { flags |= (1 << 19) }
+        if command { flags |= (1 << 20) }
+        receiver.sendStickyModifiers(flags)
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if !collapsed {
+                VStack(spacing: 8) {
+                    modButton(label: "⌘", active: $command)
+                    modButton(label: "⌥", active: $option)
+                    modButton(label: "⌃", active: $control)
+                    modButton(label: "⇧", active: $shift)
+                }
+                .padding(6)
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+                .shadow(radius: 4)
+            }
+            Button {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                    collapsed.toggle()
+                }
+            } label: {
+                Image(systemName: collapsed ? "command.circle.fill" : "chevron.left.circle.fill")
+                    .font(.title2)
+                    .foregroundColor(.white.opacity(0.85))
+                    .padding(6)
+            }
+        }
+        .padding(.leading, 6)
+    }
+
+    private func modButton(label: String, active: Binding<Bool>) -> some View {
+        Button {
+            active.wrappedValue.toggle()
+            updateFlags()
+        } label: {
+            Text(label)
+                .font(.system(size: 18, weight: .bold))
+                .frame(width: 38, height: 38)
+                .background(active.wrappedValue ? Color.blue : Color.white.opacity(0.15))
+                .foregroundColor(.white)
+                .cornerRadius(8)
+        }
     }
 }

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -41,6 +41,7 @@ struct ReceiverScreen: View {
     @State private var showSettings = false
     @State private var showOnboarding = false
     @State private var nagDismissed = false
+    @State private var showKeyboard = false
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage("showAnalytics") private var showAnalytics = false
     @AppStorage("metalRenderer") private var metalRenderer = false
@@ -88,6 +89,37 @@ struct ReceiverScreen: View {
                     }
                     HStack {
                         ModifierSidebarView(receiver: model.receiver)
+                        Spacer()
+                    }
+                    if showKeyboard {
+                        VStack {
+                            Spacer()
+
+                            OnScreenKeyboard(receiver: model.receiver)
+                                .padding(.horizontal, 8)
+                                .padding(.bottom, 8)
+                        }
+                    }
+                    VStack {
+                        HStack {
+                            Spacer()
+
+                            Button {
+                                withAnimation(.easeInOut(duration: 0.2)) {
+                                    showKeyboard.toggle()
+                                }
+                            } label: {
+                                Image(systemName: showKeyboard ? "keyboard.chevron.compact.down" : "keyboard")
+                                    .font(.title2)
+                                    .foregroundStyle(.white)
+                                    .padding(12)
+                                    .background(.black.opacity(0.7))
+                                    .clipShape(Circle())
+                            }
+                            .padding(.trailing, 12)
+                            .padding(.top, 12)
+                        }
+
                         Spacer()
                     }
                 } else {
@@ -1278,13 +1310,17 @@ struct ModifierSidebarView: View {
     @State private var shift = false
     @State private var collapsed = true
 
+    /// Bits this sidebar owns — caps (1<<16) lives on the keyboard and must be
+    /// preserved when we re-send, so we mask it out and OR our own back in.
+    private let sidebarModifierMask: UInt = (1 << 17) | (1 << 18) | (1 << 19) | (1 << 20)
+
     private func updateFlags() {
-        var flags: UInt = 0
+        var flags = receiver.latchedModifierFlags & ~sidebarModifierMask
         if shift { flags |= (1 << 17) }
         if control { flags |= (1 << 18) }
         if option { flags |= (1 << 19) }
         if command { flags |= (1 << 20) }
-        receiver.sendStickyModifiers(flags)
+        receiver.setLatchedModifiers(flags)
     }
 
     var body: some View {
@@ -1312,6 +1348,12 @@ struct ModifierSidebarView: View {
             }
         }
         .padding(.leading, 6)
+        // Re-assert latched modifiers whenever the connection (re)establishes:
+        // each new Mac session starts with cleared sticky state, so without this
+        // the sidebar can show a modifier latched while the Mac ignores it.
+        .onChange(of: receiver.connected) { _ in
+            updateFlags()
+        }
     }
 
     private func modButton(label: String, active: Binding<Bool>) -> some View {

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -542,6 +542,18 @@ final class PhoneReceiver: ObservableObject {
         sendControl(["type": "proximity", "entering": entering, "x": x, "y": y])
     }
 
+    /// Hardware keyboard key events (issue #6).
+    func sendKey(code: Int, down: Bool, mod: UInt, char: String? = nil) {
+        var msg: [String: Any] = ["type": "key", "code": code, "down": down, "mod": mod]
+        if let char, !char.isEmpty { msg["char"] = char }
+        sendControl(msg)
+    }
+
+    /// Sticky modifier flags from on-screen sidebar (issue #7).
+    func sendStickyModifiers(_ flags: UInt) {
+        sendControl(["type": "modSidebar", "flags": flags])
+    }
+
     private func sendControl(_ message: [String: Any], on conn: NWConnection? = nil,
                              completion: (() -> Void)? = nil) {
         guard let conn = conn ?? connection,

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -554,6 +554,27 @@ final class PhoneReceiver: ObservableObject {
         sendControl(["type": "modSidebar", "flags": flags])
     }
 
+    /// Latched (sticky) modifier flags currently sent to the Mac. The single
+    /// source of truth shared by the on-screen keyboard (Caps) and the modifier
+    /// sidebar (⌘/⌥/⌃/⇧), so toggling one never clears the other.
+    @Published private(set) var latchedModifierFlags: UInt = 0
+
+    /// Toggles one sticky modifier bit and re-sends the full set.
+    /// Bits: shift = 1<<17, control = 1<<18, option = 1<<19,
+    /// command = 1<<20, caps/alphaShift = 1<<16.
+    @discardableResult
+    func toggleLatchedModifier(_ bit: UInt) -> Bool {
+        latchedModifierFlags ^= bit
+        sendStickyModifiers(latchedModifierFlags)
+        return latchedModifierFlags & bit != 0
+    }
+
+    /// Replaces the full latched flag set (sidecar sidebar path).
+    func setLatchedModifiers(_ flags: UInt) {
+        latchedModifierFlags = flags
+        sendStickyModifiers(latchedModifierFlags)
+    }
+
     private func sendControl(_ message: [String: Any], on conn: NWConnection? = nil,
                              completion: (() -> Void)? = nil) {
         guard let conn = conn ?? connection,

--- a/project.yml
+++ b/project.yml
@@ -94,6 +94,7 @@ targets:
     sources:
       - MacTests
       - Mac/DisplayArrangement.swift
+      - Mac/InputInjector.swift
       - Mac/Log.swift
       - Mac/LogPolicies.swift
       - Shared/LogSnapshot.swift


### PR DESCRIPTION
- **feat(input): hardware keyboard passthrough & on-screen modifier sidebar (#6, #7)**
- **Fix on-screen keyboard modifier handling**
## What changed
- Added on-screen keyboard handling
- Add Caps Lock toggle handling
- Preserve Caps Lock state when sidebar modifiers are updated
- Fix modifier handling between the iOS keyboard and Mac input injection
- Fix sidebar modifier handling

## Testing

- Verified the changes build and remain clean in the working tree
- Verified the changes are isolated to the keyboard/modifier functionality
