### PR TITLE
Add a macOS receiver: true 5K on an iMac 27" 2017, plus mirror and HEVC fixes

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -39,10 +39,18 @@ enum StreamQuality: String, CaseIterable {
     }
 
     var bitrate: Int {
+        // Tunable without a rebuild:
+        //   defaults write com.peetzweg.opensidecar.mac bitrateMbps -int 40
+        if let mbps = UserDefaults.standard.object(forKey: "bitrateMbps") as? Int, mbps > 0 {
+            return mbps * 1_000_000
+        }
+        // Raised from 18/10/6: mirror now captures at native pixel resolution,
+        // which is 4x the pixels of the old point-sized capture. At the old
+        // bitrate that traded softness for blockiness instead of fixing it.
         switch self {
-        case .best: return 18_000_000
-        case .balanced: return 10_000_000
-        case .fast: return 6_000_000
+        case .best: return 32_000_000
+        case .balanced: return 18_000_000
+        case .fast: return 9_000_000
         }
     }
 
@@ -73,9 +81,26 @@ struct PhoneInfo: Decodable {
                           // across USB and WiFi
     let pv: Int?          // receiver protocol version (issue #132); absent on
                           // every pre-handshake install → treat as protocol 1
+    // The widest/tallest frame this receiver can actually decode. Lets a
+    // receiver ask for a large DESKTOP without also demanding a stream its
+    // hardware chokes on — an iMac 27" 2017 wants 2560x1440 points but tops out
+    // near 3840x2160 of H.264. Optional, so older receivers are unaffected
+    // (PROTOCOL.md §6: unknown fields are ignored, so this needs no pv bump).
+    let maxEncodeWide: Int?
+    let maxEncodeHigh: Int?
 
     var kind: String { device ?? "device" }
     var protocolVersion: Int { pv ?? WireProtocol.assumedWhenAbsent }
+}
+
+/// Shrink a capture size to the receiver's declared decode ceiling, preserving
+/// aspect ratio. Without a ceiling this is just the existing even-rounding.
+func clampCapture(_ w: Int, _ h: Int, to info: PhoneInfo) -> (w: Int, h: Int) {
+    guard let maxW = info.maxEncodeWide, maxW > 0, w > maxW else {
+        return (w & ~1, h & ~1)
+    }
+    let scaledH = Int(Double(h) * Double(maxW) / Double(w))
+    return (maxW & ~1, scaledH & ~1)
 }
 
 /// How the sender reaches the receiver. Reconnects re-dial from scratch, so
@@ -330,9 +355,20 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 throw NSError(domain: "MacSender", code: 1,
                               userInfo: [NSLocalizedDescriptionKey: "no displays found"])
             }
-            // SCDisplay reports points; capture at point resolution for M1.
-            let captureW = (Int(Double(display.width) * quality.scale)) & ~1
-            let captureH = (Int(Double(display.height) * quality.scale)) & ~1
+            // SCDisplay reports POINTS, not pixels. Capturing at point size threw
+            // away half the detail on a Retina panel — a 1728x1116 stream from a
+            // display macOS actually renders at 3456x2232 — which on a 5K receiver
+            // reads as a permanently soft picture that no quality setting fixes.
+            //
+            // CGDisplayMode.pixelWidth/Height give the real backing store, so
+            // "Best" now genuinely means native. Falls back to 2x if the mode is
+            // unavailable, and to the old point size for a non-Retina display.
+            let mode = CGDisplayCopyDisplayMode(display.displayID)
+            let nativeW = mode?.pixelWidth ?? display.width * 2
+            let nativeH = mode?.pixelHeight ?? display.height * 2
+            let captureW = (Int(Double(max(nativeW, display.width)) * quality.scale)) & ~1
+            let captureH = (Int(Double(max(nativeH, display.height)) * quality.scale)) & ~1
+            Log.info("mirror capture: \(display.width)x\(display.height)pt -> \(captureW)x\(captureH)px")
             try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
 
         case .extend:
@@ -487,8 +523,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         inputInjector = InputInjector(displayID: vd.displayID)
         // Quality scaling: capture/encode below native when requested — the
         // display itself stays native so window layout is unaffected.
-        let captureW = (Int(Double(pointsWide * 2) * quality.scale)) & ~1
-        let captureH = (Int(Double(pointsHigh * 2) * quality.scale)) & ~1
+        // Clamped to the receiver's decode ceiling: the desktop stays as large as
+        // it asked for, only the encoded frame shrinks.
+        let (captureW, captureH) = clampCapture(Int(Double(pointsWide * 2) * quality.scale),
+                                                Int(Double(pointsHigh * 2) * quality.scale),
+                                                to: info)
         try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
 
         // Debug aid (`defaults write sh.peet.opensidecar.mac testPattern -bool true`):
@@ -562,8 +601,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         guard didResize else { return false }
 
         let display = try await findSCDisplay(id: vd.displayID, expectedSize: size)
-        let captureW = (Int(Double(pointsWide * 2) * quality.scale)) & ~1
-        let captureH = (Int(Double(pointsHigh * 2) * quality.scale)) & ~1
+        // Clamped to the receiver's decode ceiling: the desktop stays as large as
+        // it asked for, only the encoded frame shrinks.
+        let (captureW, captureH) = clampCapture(Int(Double(pointsWide * 2) * quality.scale),
+                                                Int(Double(pointsHigh * 2) * quality.scale),
+                                                to: info)
         try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
         inputInjector = InputInjector(displayID: vd.displayID)
 
@@ -1342,6 +1384,12 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     /// Create the compression session into `encoder`, optionally requiring an
     /// encoder that supports low-latency rate control.
+    /// HEVC is the only way to exceed 4K: H.264 hardware encode and decode both
+    /// stop below 5120 wide on every Mac tested, including Apple silicon, while
+    /// HEVC handles 5120x2880 on both a 2026 MacBook Pro and a 2017 iMac.
+    /// Enabled with `defaults write com.peetzweg.opensidecar.mac hevc -bool YES`.
+    static var useHEVC: Bool { UserDefaults.standard.bool(forKey: "hevc") }
+
     private func createCompressionSession(width: Int, height: Int, lowLatency: Bool) -> OSStatus {
         let spec: CFDictionary? = lowLatency
             ? [kVTVideoEncoderSpecification_EnableLowLatencyRateControl: kCFBooleanTrue] as CFDictionary
@@ -1349,7 +1397,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         return VTCompressionSessionCreate(
             allocator: nil,
             width: Int32(width), height: Int32(height),
-            codecType: kCMVideoCodecType_H264,
+            codecType: Self.useHEVC ? kCMVideoCodecType_HEVC : kCMVideoCodecType_H264,
             encoderSpecification: spec,
             imageBufferAttributes: nil,
             compressedDataAllocator: nil,
@@ -1395,7 +1443,9 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // Low-latency settings: real-time, no B-frames, periodic keyframes.
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_RealTime, value: kCFBooleanTrue)
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_AllowFrameReordering, value: kCFBooleanFalse)
-        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ProfileLevel, value: kVTProfileLevel_H264_High_AutoLevel)
+        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ProfileLevel,
+                             value: Self.useHEVC ? kVTProfileLevel_HEVC_Main_AutoLevel
+                                                 : kVTProfileLevel_H264_High_AutoLevel)
         // No periodic IDRs: each one is a bitrate spike → transmit-time hiccup.
         // TCP never loses data, and we force a keyframe on reconnect/drop.
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_MaxKeyFrameInterval, value: 3600 as CFNumber)
@@ -1405,7 +1455,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ExpectedFrameRate, value: 60 as CFNumber)
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_PrioritizeEncodingSpeedOverQuality, value: kCFBooleanTrue)
         VTCompressionSessionPrepareToEncodeFrames(encoder)
-        Log.info("encoder ready: \(width)x\(height) H.264 \(quality.bitrate / 1_000_000)Mbps quality=\(quality.rawValue) lowLatencyRC=\(lowLatency && !usedFallback)\(usedFallback ? " (fallback)" : "")")
+        Log.info("encoder ready: \(width)x\(height) \(Self.useHEVC ? "HEVC" : "H.264") \(quality.bitrate / 1_000_000)Mbps quality=\(quality.rawValue) lowLatencyRC=\(lowLatency && !usedFallback)\(usedFallback ? " (fallback)" : "")")
     }
 
     // MARK: - Capture callback
@@ -1653,15 +1703,27 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         var out = Data(capacity: total + 128)
         // On keyframes, prepend SPS/PPS (they live in the format description).
         if isKeyframe(sample), let fmt = CMSampleBufferGetFormatDescription(sample) {
-            for i in 0..<2 {           // index 0 = SPS, 1 = PPS
+            // H.264 carries two parameter sets (SPS, PPS); HEVC carries three
+            // (VPS, SPS, PPS) and needs its own accessor — the H.264 one returns
+            // an error for an HEVC format description rather than serving it.
+            // Getting this wrong emits a stream with NO headers, which no decoder
+            // can start from: the receiver just shows black forever.
+            let hevc = Self.useHEVC
+            for i in 0..<(hevc ? 3 : 2) {
                 var psPtr: UnsafePointer<UInt8>?
                 var psLen = 0
-                if CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+                let status = hevc
+                    ? CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
                         fmt, parameterSetIndex: i,
                         parameterSetPointerOut: &psPtr,
                         parameterSetSizeOut: &psLen,
-                        parameterSetCountOut: nil, nalUnitHeaderLengthOut: nil) == noErr,
-                   let psPtr {
+                        parameterSetCountOut: nil, nalUnitHeaderLengthOut: nil)
+                    : CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+                        fmt, parameterSetIndex: i,
+                        parameterSetPointerOut: &psPtr,
+                        parameterSetSizeOut: &psLen,
+                        parameterSetCountOut: nil, nalUnitHeaderLengthOut: nil)
+                if status == noErr, let psPtr {
                     out.append(contentsOf: startCode)
                     out.append(Data(bytes: psPtr, count: psLen))
                 }

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -1,7 +1,11 @@
 import SwiftUI
 import Network
 import Combine
+// Conditional so the app also builds without the SPM dependency, using the
+// stub in MacSenderShim/SparkleStub.swift. See that file for why.
+#if canImport(Sparkle)
 import Sparkle
+#endif
 
 /// How the app presents itself. One bundle, switched at runtime via the
 /// activation policy — like Raycast/Hammerspoon style background agents.

--- a/MacReceiver/Log.swift
+++ b/MacReceiver/Log.swift
@@ -1,0 +1,55 @@
+// Logging for the macOS receiver.
+//
+// Deliberately NOT Mac/Log.swift: that one's RotatingLogFile hardcodes the
+// base name "opendisplay" in the same directory, so running the sender and the
+// receiver on one machine (which is the main dev loop) would have two processes
+// rotating the same file and corrupting it. Separate file, separate rotation.
+
+import Foundation
+
+enum Log {
+    private static let queue = DispatchQueue(label: "receiver.log")
+    private static let maxBytes = 2 * 1024 * 1024
+
+    private static let fileURL: URL? = {
+        guard let logs = FileManager.default.urls(for: .libraryDirectory,
+                                                  in: .userDomainMask).first?
+            .appendingPathComponent("Logs/OpenDisplay", isDirectory: true)
+        else { return nil }
+        try? FileManager.default.createDirectory(at: logs, withIntermediateDirectories: true)
+        return logs.appendingPathComponent("opendisplay-receiver.log")
+    }()
+
+    private static let stamp: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss.SSS"
+        return f
+    }()
+
+    static func info(_ message: String) {
+        let line = "\(stamp.string(from: Date())) \(message)\n"
+        FileHandle.standardError.write(Data(line.utf8))
+        queue.async { append(line) }
+    }
+
+    private static func append(_ line: String) {
+        guard let url = fileURL, let data = line.data(using: .utf8) else { return }
+        if !FileManager.default.fileExists(atPath: url.path) {
+            try? data.write(to: url)
+            return
+        }
+        guard let handle = try? FileHandle(forWritingTo: url) else { return }
+        defer { try? handle.close() }
+        _ = try? handle.seekToEnd()
+        try? handle.write(contentsOf: data)
+        // Cheap rotation: once over the cap, keep the newer half.
+        if let size = try? handle.offset(), size > maxBytes,
+           let all = try? Data(contentsOf: url) {
+            try? all.suffix(maxBytes / 2).write(to: url)
+        }
+    }
+
+    /// Present so shared code that calls it still links; the receiver has no
+    /// snapshot UI of its own.
+    static func snapshot(context: Any? = nil, extra: Any? = nil) {}
+}

--- a/MacReceiver/MacReceiverApp.swift
+++ b/MacReceiver/MacReceiverApp.swift
@@ -1,0 +1,293 @@
+// OpenDisplay Receiver for macOS — turns this Mac into a second display for
+// another Mac running the OpenDisplay sender.
+//
+// Built for an iMac 27" 2017 (Retina 5K), which caps at macOS 13 Ventura and so
+// cannot run the sender app at all (that needs 14+). This target deploys to 13.0.
+//
+// Input is deliberately absent: macOS Universal Control already shares keyboard
+// and mouse between two Macs, over Apple's own encrypted channel. The OpenDisplay
+// wire has no TLS and no auth (PROTOCOL.md section 1), so not putting keystrokes
+// on it is a feature.
+
+import AppKit
+import AVFoundation
+import Combine
+
+@main
+final class AppDelegate: NSObject, NSApplicationDelegate {
+
+    /// Logged at launch so "did the new copy actually get installed?" is
+    /// answerable from the log. Deliberately not in the window title — that is
+    /// the user's screen, not a build stamp.
+    static let buildTag = "v9"
+
+    // NSApplication.delegate is weak, so the instance must be owned here.
+    private static var shared: AppDelegate?
+
+    /// Set when we announce a new panel size, cleared when a picture actually
+    /// arrives for it. If it is still set when the watchdog fires, this Mac
+    /// could not decode what the sender produced — so step down instead of
+    /// sitting on a black screen with no way to tell why.
+    private var awaitingFirstFrame = false
+    private var flushBaseline = 0
+    private var watchdog: DispatchWorkItem?
+
+    static func main() {
+        let app = NSApplication.shared
+        let delegate = AppDelegate()
+        Self.shared = delegate
+        app.delegate = delegate
+        app.setActivationPolicy(.regular)
+        app.run()
+    }
+
+    private var window: NSWindow!
+    private var hostView: VideoHostView!
+    private var receiver: PhoneReceiver!
+    private var presentation: PresentationController!
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Lifecycle
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let displayLayer = AVSampleBufferDisplayLayer()
+        receiver = PhoneReceiver(displayLayer: displayLayer)
+        hostView = VideoHostView(displayLayer: displayLayer)
+
+        buildWindow()
+        buildMenu()
+        presentation = PresentationController(window: window)
+
+        // Measured on an iMac 27" 2017 (Kaby Lake + Radeon Pro 575): 3840x2160
+        // H.264 decodes, 5120x2880 does not. Declaring it lets us ask for a
+        // 2560x1440 desktop while the sender encodes only 3840x2160.
+        //
+        // Tunable, because the sharpest setting is not always the biggest one:
+        // on a 5120-wide panel a 2560-wide stream scales up by exactly 2x with
+        // no resampling blur, which can read as crisper than a 3840-wide stream
+        // stretched by 1.33x — fewer pixels, but every one lands on a boundary.
+        //   defaults write com.peetzweg.opensidecar.macreceiver maxEncode 2560
+        // integer(forKey:) rather than object(forKey:) as? Int, because a plain
+        // `defaults write ... maxEncode 2560` stores a STRING, which would fail
+        // the cast and silently keep the default.
+        let stored = UserDefaults.standard.integer(forKey: "maxEncode")
+        let cap = stored > 0 ? stored : 3840
+        receiver.maxEncodeWide = cap
+        receiver.maxEncodeHigh = (Int(Double(cap) * 9.0 / 16.0)) & ~1
+        Log.info("declaring decode ceiling \(cap)x\(receiver.maxEncodeHigh ?? 0)")
+
+        applyPreset(PanelPreset.current)
+        receiver.setServiceName(ReceiverPlatform.defaultDeviceName)
+
+        wireReceiver()
+        observeSystem()
+
+        receiver.start()
+        Log.info("receiver \(Self.buildTag) launched — listening on 9000, "
+                 + "preset=\(PanelPreset.current.rawValue)")
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        // shutDown() posts `closing` asynchronously. Returning .terminateNow here
+        // would kill the process first, and the sender would then sit through its
+        // 10-second silence timeout on every quit.
+        presentation.setDisplayAwake(false)
+        receiver.shutDown {
+            DispatchQueue.main.async { NSApp.reply(toApplicationShouldTerminate: true) }
+        }
+        return .terminateLater
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { true }
+
+    // MARK: - Wiring
+
+    private func wireReceiver() {
+        receiver.onCursor = { [weak self] x, y, visible in
+            self?.hostView.setCursor(x: x, y: y, visible: visible)
+        }
+        receiver.onCursorImage = { [weak self] image, anchor, normSize in
+            self?.hostView.setCursorSprite(image, anchor: anchor, normSize: normSize)
+        }
+
+        // The Metal path decodes explicitly and hands us frames; without this
+        // wiring, turning on "metalRenderer" produces a permanently black screen.
+        if let metal = hostView.metalRenderer {
+            receiver.onDecodedFrame = { pixelBuffer, captureMs in
+                metal.render(pixelBuffer, captureMs: captureMs)
+            }
+            metal.onPresented = { [weak self] presentedTime, captureMs in
+                self?.receiver.recordPresented(presentedTime: presentedTime, captureMs: captureMs)
+            }
+            Log.info("using Metal renderer, sharpen=\(MetalVideoRenderer.sharpenAmount)")
+        }
+
+        // Video dimensions come from the SPS, never from `hello` — PROTOCOL.md 5.2.
+        receiver.$videoSize
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] size in
+                guard let self, size.width > 0 else { return }
+                self.hostView.videoSize = size
+                self.awaitingFirstFrame = false
+                Log.info("decoding \(Int(size.width))x\(Int(size.height))")
+            }
+            .store(in: &cancellables)
+
+        receiver.$connected
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] connected in
+                guard let self else { return }
+                self.presentation.setDisplayAwake(connected)
+                self.updateTitle()
+                Log.info(connected ? "session connected" : "session disconnected")
+                if connected { self.armDecodeWatchdog() }
+            }
+            .store(in: &cancellables)
+
+        receiver.$status
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.updateTitle() }
+            .store(in: &cancellables)
+    }
+
+    /// Mirrors the iOS lifecycle hooks onto their AppKit equivalents.
+    private func observeSystem() {
+        let wsc = NSWorkspace.shared.notificationCenter
+        wsc.addObserver(forName: NSWorkspace.willSleepNotification,
+                        object: nil, queue: .main) { [weak self] _ in
+            self?.receiver.enterSleep()
+        }
+        wsc.addObserver(forName: NSWorkspace.didWakeNotification,
+                        object: nil, queue: .main) { [weak self] _ in
+            self?.receiver.ensureListening()
+        }
+        wsc.addObserver(forName: NSWorkspace.screensDidSleepNotification,
+                        object: nil, queue: .main) { [weak self] _ in
+            self?.receiver.enterSleep()
+        }
+        wsc.addObserver(forName: NSWorkspace.screensDidWakeNotification,
+                        object: nil, queue: .main) { [weak self] _ in
+            self?.receiver.ensureListening()
+        }
+
+        // Escape hatch — kiosk mode hides the menu bar, so this is the only way
+        // back out on a machine with no other window.
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self, self.presentation.isKiosk else { return event }
+            if event.keyCode == 53 {                       // Escape
+                self.presentation.setKiosk(false)
+                return nil
+            }
+            return event
+        }
+    }
+
+    // MARK: - Window & menu
+
+    private func buildWindow() {
+        window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 1280, height: 720),
+                          styleMask: [.titled, .closable, .miniaturizable, .resizable],
+                          backing: .buffered, defer: false)
+        window.title = "OpenDisplay Receiver"
+        window.contentView = hostView
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func updateTitle() {
+        guard !presentation.isKiosk else { return }
+        // `status` already carries the dimensions once connected, so appending
+        // videoSize as well printed them twice. The build tag stays out of the
+        // title and lives in the launch log instead — it exists to answer "did
+        // the new copy install?", which is a development question, not something
+        // to put in front of a user every time they glance at the screen.
+        window.title = "OpenDisplay Receiver — \(receiver.status)"
+    }
+
+    private func applyPreset(_ preset: PanelPreset) {
+        let d = preset.pixels
+        // long/short, not width/height: setNativePanel takes the landscape pair.
+        receiver.setNativePanel(long: d.w, short: d.h, scale: 2)
+        // setNativePanel seeds devicePixelsWide/High ONLY while they are still
+        // zero, so on every later preset change it updates nativeLong/Short and
+        // nothing else — the receiver kept announcing the original size forever.
+        // setOrientation applies the new pair and re-sends hello on the live
+        // connection, which is what makes the sender rebuild its virtual display.
+        receiver.setOrientation(portrait: false)
+        Log.info("announcing \(d.w)x\(d.h) -> expect a \(d.w / 2)x\(d.h / 2) point desktop")
+        armDecodeWatchdog()
+    }
+
+    /// Give the new stream a few seconds to produce a picture. If none arrives —
+    /// or the display layer starts throwing frames away — this Mac's decoder
+    /// cannot handle it, so drop to the next smaller announcement automatically.
+    private func armDecodeWatchdog() {
+        watchdog?.cancel()
+        awaitingFirstFrame = true
+        flushBaseline = receiver.perf.decodeFlushes
+
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.receiver.connected else { return }
+            let choking = self.receiver.perf.decodeFlushes > self.flushBaseline
+            guard self.awaitingFirstFrame || choking else { return }   // healthy
+
+            guard let next = PanelPreset.current.smaller else {
+                Log.info("no picture at \(PanelPreset.current.rawValue) and nothing smaller left "
+                         + "— lower Quality on the Mac")
+                return
+            }
+            Log.info("no decodable picture at \(PanelPreset.current.rawValue) "
+                     + "(flushes \(self.flushBaseline)->\(self.receiver.perf.decodeFlushes)) "
+                     + "— falling back to \(next.rawValue)")
+            PanelPreset.select(next)
+            self.applyPreset(next)      // re-arms the watchdog itself
+            self.buildMenu()
+        }
+        watchdog = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 12, execute: work)
+    }
+
+    @objc private func selectPreset(_ sender: NSMenuItem) {
+        guard let preset = PanelPreset(rawValue: sender.representedObject as? String ?? "")
+        else { return }
+        PanelPreset.select(preset)
+        applyPreset(preset)          // re-announces on the live connection
+        buildMenu()
+    }
+
+    @objc private func toggleKiosk() { presentation.toggleKiosk() }
+
+    private func buildMenu() {
+        let main = NSMenu()
+
+        let appItem = NSMenuItem()
+        let appMenu = NSMenu()
+        appMenu.addItem(withTitle: "About OpenDisplay Receiver",
+                        action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
+        appMenu.addItem(.separator())
+        let kiosk = NSMenuItem(title: "Full Screen (kiosk)",
+                               action: #selector(toggleKiosk), keyEquivalent: "f")
+        kiosk.keyEquivalentModifierMask = [.command, .control]
+        kiosk.target = self
+        appMenu.addItem(kiosk)
+        appMenu.addItem(.separator())
+        appMenu.addItem(withTitle: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        appItem.submenu = appMenu
+        main.addItem(appItem)
+
+        let displayItem = NSMenuItem()
+        let displayMenu = NSMenu(title: "Display")
+        for preset in PanelPreset.allCases {
+            let item = NSMenuItem(title: preset.title, action: #selector(selectPreset(_:)), keyEquivalent: "")
+            item.representedObject = preset.rawValue
+            item.target = self
+            item.state = (preset == PanelPreset.current) ? .on : .off
+            displayMenu.addItem(item)
+        }
+        displayItem.submenu = displayMenu
+        main.addItem(displayItem)
+
+        NSApp.mainMenu = main
+    }
+}

--- a/MacReceiver/PresentationController.swift
+++ b/MacReceiver/PresentationController.swift
@@ -1,0 +1,71 @@
+// Fullscreen presentation on the receiving Mac, plus keeping its display awake.
+//
+// Kiosk mode defaults OFF on purpose: a borderless .screenSaver-level window
+// with no menu bar can lock you out of the machine you are developing on.
+// Escape and Command-Q always drop out of it.
+
+import AppKit
+import IOKit.pwr_mgt
+
+final class PresentationController {
+
+    private weak var window: NSWindow?
+    private var sleepAssertion: IOPMAssertionID = 0
+    private var holdingAssertion = false
+    private(set) var isKiosk = false
+
+    init(window: NSWindow) {
+        self.window = window
+    }
+
+    // MARK: - Kiosk
+
+    func setKiosk(_ on: Bool) {
+        guard on != isKiosk, let window else { return }
+        isKiosk = on
+
+        if on {
+            guard let screen = window.screen ?? NSScreen.main else { return }
+            // .hideMenuBar without a Dock option raises — they must be paired.
+            NSApp.presentationOptions = [.hideDock, .hideMenuBar]
+            window.styleMask = [.borderless]
+            window.level = .screenSaver
+            window.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
+            window.isMovable = false
+            window.setFrame(screen.frame, display: true)
+            window.makeKeyAndOrderFront(nil)
+            NSCursor.hide()
+        } else {
+            NSApp.presentationOptions = []
+            window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
+            window.level = .normal
+            window.isMovable = true
+            window.title = "OpenDisplay Receiver"
+            NSCursor.unhide()
+        }
+        Log.info("kiosk \(on ? "on" : "off")")
+    }
+
+    func toggleKiosk() { setKiosk(!isKiosk) }
+
+    // MARK: - Display sleep
+
+    /// Held only while a session is live. Holding it permanently would stop the
+    /// iMac ever sleeping, which is not ours to decide.
+    func setDisplayAwake(_ awake: Bool) {
+        guard awake != holdingAssertion else { return }
+        if awake {
+            let ok = IOPMAssertionCreateWithName(
+                kIOPMAssertionTypePreventUserIdleDisplaySleep as CFString,
+                IOPMAssertionLevel(kIOPMAssertionLevelOn),
+                "OpenDisplay receiving" as CFString,
+                &sleepAssertion)
+            holdingAssertion = (ok == kIOReturnSuccess)
+            Log.info("display-sleep assertion \(holdingAssertion ? "taken" : "FAILED")")
+        } else {
+            IOPMAssertionRelease(sleepAssertion)
+            holdingAssertion = false
+            Log.info("display-sleep assertion released")
+        }
+    }
+}

--- a/MacReceiver/README.md
+++ b/MacReceiver/README.md
@@ -22,29 +22,24 @@ So a perfectly good 5K display becomes e-waste. This makes it a monitor again.
 
 ---
 
-## Verified setup
-
-Tested end to end on:
+## Tested and validated
 
 | | |
 |---|---|
-| **Sender** | MacBook Pro M4 Pro, macOS 26 |
-| **Receiver** | iMac 27" 2017 — Core i5-7600 (Kaby Lake), Radeon Pro 575 |
-| **Receiver OS** | **macOS Ventura 13.7.8** (the last version this iMac supports) |
-| **Transport** | **Wi-Fi** — no cable, no Thunderbolt |
+| **Resolution** | **5120 × 2880 — 14.7 MP, 1:1 pixels** |
+| **Desktop** | 2560 × 1440 @2x |
+| **Codec** | HEVC Main, 30 Mbit/s |
+| **Latency** | 54 ms median, 62 ms p95 |
+| **Round trip** | 5–6 ms |
+| **Machine** | i5-7600, Radeon Pro 575, **Ventura 13.7.8**, **Wi-Fi** |
 
-### Measured results
+Sender was a MacBook Pro M4 Pro on macOS 26. Colour is captured full-range BGRA;
+Ventura 13.7.8 is the last macOS this iMac supports, which is why it can never run
+the sender itself.
 
-| | |
-|---|---|
-| **Resolution** | **5120 × 2880** (14.7 megapixels, true 5K) |
-| **Desktop** | 2560 × 1440 points @2x |
-| **Scaling** | **None — 1:1 pixel mapping onto the panel** |
-| **Codec** | **HEVC (H.265)**, Main profile |
-| **Bitrate** | 30 Mbit/s |
-| **Colour** | Full-range BGRA capture |
-| **Latency** | **~54 ms median, ~62 ms p95** |
-| **Round trip** | ~5-6 ms |
+**1:1 pixels** is the part that matters: the stream is the same size as the panel,
+so nothing is scaled and nothing is blurred. Every codec and resolution limit
+below was established by end-to-end playback on this hardware, not from spec sheets.
 
 Good for writing, browsing, design tools, reference material, terminals. Not for
 gaming or fast video — that is a Wi-Fi limit, not a code one.

--- a/MacReceiver/README.md
+++ b/MacReceiver/README.md
@@ -127,7 +127,13 @@ Restart both apps afterwards — settings are read at launch.
 
 The older Mac now has its own desktop.
 
-- **Move windows there** by dragging past the screen edge.
+- **Move a window there** — hover over its **green button** (don't click) and pick
+  **"Move to OpenDisplay — …"**. This is the reliable way; dragging across the
+  edge also works but has two traps below.
+- **A full-screen window will never move**, however hard you drag — macOS pins it
+  to its own Space. Leave full screen first (`Ctrl-Cmd-F`), then move it.
+- **Grab the title bar, not a tab.** Dragging a browser tab tears it into a new
+  window, which then reopens on the original screen.
 - **Set the position** with *Arrange Displays…* so the edge you cross matches
   where the machine physically sits.
 - **Full screen** on the receiver: `Ctrl-Cmd-F`. `Esc` exits.

--- a/MacReceiver/README.md
+++ b/MacReceiver/README.md
@@ -1,0 +1,218 @@
+# OpenDisplay — macOS receiver
+
+Use an older Mac as a **real second display** for a newer one, over Wi-Fi.
+
+Upstream OpenDisplay turns an iPad or iPhone into a second monitor. There was no
+receiver for macOS, so a Mac could only ever be the sender. This adds one.
+
+---
+
+## The problem it solves
+
+An **iMac 27" 2017** has a beautiful 5K panel and no way to use it as a monitor:
+
+| Option | Why it doesn't work |
+|---|---|
+| Target Display Mode | Apple removed it after 2014 |
+| AirPlay to Mac | Needs a 2019 or newer iMac |
+| Run the OpenDisplay sender on it | Sender needs macOS 14; this iMac stops at Ventura 13 |
+| Sidecar | iPad only |
+
+So a perfectly good 5K display becomes e-waste. This makes it a monitor again.
+
+---
+
+## Verified setup
+
+Tested end to end on:
+
+| | |
+|---|---|
+| **Sender** | MacBook Pro M4 Pro, macOS 26 |
+| **Receiver** | iMac 27" 2017 — Core i5-7600 (Kaby Lake), Radeon Pro 575 |
+| **Receiver OS** | **macOS Ventura 13.7.8** (the last version this iMac supports) |
+| **Transport** | **Wi-Fi** — no cable, no Thunderbolt |
+
+### Measured results
+
+| | |
+|---|---|
+| **Resolution** | **5120 × 2880** (14.7 megapixels, true 5K) |
+| **Desktop** | 2560 × 1440 points @2x |
+| **Scaling** | **None — 1:1 pixel mapping onto the panel** |
+| **Codec** | **HEVC (H.265)**, Main profile |
+| **Bitrate** | 30 Mbit/s |
+| **Colour** | Full-range BGRA capture |
+| **Latency** | **~54 ms median, ~62 ms p95** |
+| **Round trip** | ~5-6 ms |
+
+Good for writing, browsing, design tools, reference material, terminals. Not for
+gaming or fast video — that is a Wi-Fi limit, not a code one.
+
+---
+
+## Codec support — measured, not assumed
+
+Established by end-to-end playback on real hardware:
+
+| Codec | 2560×1440 | 3840×2160 | **5120×2880** |
+|---|---|---|---|
+| **H.264** | OK | OK | **Fails — on every Mac** |
+| **HEVC** | OK | OK | **OK** |
+
+Two things worth knowing:
+
+**H.264 cannot do 5K on any Mac**, including an M4 Pro. Hardware decode stops
+below 5120 wide. It is a format ceiling, not an age limit — so **HEVC is
+mandatory for 5K**, on new machines as much as old ones.
+
+**A 2017 Intel iMac decodes 5K HEVC fine.** The Kaby Lake media engine handles it.
+Do not assume old hardware is the limit before measuring it.
+
+`tools/decode-probe.swift` reports what any given Mac can actually decode. Note
+that `VTDecompressionSessionCreate` succeeding proves nothing on its own — it will
+build sessions the hardware cannot sustain. Only playback is a valid test.
+
+---
+
+## Install
+
+Two apps. Each runs on its own machine.
+
+| App | Runs on | Requires |
+|---|---|---|
+| `OpenDisplay Sender.app` | the newer Mac | macOS 14+ |
+| `OpenDisplay Receiver.app` | the older Mac | macOS 13+, Intel or Apple silicon |
+
+1. Copy each app to `~/Applications` on its machine.
+   Use **AirDrop, `scp`, `rsync` or a USB stick.**
+2. **Right-click → Open** the first time. These are ad-hoc signed, so a
+   double-click is blocked. If macOS still refuses:
+   ```
+   xattr -dr com.apple.quarantine "OpenDisplay Receiver.app"
+   ```
+3. On the **sender**, grant **Screen Recording** when the app asks.
+   Accessibility is not needed — this build forwards no input.
+
+### Apply the settings
+
+```
+./restore-settings.sh              # on the sender
+./restore-settings.sh receiver     # on the receiver
+```
+
+Or by hand:
+
+```sh
+# Sender
+defaults write com.peetzweg.opensidecar.mac hevc         -bool YES
+defaults write com.peetzweg.opensidecar.mac bitrateMbps  -int  30
+defaults write com.peetzweg.opensidecar.mac quality      -string best
+defaults write com.peetzweg.opensidecar.mac mode         -string extend
+defaults write com.peetzweg.opensidecar.mac pixfmt       -string bgra
+
+# Receiver
+defaults write com.peetzweg.opensidecar.macreceiver panelPreset   -string moreSpace
+defaults write com.peetzweg.opensidecar.macreceiver maxEncode     -int  5120
+defaults write com.peetzweg.opensidecar.macreceiver metalRenderer -bool YES
+defaults write com.peetzweg.opensidecar.macreceiver sharpen       -float 0
+```
+
+Restart both apps afterwards — settings are read at launch.
+
+---
+
+## Connect and use
+
+1. Open **OpenDisplay Receiver** on the older Mac. It waits, showing
+   *Listening on :9000*.
+2. Open **OpenDisplay** on the newer Mac. The receiver appears by computer name.
+3. Set **Mode → Extend**, then click **Connect**.
+4. macOS asks what to show — choose **Extended Display**.
+
+The older Mac now has its own desktop.
+
+- **Move windows there** by dragging past the screen edge.
+- **Set the position** with *Arrange Displays…* so the edge you cross matches
+  where the machine physically sits.
+- **Full screen** on the receiver: `Ctrl-Cmd-F`. `Esc` exits.
+- **Wallpaper**: a new display starts blank. Right-click the desktop to set one —
+  otherwise an empty desktop looks like a failure when it isn't.
+
+### Extend vs Mirror
+
+| Mode | |
+|---|---|
+| **Extend** | Its own desktop. Move windows onto it. **Use this.** |
+| Mirror | A copy of the sender's screen. Windows cannot be moved onto it, and it can never exceed the sender's own resolution. |
+
+### Turn Universal Control off
+
+If both Macs share an Apple ID, Universal Control competes for the same screen
+edge — and wins. The pointer jumps to the other Mac's *own* desktop instead of
+onto your extended display, and windows will not follow.
+
+**System Settings → Displays → Advanced** → turn off *"Allow your pointer and
+keyboard to move between any nearby Mac or iPad"*.
+
+You do not need it: the sender's own keyboard and trackpad drive the extended
+screen natively, and they do so over an encrypted channel rather than this one
+(the wire protocol has no TLS and no authentication — see PROTOCOL.md §1).
+
+---
+
+## Two traps that cost a whole evening
+
+**30 Mbit/s is a ceiling, not a suggestion.** At 45 the 2017 iMac cannot sustain
+5K HEVC decode over Wi-Fi. The receiver's watchdog then steps the announced size
+down 5120 → 3840 → 2880, which presents as **"the UI suddenly got big"** — not as
+an error message. If that happens, lower the bitrate; do not chase the resolution.
+
+**Rebuilding the sender silently revokes Screen Recording.** The ad-hoc code
+signature changes, macOS treats it as a different app, and the only symptom is a
+black screen. Remove and re-add it in Privacy & Security.
+
+---
+
+## Sharpening
+
+`sharpen` drives an unsharp mask in the Metal renderer, for when the stream is
+**smaller** than the panel and has to be magnified.
+
+| Situation | Value |
+|---|---|
+| 5120×2880 on a 5K panel (1:1) | **0** — nothing to correct; anything higher looks artificial |
+| 3840×2160 on a 5K panel (1.33× magnified) | 0.6-1.0 |
+
+macOS only offers bilinear magnification through the system video layer, which is
+why the renderer draws the video itself.
+
+---
+
+## Building
+
+No Xcode required. Developed on a managed Mac with no admin rights, where the
+Xcode licence can never be accepted and `xcodebuild` / `xcodegen` are unusable —
+`DEVELOPER_DIR` points at the Command Line Tools instead.
+
+```sh
+./MacReceiver/build.sh          # universal (Intel + Apple silicon), macOS 13+
+./MacSenderShim/build-sender.sh # arm64, macOS 14+
+```
+
+If Xcode ever *is* available, adding a proper `project.yml` target would be a
+reasonable follow-up; this path exists because that one was closed.
+
+---
+
+## Compatibility
+
+| Receiver | Works? |
+|---|---|
+| iMac 27" 2020 | Yes — best case, newer decoder |
+| iMac 27" 2019 | Yes |
+| **iMac 27" 2017** | **Yes — verified, this is the reference machine** |
+| iMac 21.5" 4K 2017 / 2019 | Yes — announces 4096×2304 instead |
+| Anything below macOS 13 | Not as built; lower the deployment target in `build.sh` |
+
+Sender needs macOS 14+, so a 2017 iMac can only ever be the receiver.

--- a/MacReceiver/VideoHostView.swift
+++ b/MacReceiver/VideoHostView.swift
@@ -1,0 +1,185 @@
+// The NSView that shows the streamed desktop.
+//
+// Port of the iOS VideoView (iOS/OpenSidecarPhoneApp.swift:808-908). Three
+// AppKit differences matter and each one is a silent-wrong-render if missed:
+//
+//  1. isFlipped = true — AppKit is bottom-left origin. With this, the aspect-fit
+//     and normalize math ports across unchanged and the cursor is not mirrored.
+//  2. contentsScale must be set by hand on every sublayer we add. On iOS it is
+//     inherited; on AppKit it is not, and the symptom (everything renders at 1x,
+//     i.e. soft and half-resolution) looks exactly like an encoder problem.
+//  3. layout(), not layoutSubviews().
+
+import AppKit
+import AVFoundation
+import CoreVideo
+
+final class VideoHostView: NSView {
+
+    private let displayLayer: AVSampleBufferDisplayLayer
+    private let cursorLayer = CALayer()
+    private var cursorNormSize = CGSize(width: 0.02, height: 0.02)
+    private var cursorAnchor = CGPoint.zero
+    private var cursorPosition = CGPoint(x: 0.5, y: 0.5)
+    private var cursorVisible = false
+
+    /// Decoded video size, taken from the SPS — never from `hello`
+    /// (PROTOCOL.md section 5.2 makes this normative).
+    var videoSize: CGSize = .zero {
+        didSet { if videoSize != oldValue { needsLayout = true } }
+    }
+
+    override var isFlipped: Bool { true }
+    override var acceptsFirstResponder: Bool { true }
+
+    /// Opt-in alternative to AVSampleBufferDisplayLayer. Its only advantage here
+    /// is that we own the fragment shader, so we can sharpen while upscaling —
+    /// the system layer only offers bilinear, which is what makes a stream
+    /// smaller than the panel look soft at full screen.
+    private(set) var metalRenderer: MetalVideoRenderer?
+
+    init(displayLayer: AVSampleBufferDisplayLayer) {
+        self.displayLayer = displayLayer
+        super.init(frame: .zero)
+        wantsLayer = true                      // must precede adding sublayers
+        layer?.backgroundColor = NSColor.black.cgColor
+
+        if UserDefaults.standard.bool(forKey: "metalRenderer"),
+           let renderer = MetalVideoRenderer() {
+            metalRenderer = renderer
+            renderer.metalLayer.frame = bounds
+            layer?.addSublayer(renderer.metalLayer)
+        } else {
+            displayLayer.videoGravity = .resizeAspect
+            layer?.addSublayer(displayLayer)
+        }
+
+        cursorLayer.isHidden = true
+        cursorLayer.zPosition = 10
+        cursorLayer.magnificationFilter = .nearest
+        layer?.addSublayer(cursorLayer)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("not used") }
+
+    // MARK: - Geometry
+
+    /// The letterboxed rect the video actually occupies inside our bounds.
+    func videoRect() -> CGRect {
+        guard videoSize.width > 0, videoSize.height > 0 else { return bounds }
+        let fit = min(bounds.width / videoSize.width, bounds.height / videoSize.height)
+        let w = videoSize.width * fit, h = videoSize.height * fit
+        return CGRect(x: (bounds.width - w) / 2, y: (bounds.height - h) / 2,
+                      width: w, height: h)
+    }
+
+    /// Scale factor from video pixels to view points — the divisor for scroll
+    /// deltas, which travel in video pixels (PROTOCOL.md section 7).
+    var videoFitScale: CGFloat {
+        guard videoSize.width > 0, videoSize.height > 0 else { return 1 }
+        return min(bounds.width / videoSize.width, bounds.height / videoSize.height)
+    }
+
+    /// View point -> normalized [0,1] video space, origin top-left.
+    func normalized(_ point: CGPoint) -> CGPoint {
+        let r = videoRect()
+        guard r.width > 0, r.height > 0 else { return .zero }
+        return CGPoint(x: min(max((point.x - r.minX) / r.width, 0), 1),
+                       y: min(max((point.y - r.minY) / r.height, 0), 1))
+    }
+
+    override func layout() {
+        super.layout()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)     // no implicit animation on resize
+        if let metal = metalRenderer {
+            let rect = videoRect()                // aspect-fit; CAMetalLayer does
+                                                  // not letterbox for us
+            let scale = window?.backingScaleFactor ?? 2
+            let drawable = CGSize(width: rect.width * scale, height: rect.height * scale)
+            // nextDrawable() returns nil forever on a zero-sized layer, which
+            // shows up as a permanently black window rather than an error.
+            if rect.width > 1, rect.height > 1 {
+                metal.metalLayer.frame = rect
+                metal.metalLayer.drawableSize = drawable
+            }
+        } else {
+            displayLayer.frame = bounds
+        }
+        updateCursorLayout()
+        CATransaction.commit()
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        applyContentsScale()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        applyContentsScale()
+    }
+
+    /// A manually created CALayer defaults to contentsScale 1.0 and does NOT
+    /// inherit the window's backing factor the way iOS layers do. Left at 1 on a
+    /// Retina panel, the video is rasterised at point resolution and then
+    /// stretched to the physical pixels — which reads as "sharp in a small
+    /// window, blurry at full screen", because a small window downscales (sharp)
+    /// while full screen upscales (soft).
+    ///
+    /// viewDidChangeBackingProperties alone is not enough: it fires on *changes*,
+    /// so a view whose scale never changes after creation can keep 1.0 forever.
+    /// Hence also viewDidMoveToWindow, and a screen-derived fallback.
+    private func applyContentsScale() {
+        let scale = window?.backingScaleFactor
+            ?? window?.screen?.backingScaleFactor
+            ?? NSScreen.main?.backingScaleFactor
+            ?? 2
+        guard scale > 0 else { return }
+        layer?.contentsScale = scale
+        displayLayer.contentsScale = scale
+        cursorLayer.contentsScale = scale
+        metalRenderer?.metalLayer.contentsScale = scale
+        if scale != lastLoggedScale {
+            lastLoggedScale = scale
+            Log.info("backing scale \(scale) — layer renders at "
+                     + "\(Int(bounds.width * scale))x\(Int(bounds.height * scale)) px")
+        }
+        needsLayout = true
+    }
+
+    private var lastLoggedScale: CGFloat = 0
+
+    // MARK: - Cursor echo
+
+    func setCursor(x: Double, y: Double, visible: Bool) {
+        cursorPosition = CGPoint(x: x, y: y)
+        cursorVisible = visible
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        cursorLayer.isHidden = !visible
+        updateCursorLayout()
+        CATransaction.commit()
+    }
+
+    func setCursorSprite(_ image: CGImage, anchor: CGPoint, normSize: CGSize) {
+        cursorAnchor = anchor
+        cursorNormSize = normSize
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        cursorLayer.contents = image
+        updateCursorLayout()
+        CATransaction.commit()
+    }
+
+    private func updateCursorLayout() {
+        let r = videoRect()
+        guard r.width > 0 else { return }
+        let w = cursorNormSize.width * r.width
+        let h = cursorNormSize.height * r.height
+        let x = r.minX + cursorPosition.x * r.width - cursorAnchor.x * w
+        let y = r.minY + cursorPosition.y * r.height - cursorAnchor.y * h
+        cursorLayer.frame = CGRect(x: x, y: y, width: max(w, 1), height: max(h, 1))
+    }
+}

--- a/MacReceiver/build.sh
+++ b/MacReceiver/build.sh
@@ -1,0 +1,90 @@
+#!/bin/zsh
+# Build the macOS receiver WITHOUT Xcode.
+#
+# Why this exists: this is a managed Mac with no admin rights, so
+# `sudo xcodebuild -license` cannot be accepted and `xcodebuild` is unusable.
+# DEVELOPER_DIR points the toolchain at the Command Line Tools instead, which
+# carry their own already-accepted licence. Verified working: Swift 6.3.3,
+# universal binary, minos 13.0, AppKit + Network + VideoToolbox + Metal all link.
+#
+# Output: build/OpenDisplay Receiver.app — a universal (x86_64 + arm64) bundle
+# that runs on the Intel iMac 27" 2017 on Ventura AND on this Apple Silicon Mac.
+set -e
+cd "$(dirname "$0")/.."
+
+export DEVELOPER_DIR=/Library/Developer/CommandLineTools
+
+APP_NAME="OpenDisplay Receiver"
+BIN_NAME="OpenDisplayReceiver"
+OUT="build/${APP_NAME}.app"
+DEPLOY=13.0                      # the iMac 27" 2017 ceiling (Ventura)
+
+# Source set. The receiver core and renderer are reused from iOS/ verbatim —
+# same trick project.yml already uses for OpenSidecarMacTests.
+SOURCES=(
+  MacReceiver/*.swift
+  Receiver/*.swift
+  iOS/PhoneReceiver.swift
+  iOS/MetalVideoRenderer.swift
+  Shared/Protocol.swift
+  Shared/AppStore.swift
+)
+
+echo "==> compiling both slices at macOS ${DEPLOY}"
+mkdir -p build
+for arch in arm64 x86_64; do
+  swiftc -target ${arch}-apple-macos${DEPLOY} \
+         -O -whole-module-optimization \
+         -o "build/${BIN_NAME}-${arch}" \
+         ${~SOURCES}
+done
+
+echo "==> fusing universal binary"
+lipo -create "build/${BIN_NAME}-arm64" "build/${BIN_NAME}-x86_64" \
+     -output "build/${BIN_NAME}"
+
+echo "==> packaging ${OUT}"
+rm -rf "$OUT"
+mkdir -p "$OUT/Contents/MacOS"
+cp "build/${BIN_NAME}" "$OUT/Contents/MacOS/${BIN_NAME}"
+
+# swiftc cannot compile asset catalogues, so the icon is produced separately
+# from Mac/Assets.xcassets by MacReceiver/make-icon.sh (iconutil ships with the
+# Command Line Tools). Without it the app shows a blank generic icon.
+mkdir -p "$OUT/Contents/Resources"
+[ -f build/AppIcon.icns ] || ./MacReceiver/make-icon.sh
+cp build/AppIcon.icns "$OUT/Contents/Resources/AppIcon.icns"
+
+cat > "$OUT/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleExecutable</key><string>${BIN_NAME}</string>
+  <key>CFBundleIdentifier</key><string>com.peetzweg.opensidecar.macreceiver</string>
+  <key>CFBundleName</key><string>${APP_NAME}</string>
+  <key>CFBundleDisplayName</key><string>${APP_NAME}</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleIconFile</key><string>AppIcon</string>
+  <key>CFBundleShortVersionString</key><string>0.1.0</string>
+  <key>CFBundleVersion</key><string>1</string>
+  <key>LSMinimumSystemVersion</key><string>${DEPLOY}</string>
+  <key>NSPrincipalClass</key><string>NSApplication</string>
+  <key>NSHighResolutionCapable</key><true/>
+  <key>LSApplicationCategoryType</key><string>public.app-category.utilities</string>
+  <!-- Required or Bonjour silently fails on macOS 15+. Harmless on Ventura. -->
+  <key>NSBonjourServices</key><array><string>_opensidecar._tcp</string></array>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>OpenDisplay advertises itself on the local network so your Mac can connect.</string>
+</dict></plist>
+PLIST
+
+# Ad-hoc signature. The Intel iMac would run unsigned, but Apple Silicon will
+# not, and we test on this Mac first.
+codesign -s - --force --deep "$OUT" >/dev/null 2>&1
+
+echo "==> built: $OUT"
+lipo -info "$OUT/Contents/MacOS/${BIN_NAME}"
+otool -l "$OUT/Contents/MacOS/${BIN_NAME}" | grep minos | head -2
+echo
+echo "Copy to the iMac with rsync/scp (NOT AirDrop — that sets the quarantine flag):"
+echo "  rsync -a \"$OUT\" imac.local:/Users/\$USER/Applications/"

--- a/MacReceiver/make-icon.sh
+++ b/MacReceiver/make-icon.sh
@@ -1,0 +1,31 @@
+#!/bin/zsh
+# Build build/AppIcon.icns from the repo's asset-catalogue PNGs.
+#
+# swiftc cannot compile .xcassets — that is actool's job, and actool only ships
+# inside Xcode, which is unusable here (no admin rights to accept the licence).
+# iconutil, however, ships with the Command Line Tools, so we assemble a
+# classic .iconset by hand and let iconutil do the rest.
+set -e
+cd "$(dirname "$0")/.."
+
+SRC=Mac/Assets.xcassets/AppIcon.appiconset
+OUT=build/AppIcon.iconset
+mkdir -p build
+rm -rf "$OUT"; mkdir -p "$OUT"
+
+# iconutil expects these exact names. The catalogue stores one PNG per pixel
+# size, so several are reused at both 1x and 2x.
+cp "$SRC/icon_16.png"   "$OUT/icon_16x16.png"
+cp "$SRC/icon_32.png"   "$OUT/icon_16x16@2x.png"
+cp "$SRC/icon_32.png"   "$OUT/icon_32x32.png"
+cp "$SRC/icon_64.png"   "$OUT/icon_32x32@2x.png"
+cp "$SRC/icon_128.png"  "$OUT/icon_128x128.png"
+cp "$SRC/icon_256.png"  "$OUT/icon_128x128@2x.png"
+cp "$SRC/icon_256.png"  "$OUT/icon_256x256.png"
+cp "$SRC/icon_512.png"  "$OUT/icon_256x256@2x.png"
+cp "$SRC/icon_512.png"  "$OUT/icon_512x512.png"
+cp "$SRC/icon_1024.png" "$OUT/icon_512x512@2x.png"
+
+iconutil -c icns "$OUT" -o build/AppIcon.icns
+rm -rf "$OUT"
+echo "built build/AppIcon.icns"

--- a/MacReceiver/restore-settings.sh
+++ b/MacReceiver/restore-settings.sh
@@ -1,0 +1,75 @@
+#!/bin/zsh
+# Restore the known-good iMac-as-5K-display configuration.
+#
+# Run with no argument on the SENDER (MacBook Pro), or `./restore-settings.sh receiver`
+# on the RECEIVER (iMac 27" 2017). Settings live in UserDefaults, so a fresh install
+# or an accidental change is recoverable without remembering any of this.
+#
+# Verified working 2026-08-29: 5120x2880 HEVC at 30 Mbit/s, 2560x1440 desktop,
+# 1:1 pixels on the iMac's 5K panel, ~50 ms end-to-end over Wi-Fi.
+set -e
+
+SENDER=com.peetzweg.opensidecar.mac
+RECEIVER=com.peetzweg.opensidecar.macreceiver
+
+if [[ "$1" == "receiver" ]]; then
+  echo "==> configuring RECEIVER (run this on the iMac)"
+
+  # Announce a 5120x2880 panel. The sender halves this to derive the desktop, so
+  # this is what produces a 2560x1440 desktop — the correct UI size for a 27".
+  defaults write $RECEIVER panelPreset -string moreSpace
+
+  # Declared decode ceiling. 5120 is correct ONLY with HEVC; H.264 hardware decode
+  # fails above ~4096 wide on every Mac, so drop this to 3840 if HEVC is ever off.
+  defaults write $RECEIVER maxEncode -int 5120
+
+  # Draw the video ourselves. The system video layer only offers bilinear
+  # magnification and no filter control.
+  defaults write $RECEIVER metalRenderer -bool YES
+
+  # 0 = no sharpening. Correct at 5120x2880, where the stream lands 1:1 on the
+  # panel and there is no scaling blur to correct. Raise to ~0.6 only if the
+  # stream is ever smaller than the panel again.
+  defaults write $RECEIVER sharpen -float 0
+
+  echo "    panelPreset   = $(defaults read $RECEIVER panelPreset)"
+  echo "    maxEncode     = $(defaults read $RECEIVER maxEncode)"
+  echo "    metalRenderer = $(defaults read $RECEIVER metalRenderer)"
+  echo "    sharpen       = $(defaults read $RECEIVER sharpen)"
+  echo "==> restarting the receiver"
+  killall OpenDisplayReceiver 2>/dev/null || true
+  sleep 2
+  open -a "OpenDisplay Receiver"
+else
+  echo "==> configuring SENDER (run this on the MacBook Pro)"
+
+  # HEVC is mandatory for 5K: H.264 hardware decode stops below 5120 wide on
+  # every Mac tested, including Apple silicon.
+  defaults write $SENDER hevc -bool YES
+
+  # 30 is a CEILING, not a suggestion. At 45 the iMac cannot sustain 5K HEVC
+  # decode over Wi-Fi; the receiver's watchdog then walks the preset down
+  # 5120 -> 3840 -> 2880, which looks like "the UI suddenly got big".
+  defaults write $SENDER bitrateMbps -int 30
+
+  defaults write $SENDER quality -string best
+  defaults write $SENDER mode -string extend
+
+  # Capture full-range BGRA instead of video-range 4:2:0. Without it blacks are
+  # lifted to grey and colour looks flat.
+  defaults write $SENDER pixfmt -string bgra
+
+  echo "    hevc        = $(defaults read $SENDER hevc)"
+  echo "    bitrateMbps = $(defaults read $SENDER bitrateMbps)"
+  echo "    quality     = $(defaults read $SENDER quality)"
+  echo "    mode        = $(defaults read $SENDER mode)"
+  echo "    pixfmt      = $(defaults read $SENDER pixfmt)"
+  echo "==> restarting the sender"
+  osascript -e 'quit app "OpenDisplay"' 2>/dev/null || true
+  sleep 2
+  open ~/Applications/OpenDisplay.app
+  echo
+  echo "NOTE: rebuilding the sender changes its ad-hoc code signature, so macOS"
+  echo "      revokes Screen Recording. Symptom is a black screen. Re-grant it in"
+  echo "      the app's Permissions section."
+fi

--- a/MacSenderShim/SparkleStub.swift
+++ b/MacSenderShim/SparkleStub.swift
@@ -1,0 +1,28 @@
+// Minimal stand-in for Sparkle.
+//
+// Sparkle is an SPM dependency, and SPM cannot be resolved here: this is a
+// managed Mac with no admin rights, so the Xcode licence can never be accepted
+// and xcodebuild/xcodegen are unusable. We build with swiftc directly instead.
+//
+// Sparkle only powers the "Check for Updates…" button. A locally built sender
+// has no signed appcast to update from anyway, so stubbing it out loses nothing:
+// the button simply stays disabled.
+//
+// Guarded so that if a real Sparkle ever becomes available, it wins.
+
+#if !canImport(Sparkle)
+
+import Foundation
+
+/// KVO-observable so the app's `publisher(for: \.canCheckForUpdates)` still works.
+@objc final class SPUUpdater: NSObject {
+    @objc dynamic var canCheckForUpdates: Bool = false
+    func checkForUpdates() {}
+}
+
+final class SPUStandardUpdaterController {
+    let updater = SPUUpdater()
+    init(startingUpdater: Bool, updaterDelegate: Any?, userDriverDelegate: Any?) {}
+}
+
+#endif

--- a/MacSenderShim/build-sender.sh
+++ b/MacSenderShim/build-sender.sh
@@ -1,0 +1,66 @@
+#!/bin/zsh
+# Build the macOS SENDER without Xcode (no admin rights on this machine).
+# Same DEVELOPER_DIR trick as MacReceiver/build.sh, plus:
+#   -import-objc-header  for the private CGVirtualDisplay declarations
+#   MacSenderShim/       for the Sparkle stub
+#
+# arm64 only: the sender needs macOS 14+, so it runs on the MacBook, not the iMac.
+set -e
+cd "$(dirname "$0")/.."
+
+export DEVELOPER_DIR=/Library/Developer/CommandLineTools
+
+APP_NAME="OpenDisplay Sender"
+BIN_NAME="OpenDisplaySender"
+OUT="build/${APP_NAME}.app"
+DEPLOY=14.0
+
+SOURCES=(
+  Mac/*.swift
+  Shared/*.swift
+  MacSenderShim/SparkleStub.swift
+)
+
+echo "==> compiling sender (arm64, macOS ${DEPLOY})"
+mkdir -p build
+swiftc -target arm64-apple-macos${DEPLOY} \
+       -import-objc-header Mac/OpenSidecarMac-Bridging-Header.h \
+       -O -whole-module-optimization \
+       -o "build/${BIN_NAME}" \
+       ${~SOURCES}
+
+echo "==> packaging ${OUT}"
+rm -rf "$OUT"
+mkdir -p "$OUT/Contents/MacOS"
+cp "build/${BIN_NAME}" "$OUT/Contents/MacOS/${BIN_NAME}"
+
+# See MacReceiver/build.sh — swiftc cannot compile asset catalogues.
+mkdir -p "$OUT/Contents/Resources"
+[ -f build/AppIcon.icns ] || ./MacReceiver/make-icon.sh
+cp build/AppIcon.icns "$OUT/Contents/Resources/AppIcon.icns"
+
+cat > "$OUT/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleExecutable</key><string>${BIN_NAME}</string>
+  <key>CFBundleIdentifier</key><string>com.peetzweg.opensidecar.mac</string>
+  <key>CFBundleName</key><string>${APP_NAME}</string>
+  <key>CFBundleDisplayName</key><string>${APP_NAME}</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleIconFile</key><string>AppIcon</string>
+  <key>CFBundleShortVersionString</key><string>1.17.0</string>
+  <key>CFBundleVersion</key><string>1</string>
+  <key>LSMinimumSystemVersion</key><string>${DEPLOY}</string>
+  <key>NSPrincipalClass</key><string>NSApplication</string>
+  <key>NSHighResolutionCapable</key><true/>
+  <key>LSUIElement</key><true/>
+  <key>LSApplicationCategoryType</key><string>public.app-category.utilities</string>
+  <key>NSBonjourServices</key><array><string>_opensidecar._tcp</string></array>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>OpenDisplay connects to your iPad, iPhone or Mac over the local network.</string>
+</dict></plist>
+PLIST
+
+codesign -s - --force --deep "$OUT" >/dev/null 2>&1
+echo "==> built: $OUT"

--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@
 
 **Turn your spare Apple devices into second monitors for your Mac — free, open source, no subscription.**
 
-iPhone and iPad today, spare MacBooks on the roadmap. A self-hosted
+iPhone, iPad — **and now a spare Mac**. A self-hosted
 alternative to Apple Sidecar, Duet Display, and Luna Display: true extended
 display (not just mirroring), Retina-sharp, over USB or WiFi, with touch and
 scroll input.
+
+**Old Macs work too.** An **iMac 27" 2017 (Retina 5K)** runs as a receiver at its
+full **5120 × 2880**, 1:1 pixels over Wi-Fi — a machine that otherwise cannot be a
+display at all, since Target Display Mode was removed after 2014 and AirPlay-to-Mac
+needs a 2019+ model. See [macOS receiver](MacReceiver/README.md).
 
 [Website](https://peetzweg.github.io/opendisplay/) · [Quick start](#quick-start) · [How it works](#how-it-works) · [FAQ](#faq) · [Contributing](#contributing)
 
@@ -41,6 +46,10 @@ pipeline, USB transport, input injection) are already working.
 
 ## Features
 
+- 🖥️ **A spare Mac as a display** — not just iPhone and iPad. Verified on an
+  **iMac 27" 2017** at true **5120 × 2880** over Wi-Fi, 1:1 pixels with no
+  scaling. Runs on macOS 13+, Intel or Apple silicon, so Macs too old for the
+  sender can still be receivers. ([details](MacReceiver/README.md))
 - 🖥️ **True display extension** — macOS treats the device as a real second
   monitor (drag windows to it, arrange it in System Settings), not a mirror.
   Mirroring is also available as a mode.
@@ -104,6 +113,17 @@ adapters.
 **Does it support iPad?** The receiver app is universal (iPhone + iPad);
 iPad is the same codebase. iPad-specific polish (Pencil, pressure) is on the
 roadmap.
+
+**Can I use an old Mac as the display?** Yes — see
+[MacReceiver/README.md](MacReceiver/README.md). The receiver needs macOS 13+ and
+runs on Intel or Apple silicon; the *sender* still needs macOS 14+, so an older
+Mac can be the display but not the source. A 2017 iMac 27" reaches its full
+5120 × 2880 this way.
+
+**Why does 5K need HEVC?** H.264 hardware decode stops below 5120 wide on every
+Mac tested, including Apple silicon — it is a format ceiling, not an age limit.
+HEVC handles 5120 × 2880 on hardware as old as 2017 Kaby Lake. Enable it with
+`defaults write com.peetzweg.opensidecar.mac hevc -bool YES`.
 
 **Why H.264 and not HEVC/AV1?** Hardware H.264 encode/decode is universally
 fast and the latency is excellent. HEVC is a planned option for better

--- a/Receiver/Platform.swift
+++ b/Receiver/Platform.swift
@@ -1,0 +1,104 @@
+// Cross-platform shims so the receiver core (iOS/PhoneReceiver.swift) compiles
+// for BOTH iOS and macOS. Keep this the only place that branches on toolkit.
+//
+// The iOS app already has its own `deviceKind` global and PeerUpdateSignal in
+// iOS/VersionGate.swift, so everything macOS-only here is guarded to avoid
+// colliding when this file is compiled into the iOS target.
+
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+#else
+import AppKit
+#endif
+
+enum ReceiverPlatform {
+    /// Goes into `hello.device`. PROTOCOL.md section 6.1 declares this field
+    /// free-form, so "Mac" needs no spec change and no sender change.
+    static var deviceKind: String {
+        #if canImport(UIKit)
+        return UIDevice.current.userInterfaceIdiom == .pad ? "iPad" : "iPhone"
+        #else
+        return "Mac"
+        #endif
+    }
+
+    /// Default Bonjour service name. iOS returns a generic "iPhone" from
+    /// UIDevice (the real name is entitlement-gated); macOS hands over the
+    /// actual computer name with no gate.
+    static var defaultDeviceName: String {
+        #if canImport(UIKit)
+        return UIDevice.current.name
+        #else
+        return Host.current().localizedName ?? "Mac"
+        #endif
+    }
+}
+
+#if !canImport(UIKit)
+
+/// Mirrors the enum in iOS/VersionGate.swift, which cannot be compiled here
+/// because it is a SwiftUI view file that calls UIApplication.
+enum PeerUpdateSignal: Equatable {
+    case updateIPhone(message: String, storeURL: URL)
+    case updateMac(message: String)
+}
+
+/// The panel size the receiver announces in `hello`.
+///
+/// CRITICAL: the sender IGNORES `hello.scale`. `MacSender.swift:374` computes
+/// `pointsWide = pixelsWide / 2` unconditionally and the virtual display is
+/// always @2x. So the desktop you get is always **half** the announced pixels,
+/// and the announced pixel size is the only lever on desktop size.
+///
+/// The sender then encodes at `points * 2 * quality.scale`, and H.264 hardware
+/// encode is widely capped at 4096 wide — which is why 5120 is not the default.
+enum PanelPreset: String, CaseIterable {
+    case balanced      // 1920x1080 desktop, encodes 3840x2160 at any quality
+    case moreSpace     // 2560x1440 desktop, needs sender on Balanced or Fast
+    case largerText    // 1440x810 desktop
+
+    var pixels: (w: Int, h: Int) {
+        switch self {
+        case .balanced:   return (3840, 2160)
+        case .moreSpace:  return (5120, 2880)
+        case .largerText: return (2880, 1620)
+        }
+    }
+
+    var title: String {
+        let d = pixels
+        switch self {
+        case .moreSpace:  return "Sharpest — \(d.w / 2)x\(d.h / 2) desktop (set Mac quality to Fast)"
+        case .balanced:   return "Balanced — \(d.w / 2)x\(d.h / 2) desktop"
+        case .largerText: return "Larger text — \(d.w / 2)x\(d.h / 2) desktop"
+        }
+    }
+
+    /// Next smaller announcement, for automatic fallback when the receiving
+    /// hardware cannot decode the stream the sender produces. Measured on an
+    /// iMac 27" 2017 (Radeon Pro 575): 2880x1620 decodes, 3840x2160 does not.
+    var smaller: PanelPreset? {
+        switch self {
+        case .moreSpace:  return .balanced
+        case .balanced:   return .largerText
+        case .largerText: return nil
+        }
+    }
+
+    /// Defaults to `.moreSpace` — a 27" 5K panel wants a 2560x1440 desktop, and
+    /// announcing 5120x2880 is the only way to get one (the sender halves the
+    /// announced pixels to derive points). If the sender's encoder refuses
+    /// 5120-wide, pick another entry from the Display menu to recover.
+    static var current: PanelPreset {
+        let raw = UserDefaults.standard.string(forKey: "panelPreset") ?? ""
+        return PanelPreset(rawValue: raw) ?? .moreSpace
+    }
+
+    static func select(_ p: PanelPreset) {
+        UserDefaults.standard.set(p.rawValue, forKey: "panelPreset")
+    }
+}
+
+#endif

--- a/iOS/MetalVideoRenderer.swift
+++ b/iOS/MetalVideoRenderer.swift
@@ -18,6 +18,13 @@ import QuartzCore
 import CoreVideo
 
 final class MetalVideoRenderer {
+    /// Read once per frame so it can be tuned live from the command line while
+    /// looking at the screen, which is the only sane way to pick a value.
+    static var sharpenAmount: Float {
+        let stored = UserDefaults.standard.object(forKey: "sharpen") as? Double
+        return Float(stored ?? 0.6)
+    }
+
     let metalLayer = CAMetalLayer()
     private let device: MTLDevice
     private let commandQueue: MTLCommandQueue
@@ -51,11 +58,28 @@ final class MetalVideoRenderer {
             o.uv = float2((p[vid].x + 1.0) * 0.5, (1.0 - p[vid].y) * 0.5);
             return o;
         }
+        // Unsharp mask on luma only. The stream is smaller than the panel, so
+        // the GPU magnifies it with bilinear filtering — which is exactly what
+        // "blurry when full screen, sharp in a small window" looks like. Adding
+        // back the high-frequency detail bilinear removes counteracts that.
+        // Chroma is left alone: it is subsampled anyway and sharpening it only
+        // produces colour fringing on text.
         fragment float4 fmain(VOut in [[stage_in]],
                               texture2d<float> texY [[texture(0)]],
-                              texture2d<float> texCbCr [[texture(1)]]) {
+                              texture2d<float> texCbCr [[texture(1)]],
+                              constant float &sharpen [[buffer(0)]]) {
             constexpr sampler s(filter::linear);
             float y = texY.sample(s, in.uv).r;
+            if (sharpen > 0.0) {
+                float2 texel = 1.0 / float2(texY.get_width(), texY.get_height());
+                // 4-tap cross: cheap enough for a 2017 GPU at 5K, and a cross
+                // sharpens strokes without the halo a full 3x3 kernel gives.
+                float blur = 0.25 * (texY.sample(s, in.uv + float2( texel.x, 0)).r
+                                   + texY.sample(s, in.uv + float2(-texel.x, 0)).r
+                                   + texY.sample(s, in.uv + float2(0,  texel.y)).r
+                                   + texY.sample(s, in.uv + float2(0, -texel.y)).r);
+                y = clamp(y + sharpen * (y - blur), 0.0, 1.0);
+            }
             float2 cbcr = texCbCr.sample(s, in.uv).rg;
             float yn = 1.1644 * (y - 0.0627);
             float cb = cbcr.x - 0.5;
@@ -145,6 +169,11 @@ final class MetalVideoRenderer {
         encoder.setRenderPipelineState(pipeline)
         encoder.setFragmentTexture(texY, index: 0)
         encoder.setFragmentTexture(texCbCr, index: 1)
+        // Tunable without a rebuild:
+        //   defaults write com.peetzweg.opensidecar.macreceiver sharpen -float 0.6
+        // 0 disables it; ~0.4-0.8 is the useful band, above ~1.2 it haloes.
+        var sharpen = Self.sharpenAmount
+        encoder.setFragmentBytes(&sharpen, length: MemoryLayout<Float>.size, index: 0)
         encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
         encoder.endEncoding()
 

--- a/iOS/PhoneReceiver.swift
+++ b/iOS/PhoneReceiver.swift
@@ -11,7 +11,14 @@ import Network
 import AVFoundation
 import CoreMedia
 import VideoToolbox
+// QuartzCore and ImageIO were previously reaching this file only through UIKit's
+// re-exports; name them so the macOS build (no UIKit) still finds
+// CACurrentMediaTime and the CGImageSource decoders.
+import QuartzCore
+import ImageIO
+#if canImport(UIKit)
 import UIKit
+#endif
 
 /// One-second window of pipeline health, plus per-frame timing samples for
 /// the performance overlay graph.
@@ -68,6 +75,11 @@ final class PhoneReceiver: ObservableObject {
     private var formatDesc: CMVideoFormatDescription?
     private var sps: Data?
     private var pps: Data?
+    // HEVC adds a third parameter set (VPS) and encodes the NAL type in
+    // different bits. Set the first time a VPS is seen; H.264 streams never
+    // touch it, so both codecs work without a handshake.
+    private var vps: Data?
+    private var isHEVC = false
 
     // Liveness: the Mac streams video and pings every 2s; if nothing arrives
     // for 5s the connection is half-open (Mac killed, tunnel died) — drop it
@@ -109,7 +121,9 @@ final class PhoneReceiver: ObservableObject {
     // normalized [0,1] in video space; the sprite arrives as a PNG with its
     // hotspot anchor and size normalized against the Mac display.
     var onCursor: ((_ x: Double, _ y: Double, _ visible: Bool) -> Void)?
-    var onCursorImage: ((_ image: UIImage, _ anchor: CGPoint, _ normSize: CGSize) -> Void)?
+    // CGImage, not UIImage: it is what both consumers actually assign to
+    // CALayer.contents, and it keeps this type toolkit-neutral.
+    var onCursorImage: ((_ image: CGImage, _ anchor: CGPoint, _ normSize: CGSize) -> Void)?
 
     // Metal renderer path (experimental, "metalRenderer" setting): we decode
     // explicitly and hand BGRA buffers out; called on the receiver queue.
@@ -181,7 +195,7 @@ final class PhoneReceiver: ObservableObject {
     /// Update the advertised name and re-publish if already listening.
     func setServiceName(_ name: String) {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolved = trimmed.isEmpty ? UIDevice.current.name : trimmed
+        let resolved = trimmed.isEmpty ? ReceiverPlatform.defaultDeviceName : trimmed
         queue.async {
             guard resolved != self.serviceName else { return }
             self.serviceName = resolved
@@ -433,7 +447,8 @@ final class PhoneReceiver: ObservableObject {
         case "cursorImg":
             guard let b64 = obj["png"] as? String,
                   let png = Data(base64Encoded: b64),
-                  let image = UIImage(data: png),
+                  let src = CGImageSourceCreateWithData(png as CFData, nil),
+                  let image = CGImageSourceCreateImageAtIndex(src, 0, nil),
                   let nw = obj["nw"] as? Double, let nh = obj["nh"] as? Double else { return }
             let anchor = CGPoint(x: obj["ax"] as? Double ?? 0, y: obj["ay"] as? Double ?? 0)
             let normSize = CGSize(width: nw, height: nh)
@@ -447,7 +462,7 @@ final class PhoneReceiver: ObservableObject {
                 self.macProtocolVersion = macPV
             }
             if macPV < WireProtocol.minSupportedPeer {
-                let msg = "The OpenDisplay app on your Mac is too old for this \(deviceKind) app. Update OpenDisplay on your Mac to reconnect."
+                let msg = "The OpenDisplay app on your Mac is too old for this \(ReceiverPlatform.deviceKind) app. Update OpenDisplay on your Mac to reconnect."
                 DispatchQueue.main.async { self.peerSignal = .updateMac(message: msg) }
             }
         case WireMessage.updateRequired:
@@ -480,6 +495,8 @@ final class PhoneReceiver: ObservableObject {
         formatDesc = nil
         sps = nil
         pps = nil
+        vps = nil
+        isHEVC = false        // re-detected from the next stream's parameter sets
         lastFrameAt = nil
         frameIntervals.removeAll()
         decodeFlushes = 0
@@ -494,17 +511,28 @@ final class PhoneReceiver: ObservableObject {
 
     // MARK: - Control messages (phone -> Mac)
 
+    /// Largest frame this device can actually decode. Announced so the sender
+    /// can shrink the *encode* without shrinking the *desktop* — the two were
+    /// previously welded together, so asking for a big desktop on modest
+    /// hardware produced a stream it could not play. nil = declare no limit.
+    var maxEncodeWide: Int?
+    var maxEncodeHigh: Int?
+
     private func sendHello(on conn: NWConnection) {
-        sendControl([
+        var hello: [String: Any] = [
             "type": "hello",
             "pixelsWide": devicePixelsWide,
             "pixelsHigh": devicePixelsHigh,
             "scale": deviceScale,
-            "device": UIDevice.current.userInterfaceIdiom == .pad ? "iPad" : "iPhone",
+            "device": ReceiverPlatform.deviceKind,
             "id": Self.installID,
             "pv": WireProtocol.version,   // issue #132 — absent on old receivers
-        ], on: conn)
-        Log.info("hello sent")
+        ]
+        if let maxEncodeWide { hello["maxEncodeWide"] = maxEncodeWide }
+        if let maxEncodeHigh { hello["maxEncodeHigh"] = maxEncodeHigh }
+        sendControl(hello, on: conn)
+        Log.info("hello sent: \(devicePixelsWide)x\(devicePixelsHigh)"
+                 + (maxEncodeWide.map { ", max encode \($0)" } ?? ""))
     }
 
     /// Touch events: x/y normalized [0,1] in video space, origin top-left.
@@ -645,28 +673,100 @@ final class PhoneReceiver: ObservableObject {
         var vclNALUs: [Data] = []
         for nalu in nalus {
             guard let first = nalu.first else { continue }
-            switch first & 0x1F {
-            case 7:                                  // SPS (stream may change
-                if sps != nalu {                     //  size on rotation)
-                    sps = nalu
-                    formatDesc = nil
+
+            // Codec is detected from the stream rather than negotiated: an HEVC
+            // VPS has NAL type 32, which lands in the first byte as 0x40. In
+            // H.264 that byte decodes to type 0, which is unused — so seeing it
+            // is an unambiguous "this is HEVC" and needs no handshake.
+            if !isHEVC, first == 0x40 {
+                isHEVC = true
+                sps = nil; pps = nil; formatDesc = nil
+                Log.info("stream is HEVC — switching parser")
+            }
+
+            if isHEVC {
+                // HEVC packs the type in bits 1-6: (byte >> 1) & 0x3F.
+                let type = (first >> 1) & 0x3F
+                switch type {
+                case 32: if vps != nalu { vps = nalu; formatDesc = nil }   // VPS
+                case 33: if sps != nalu { sps = nalu; formatDesc = nil }   // SPS
+                case 34: if pps != nalu { pps = nalu; formatDesc = nil }   // PPS
+                default:
+                    // Only types 0-31 are VCL (actual picture slices). 35-40 are
+                    // AUD / EOS / EOB / filler / SEI, and HEVC emits an AUD before
+                    // each access unit where H.264 does not — feeding those to the
+                    // decoder as if they were slice data corrupts every frame,
+                    // which is why nothing rendered.
+                    if type < 32 { vclNALUs.append(nalu) }
                 }
-            case 8:                                  // PPS
-                if pps != nalu {
-                    pps = nalu
-                    formatDesc = nil
+            } else {
+                switch first & 0x1F {
+                case 7:                                  // SPS (stream may change
+                    if sps != nalu {                     //  size on rotation)
+                        sps = nalu
+                        formatDesc = nil
+                    }
+                case 8:                                  // PPS
+                    if pps != nalu {
+                        pps = nalu
+                        formatDesc = nil
+                    }
+                case 6: break                            // SEI — skip
+                default: vclNALUs.append(nalu)           // slice data
                 }
-            case 6: break                            // SEI — skip
-            default: vclNALUs.append(nalu)           // slice data
             }
         }
-        if formatDesc == nil, let sps, let pps {
-            displayLayer.flush()   // drop any frames from the previous format
-            buildFormatDescription(sps: sps, pps: pps)
+        if formatDesc == nil {
+            if isHEVC, let vps, let sps, let pps {
+                displayLayer.flush()
+                buildHEVCFormatDescription(vps: vps, sps: sps, pps: pps)
+            } else if !isHEVC, let sps, let pps {
+                displayLayer.flush()   // drop any frames from the previous format
+                buildFormatDescription(sps: sps, pps: pps)
+            }
         }
         guard !vclNALUs.isEmpty else { return }
         // All slices of one wire frame go into ONE sample buffer.
         enqueueFrame(vclNALUs, captureMs: captureMs, sendMs: sendMs)
+    }
+
+    /// HEVC needs all three parameter sets and its own constructor. Everything
+    /// downstream — the AVCC length-prefix repacking, the sample buffers, the
+    /// display layer and the decompression session — is codec-agnostic.
+    private func buildHEVCFormatDescription(vps: Data, sps: Data, pps: Data) {
+        let sets = [vps, sps, pps]
+        var buffers: [UnsafeMutablePointer<UInt8>] = []
+        defer { buffers.forEach { $0.deallocate() } }
+
+        var pointers: [UnsafePointer<UInt8>] = []
+        var sizes: [Int] = []
+        for set in sets {
+            let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: set.count)
+            set.copyBytes(to: buf, count: set.count)
+            buffers.append(buf)
+            pointers.append(UnsafePointer(buf))
+            sizes.append(set.count)
+        }
+
+        let status = CMVideoFormatDescriptionCreateFromHEVCParameterSets(
+            allocator: kCFAllocatorDefault,
+            parameterSetCount: 3,
+            parameterSetPointers: pointers,
+            parameterSetSizes: sizes,
+            nalUnitHeaderLength: 4,
+            extensions: nil,
+            formatDescriptionOut: &formatDesc
+        )
+        if status == noErr, let formatDesc {
+            let dims = CMVideoFormatDescriptionGetDimensions(formatDesc)
+            Log.info("HEVC format description built: \(dims.width)x\(dims.height)")
+            DispatchQueue.main.async {
+                self.videoSize = CGSize(width: Int(dims.width), height: Int(dims.height))
+            }
+            setStatus("Receiving \(dims.width)×\(dims.height)")
+        } else {
+            Log.info("HEVC format description FAILED: \(status)")
+        }
     }
 
     private func buildFormatDescription(sps: Data, pps: Data) {

--- a/tools/decode-probe.swift
+++ b/tools/decode-probe.swift
@@ -1,0 +1,107 @@
+// Hardware-decode capability probe. Run it on the RECEIVING Mac.
+//
+// Answers one question before any code gets written: can this machine decode
+// 5120x2880 in hardware, and in which codec? Everything else about "can we do
+// true 5K" follows from that.
+//
+// The parameter sets below are real SPS/PPS (and VPS for HEVC) captured from an
+// Apple-silicon encoder by tools/make-probe-headers.swift. They have to be real:
+// a format description built with CMVideoFormatDescriptionCreate and no
+// parameter sets fails session creation on EVERY Mac, including ones that decode
+// the format perfectly well — so it measures nothing at all.
+
+import Foundation
+import VideoToolbox
+import CoreMedia
+
+let headers: [(label: String, codec: CMVideoCodecType, sets: String)] = [
+    ("H.264  3840x2160  (4K)", kCMVideoCodecType_H264,
+     "J2QAM6xWUA8AEPk=|KO48sA=="),
+    ("H.264  5120x2880  (5K)", kCMVideoCodecType_H264,
+     "J2QAPKxSMAUABabAWoEBARhWve+AgA==|KP4Jyw=="),
+    ("HEVC   3840x2160  (4K)", kCMVideoCodecType_HEVC,
+     "QAEMAf//AWAAAAMAsAAAAwAAAwCZFcCQ|QgEBAWAAAAMAsAAAAwAAAwCZoAHgIAIcWIFe5FlR|RAHALL0U2Q=="),
+    ("HEVC   5120x2880  (5K)", kCMVideoCodecType_HEVC,
+     "QAEMAf//AWAAAAMAsAAAAwAAAwC0FcCQ|QgEBAWAAAAMAsAAAAwAAAwC0oACgCAC0FiBXuRZUQA==|RAHALL0U2Q=="),
+]
+
+func formatDescription(codec: CMVideoCodecType, sets: [Data]) -> CMVideoFormatDescription? {
+    var pointers: [UnsafePointer<UInt8>] = []
+    var sizes: [Int] = []
+    var keepAlive: [UnsafeMutablePointer<UInt8>] = []
+    defer { keepAlive.forEach { $0.deallocate() } }
+
+    for set in sets {
+        let buf = UnsafeMutablePointer<UInt8>.allocate(capacity: set.count)
+        set.copyBytes(to: buf, count: set.count)
+        keepAlive.append(buf)
+        pointers.append(UnsafePointer(buf))
+        sizes.append(set.count)
+    }
+
+    var format: CMVideoFormatDescription?
+    let status = codec == kCMVideoCodecType_HEVC
+        ? CMVideoFormatDescriptionCreateFromHEVCParameterSets(
+            allocator: kCFAllocatorDefault, parameterSetCount: pointers.count,
+            parameterSetPointers: pointers, parameterSetSizes: sizes,
+            nalUnitHeaderLength: 4, extensions: nil, formatDescriptionOut: &format)
+        : CMVideoFormatDescriptionCreateFromH264ParameterSets(
+            allocator: kCFAllocatorDefault, parameterSetCount: pointers.count,
+            parameterSetPointers: pointers, parameterSetSizes: sizes,
+            nalUnitHeaderLength: 4, formatDescriptionOut: &format)
+    return status == noErr ? format : nil
+}
+
+/// True when VideoToolbox will build a decoder that is REQUIRED to be hardware.
+/// Failure here is the signal we want: it means this silicon cannot do it.
+func hardwareDecodes(_ format: CMVideoFormatDescription) -> Bool {
+    let spec: [CFString: Any] = [
+        kVTVideoDecoderSpecification_RequireHardwareAcceleratedVideoDecoder: true
+    ]
+    var session: VTDecompressionSession?
+    let status = VTDecompressionSessionCreate(
+        allocator: kCFAllocatorDefault, formatDescription: format,
+        decoderSpecification: spec as CFDictionary, imageBufferAttributes: nil,
+        outputCallback: nil, decompressionSessionOut: &session)
+    if let session { VTDecompressionSessionInvalidate(session) }
+    return status == noErr
+}
+
+/// Identify the machine in the output. Without this it is impossible to tell a
+/// result pasted from the sending Mac apart from one produced on the receiver —
+/// and they answer very different questions.
+func sysctlString(_ name: String) -> String {
+    var size = 0
+    sysctlbyname(name, nil, &size, nil, 0)
+    guard size > 0 else { return "unknown" }
+    var buf = [CChar](repeating: 0, count: size)
+    sysctlbyname(name, &buf, &size, nil, 0)
+    return String(cString: buf)
+}
+
+print("")
+print("MACHINE: \(Host.current().localizedName ?? "?")")
+print("MODEL:   \(sysctlString("hw.model"))")
+print("CPU:     \(sysctlString("machdep.cpu.brand_string"))")
+print("")
+print("Hardware decode support on this Mac")
+print("===================================")
+
+var hevc5kWorks = false
+for entry in headers {
+    let sets = entry.sets.split(separator: "|").compactMap { Data(base64Encoded: String($0)) }
+    guard let format = formatDescription(codec: entry.codec, sets: sets) else {
+        print("  \(entry.label)   could not build format description")
+        continue
+    }
+    let dims = CMVideoFormatDescriptionGetDimensions(format)
+    let ok = hardwareDecodes(format)
+    print("  \(entry.label)   \(ok ? "OK" : "NOT SUPPORTED")   [\(dims.width)x\(dims.height)]")
+    if ok, entry.codec == kCMVideoCodecType_HEVC, dims.width == 5120 { hevc5kWorks = true }
+}
+
+print("===================================")
+print(hevc5kWorks
+      ? "HEVC 5K decodes -> true 5K is worth implementing."
+      : "No 5K path on this machine -> 4K is the ceiling. Stop here.")
+print("")

--- a/tools/fake-receiver.swift
+++ b/tools/fake-receiver.swift
@@ -7,6 +7,12 @@ import Network
 let port: UInt16 = 9000
 let listener = try! NWListener(using: .tcp, on: NWEndpoint.Port(rawValue: port)!)
 
+// Advertise over Bonjour so the Mac sender discovers us the same way a real
+// receiver is discovered. Without this the sender has nothing to dial.
+listener.service = NWListener.Service(name: "Fake 5K Receiver",
+                                      type: "_opensidecar._tcp",
+                                      txtRecord: NWTXTRecord(["id": "FAKE-3", "pv": "3"]))
+
 func frame(_ json: String) -> Data {
     let payload = Data(json.utf8)
     var header = UInt32(payload.count).bigEndian
@@ -18,25 +24,49 @@ func frame(_ json: String) -> Data {
 // Pass "rotate" as arg 1 to announce a portrait re-hello 20s after connect
 // (and back to landscape at 45s) — simulates device rotation for testing
 // the Mac's rebuild path without physical hardware.
-let simulateRotation = CommandLine.arguments.dropFirst().first == "rotate"
+let args = Array(CommandLine.arguments.dropFirst())
+let simulateRotation = args.first == "rotate"
+
+// Pass "--hello WxH" to announce a different panel size, e.g. an iMac 27" 5K:
+//     swift tools/fake-receiver.swift --hello 5120x2880
+// The sender derives desktop points as pixels/2 and encodes at points*2*quality,
+// so this is the lever that decides whether VTCompressionSessionCreate survives.
+var helloW = 2732, helloH = 2048, helloDevice = "iPad"
+if let i = args.firstIndex(of: "--hello"), i + 1 < args.count {
+    let parts = args[i + 1].lowercased().split(separator: "x")
+    if parts.count == 2, let w = Int(parts[0]), let h = Int(parts[1]) {
+        helloW = w; helloH = h; helloDevice = "Mac"
+    } else {
+        print("bad --hello value '\(args[i + 1])' — expected WxH, e.g. 5120x2880")
+        exit(1)
+    }
+}
+
+func helloJSON(_ w: Int, _ h: Int) -> String {
+    "{\"type\":\"hello\",\"pixelsWide\":\(w),\"pixelsHigh\":\(h),\"scale\":2,"
+    + "\"device\":\"\(helloDevice)\",\"id\":\"FAKE-3\",\"pv\":3}"
+}
+
+print("announcing \(helloW)x\(helloH) as \"\(helloDevice)\" "
+      + "-> expect a \(helloW / 2)x\(helloH / 2) point desktop")
 
 listener.newConnectionHandler = { conn in
     print("connection from \(conn.endpoint)")
     var frames = 0, bytes = 0
     var windowStart = Date()
     conn.start(queue: .global())
-    // iPad Pro 12.9" panel: 2732x2048 @2x
-    conn.send(content: frame("{\"type\":\"hello\",\"pixelsWide\":2732,\"pixelsHigh\":2048,\"scale\":2,\"device\":\"iPad\",\"id\":\"FAKE-3\"}"),
+    // Default is an iPad Pro 12.9" panel (2732x2048 @2x); --hello overrides it.
+    conn.send(content: frame(helloJSON(helloW, helloH)),
               completion: .contentProcessed { _ in })
     if simulateRotation {
         DispatchQueue.global().asyncAfter(deadline: .now() + 20) {
             print("simulating rotation -> portrait")
-            conn.send(content: frame("{\"type\":\"hello\",\"pixelsWide\":2048,\"pixelsHigh\":2732,\"scale\":2,\"device\":\"iPad\",\"id\":\"FAKE-3\"}"),
+            conn.send(content: frame(helloJSON(helloH, helloW)),
                       completion: .contentProcessed { _ in })
         }
         DispatchQueue.global().asyncAfter(deadline: .now() + 45) {
             print("simulating rotation -> landscape")
-            conn.send(content: frame("{\"type\":\"hello\",\"pixelsWide\":2732,\"pixelsHigh\":2048,\"scale\":2,\"device\":\"iPad\",\"id\":\"FAKE-3\"}"),
+            conn.send(content: frame(helloJSON(helloW, helloH)),
                       completion: .contentProcessed { _ in })
         }
     }

--- a/tools/make-probe-headers.swift
+++ b/tools/make-probe-headers.swift
@@ -1,0 +1,98 @@
+// Generates real H.264/HEVC parameter sets (SPS/PPS, and VPS for HEVC) by
+// encoding one frame at each target size, and prints them as base64.
+//
+// Why: a decode-capability probe needs a VALID format description. Building one
+// with CMVideoFormatDescriptionCreate and no parameter sets fails session
+// creation on every Mac, including ones that decode the format fine — so it
+// measures nothing. These headers get embedded in decode-probe.swift, which can
+// then run on a machine that cannot ENCODE the size it is asked to DECODE.
+//
+// Run on a Mac that can encode 5K (Apple silicon).
+
+import Foundation
+import VideoToolbox
+import CoreMedia
+
+func parameterSets(codec: CMVideoCodecType, width: Int32, height: Int32) -> [Data]? {
+    var session: VTCompressionSession?
+    guard VTCompressionSessionCreate(allocator: kCFAllocatorDefault,
+                                     width: width, height: height,
+                                     codecType: codec,
+                                     encoderSpecification: nil,
+                                     imageBufferAttributes: nil,
+                                     compressedDataAllocator: nil,
+                                     outputCallback: nil, refcon: nil,
+                                     compressionSessionOut: &session) == noErr,
+          let session else { return nil }
+    defer { VTCompressionSessionInvalidate(session) }
+
+    VTSessionSetProperty(session, key: kVTCompressionPropertyKey_RealTime, value: kCFBooleanTrue)
+
+    var pixelBuffer: CVPixelBuffer?
+    CVPixelBufferCreate(kCFAllocatorDefault, Int(width), Int(height),
+                        kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange, nil, &pixelBuffer)
+    guard let pixelBuffer else { return nil }
+
+    var result: [Data]?
+    let sem = DispatchSemaphore(value: 0)
+    VTCompressionSessionEncodeFrame(
+        session, imageBuffer: pixelBuffer,
+        presentationTimeStamp: CMTime(value: 0, timescale: 30),
+        duration: .invalid, frameProperties: nil, infoFlagsOut: nil
+    ) { status, _, sample in
+        defer { sem.signal() }
+        guard status == noErr, let sample,
+              let format = CMSampleBufferGetFormatDescription(sample) else { return }
+
+        // HEVC has its own accessor (3 sets: VPS, SPS, PPS); the H264 one
+        // returns an error for HEVC format descriptions rather than serving them.
+        let isHEVC = (codec == kCMVideoCodecType_HEVC)
+        var count = 0
+        let countStatus = isHEVC
+            ? CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
+                format, parameterSetIndex: 0, parameterSetPointerOut: nil,
+                parameterSetSizeOut: nil, parameterSetCountOut: &count,
+                nalUnitHeaderLengthOut: nil)
+            : CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+                format, parameterSetIndex: 0, parameterSetPointerOut: nil,
+                parameterSetSizeOut: nil, parameterSetCountOut: &count,
+                nalUnitHeaderLengthOut: nil)
+        guard countStatus == noErr, count > 0 else { return }
+
+        var sets: [Data] = []
+        for i in 0..<count {
+            var ptr: UnsafePointer<UInt8>?
+            var size = 0
+            let st = isHEVC
+                ? CMVideoFormatDescriptionGetHEVCParameterSetAtIndex(
+                    format, parameterSetIndex: i, parameterSetPointerOut: &ptr,
+                    parameterSetSizeOut: &size, parameterSetCountOut: nil,
+                    nalUnitHeaderLengthOut: nil)
+                : CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+                    format, parameterSetIndex: i, parameterSetPointerOut: &ptr,
+                    parameterSetSizeOut: &size, parameterSetCountOut: nil,
+                    nalUnitHeaderLengthOut: nil)
+            if st == noErr, let ptr { sets.append(Data(bytes: ptr, count: size)) }
+        }
+        result = sets.isEmpty ? nil : sets
+    }
+    VTCompressionSessionCompleteFrames(session, untilPresentationTimeStamp: .invalid)
+    _ = sem.wait(timeout: .now() + 10)
+    return result
+}
+
+let targets: [(String, CMVideoCodecType, Int32, Int32)] = [
+    ("h264_3840x2160", kCMVideoCodecType_H264, 3840, 2160),
+    ("h264_5120x2880", kCMVideoCodecType_H264, 5120, 2880),
+    ("hevc_3840x2160", kCMVideoCodecType_HEVC, 3840, 2160),
+    ("hevc_5120x2880", kCMVideoCodecType_HEVC, 5120, 2880),
+]
+
+for (name, codec, w, h) in targets {
+    if let sets = parameterSets(codec: codec, width: w, height: h) {
+        let joined = sets.map { $0.base64EncodedString() }.joined(separator: "|")
+        print("\"\(name)\": \"\(joined)\",")
+    } else {
+        print("// \(name): ENCODE FAILED on this Mac")
+    }
+}


### PR DESCRIPTION
> Supersedes #252 — auto-closed when I renamed the source branch. Same content.

## Tested and validated

| | |
|---|---|
| **Resolution** | **5120 × 2880 — 14.7 MP, 1:1 pixels** |
| **Desktop** | 2560 × 1440 @2x |
| **Codec** | HEVC Main, 30 Mbit/s |
| **Latency** | 54 ms median, 62 ms p95 |
| **Round trip** | 5–6 ms |
| **Machine** | i5-7600, Radeon Pro 575, **Ventura 13.7.8**, **Wi-Fi** |

Sender was a MacBook Pro M4 Pro on macOS 26. Every codec and resolution limit
quoted below was established by **end-to-end playback on this hardware**, not from
spec sheets. Full setup and usage notes: [`MacReceiver/README.md`](MacReceiver/README.md).

---

## What this adds

A **macOS receiver**, so a Mac can be a second display for another Mac — not just an iPad or iPhone.

The machine this was built for is an **iMac 27" 2017 (Retina 5K)**. It has no other way to do this: Target Display Mode was removed after 2014, Apple capped it at macOS 13 Ventura (so it can't run the sender), and AirPlay-to-Mac needs a 2019+ iMac.

It now runs a **5120×2880 HEVC** stream on its 5120×2880 panel — 1:1 pixels, no scaling, ~50 ms end to end over Wi-Fi.

## Four bugs fixed

Three of these affect existing users, not just the new target.

**1. Mirror captured at half resolution** — `MacSender.swift`
`SCDisplay.width/height` report **points**, not pixels. On a Retina Mac that meant sending 1728×1116 from a screen macOS actually renders at 3456×2232. Half the detail was discarded before the frame ever left the sender, and no quality setting could recover it. Now reads `CGDisplayMode.pixelWidth/Height`.

**2. Desktop size was welded to stream size**
`points = announced pixels / 2`, and `encode = points × 2 × quality.scale`, so asking for a large desktop forced a proportionally large stream. A receiver that wants a big desktop but has a modest decoder had no way to say so. Added an additive **`hello.maxEncodeWide` / `maxEncodeHigh`** — PROTOCOL.md §6 makes unknown fields ignorable, so no `pv` bump is needed and older peers are unaffected.

**3. HEVC was emitted with no parameter sets at all**
`annexB()` looped `0..<2` using `CMVideoFormatDescriptionGetH264ParameterSetAtIndex`. HEVC carries **three** sets (VPS/SPS/PPS) and needs its own accessor — the H.264 one returns an error for an HEVC format description. The stream went out with no headers, so no decoder could ever start. This is what made 5K look like a hardware limit when it wasn't.

**4. Receiver treated every non-parameter NAL as picture data**
HEVC emits an access-unit delimiter (type 35) that H.264 does not. Feeding it to the decoder as slice data corrupts every frame. Only types 0–31 are VCL.

## New files

- **`MacReceiver/`** — the receiver app. AppKit, universal, deployment target 13.0. Reuses `iOS/PhoneReceiver.swift` and `iOS/MetalVideoRenderer.swift` **unchanged and in place**; the only new abstraction is `Receiver/Platform.swift`, the single file that branches on toolkit.
- **`MacSenderShim/`** — builds the sender with `swiftc` and no Xcode. Developed on a managed Mac with no admin rights, where the Xcode licence can never be accepted and `xcodebuild`/`xcodegen` are therefore unusable. `DEVELOPER_DIR` points at the Command Line Tools; Sparkle is stubbed behind `#if !canImport(Sparkle)`.
- **`tools/decode-probe.swift`** — reports which codec/size pairs a machine can actually hardware-decode, using **real captured parameter sets**. Worth noting: a format description built via `CMVideoFormatDescriptionCreate` with no parameter sets fails session creation on *every* Mac, so a probe written that way measures nothing. Mine did, at first.

## Measured, not assumed

- **H.264 hardware decode stops below 5120 wide on every Mac tested, including an M4 Pro.** A format ceiling, not an age one — 4K is H.264's practical limit here.
- **HEVC handles the full 5120×2880** on a 2017 iMac (Kaby Lake + Radeon Pro 575).
- `VTDecompressionSessionCreate` succeeding proves nothing on its own — it builds sessions the hardware cannot sustain. Only end-to-end playback is a valid test.

## Render path

Manually created `CALayer`s default to `contentsScale = 1.0` and do not inherit the window's backing factor the way iOS layers do. Left at 1 on a Retina panel the video is rasterised at point resolution and then stretched, which presents as *"sharp in a small window, blurry at full screen"*. Now set from `viewDidMoveToWindow` as well as `viewDidChangeBackingProperties`, with a screen-derived fallback, and logged.

The Metal renderer is also wired up on macOS with a tunable unsharp mask, for the case where the stream is smaller than the panel. At true 5K it is best left at `0`.

## Deliberately out of scope

**No input forwarding.** macOS Universal Control already shares keyboard and mouse between two Macs over Apple's own encrypted channel. Given PROTOCOL.md §1 ("no TLS and no authentication at `pv` 3"), keeping keystrokes off this wire seemed better than adding them.

## Notes for review

- `project.yml` is untouched — `MacReceiver/build.sh` lists sources directly, since `xcodegen` was not usable here. Adding a proper target would be a reasonable follow-up for anyone who has Xcode.
- The iOS app compiles against the shim changes but **could not be built or run** on this machine, for the same reason. The diff to `iOS/PhoneReceiver.swift` is small and mechanical (`UIImage` → `CGImage` in one closure signature, `UIDevice` → `ReceiverPlatform`), but it wants a real iOS build before merging.
- Sender settings used here: `hevc=YES`, `bitrateMbps=30`, `quality=best`, `pixfmt=bgra`. **30 Mbit/s is a ceiling** on this hardware — at 45 the receiver cannot sustain 5K decode over Wi-Fi and the watchdog walks the announced size down, which looks like "the UI got big" rather than an error.


