### PR TITLE
feat(mac): full-pixel mirror capture and a receiver decode ceiling

### DIFF
--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -77,6 +77,8 @@ struct PhoneInfo: Decodable {
                           // 6.3); absent = cursor stays on TCP
     let addrs: [String]?  // every address the receiver is reachable on
                           // (PROTOCOL.md 6.4); probed for a cable upgrade
+    let maxEncodeWide: Int?  // receiver's decode ceiling in pixels (PROTOCOL.md
+    let maxEncodeHigh: Int?  //  6.5): cap the stream, keep the desktop size
 
     var kind: String { device ?? "device" }
     var protocolVersion: Int { pv ?? WireProtocol.assumedWhenAbsent }
@@ -382,9 +384,15 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 throw NSError(domain: "MacSender", code: 1,
                               userInfo: [NSLocalizedDescriptionKey: "no displays found"])
             }
-            // SCDisplay reports points; capture at point resolution for M1.
-            let captureW = (Int(Double(display.width) * quality.scale)) & ~1
-            let captureH = (Int(Double(display.height) * quality.scale)) & ~1
+            // SCDisplay.width/height are POINTS. Capturing at points on a
+            // Retina panel discards half the raster before the encoder ever
+            // sees it, and no quality setting can bring it back — read the
+            // true pixel size from the active display mode.
+            let displayMode = CGDisplayCopyDisplayMode(display.displayID)
+            let pixelsW = displayMode?.pixelWidth ?? display.width
+            let pixelsH = displayMode?.pixelHeight ?? display.height
+            let captureW = (Int(Double(pixelsW) * quality.scale)) & ~1
+            let captureH = (Int(Double(pixelsH) * quality.scale)) & ~1
             try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
 
         case .extend:
@@ -539,8 +547,19 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         inputInjector = InputInjector(displayID: vd.displayID)
         // Quality scaling: capture/encode below native when requested — the
         // display itself stays native so window layout is unaffected.
-        let captureW = (Int(Double(pointsWide * 2) * quality.scale)) & ~1
-        let captureH = (Int(Double(pointsHigh * 2) * quality.scale)) & ~1
+        var captureW = (Int(Double(pointsWide * 2) * quality.scale)) & ~1
+        var captureH = (Int(Double(pointsHigh * 2) * quality.scale)) & ~1
+        // hello.maxEncodeWide/High (PROTOCOL.md 6.5): a big panel does not
+        // imply a big decoder. Cap the stream at the receiver's advertised
+        // decode ceiling — SCK scales the capture — while the desktop keeps
+        // its announced size.
+        if let maxW = info.maxEncodeWide, let maxH = info.maxEncodeHigh,
+           maxW > 0, maxH > 0, captureW > maxW || captureH > maxH {
+            let s = min(Double(maxW) / Double(captureW), Double(maxH) / Double(captureH))
+            captureW = (Int(Double(captureW) * s)) & ~1
+            captureH = (Int(Double(captureH) * s)) & ~1
+            Log.info("stream capped at \(captureW)x\(captureH) by the receiver's decode ceiling \(maxW)x\(maxH)")
+        }
         try await startCapture(display: display, pixelsWide: captureW, pixelsHigh: captureH)
 
         // Debug aid (`defaults write sh.peet.opensidecar.mac testPattern -bool true`):

--- a/MacReceiver/MacReceiver.swift
+++ b/MacReceiver/MacReceiver.swift
@@ -40,9 +40,15 @@ final class ReceiverController: ObservableObject {
 
     func start() {
         guard receiver == nil else { return }
+        // 4096x2304 is H.264's practical hardware-decode ceiling: end-to-end
+        // playback stops below 5120 wide on every Mac measured, including an
+        // M4 Pro — a format limit, not an age one. A 5K/6K panel still gets
+        // its full desktop; the stream is capped and upscaled. Revisit when
+        // an HEVC path lands (HEVC decodes 5K fine even on a 2017 iMac).
         let receiver = StreamReceiver(displayLayer: AVSampleBufferDisplayLayer(),
                                       deviceKind: "Mac",
-                                      fallbackServiceName: fallbackName)
+                                      fallbackServiceName: fallbackName,
+                                      maxEncodeWide: 4096, maxEncodeHigh: 2304)
         let saved = UserDefaults.standard.string(forKey: "receiverName")
         receiver.serviceName = (saved?.isEmpty == false) ? saved! : fallbackName
         announcePanel(to: receiver)

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -283,6 +283,9 @@ nothing before it arrives.
   The receiver SHOULD re-send `hello` when this set changes (a cable
   plugged mid-session creates the interface the sender must probe).
   Additive at `pv` 3, no bump.
+* `maxEncodeWide` / `maxEncodeHigh` (int, optional): the receiver's decode
+  ceiling in pixels (section 6.5) — the largest stream it can sustain,
+  independent of the panel size it announced. Additive at `pv` 3, no bump.
 
 A receiver MUST re-send `hello` on the live connection whenever its
 announced dimensions change (rotation). The sender rebuilds the display in
@@ -479,6 +482,27 @@ block its own UI. At `pv` 3 this is only sent when
 `hello.pv < welcome.min`, which never happens while `min` is 1; the
 machinery exists so a future floor raise degrades into a clear message
 instead of a silent failure.
+
+### 6.5 Decode ceiling (`hello.maxEncodeWide` / `maxEncodeHigh`)
+
+`hello.pixelsWide/High` sets the desktop size, and without further
+information it also sets the stream size — but a big panel says nothing
+about the decoder behind it. Measured end to end, H.264 hardware decode
+stops below 5120 pixels wide on every Mac tested, current models
+included: a 5K panel asking for a 5K H.264 stream gets a session the
+receiver cannot sustain, which degrades confusingly instead of failing
+cleanly.
+
+Both fields are optional and additive (no `pv` bump). A receiver MAY
+advertise the largest stream, in pixels, it can actually decode at
+frame rate; a sender that understands the fields SHOULD keep the
+desktop at the announced panel size and, when the stream it would
+encode exceeds the ceiling, scale the stream down to fit inside it,
+preserving aspect. A ceiling the stream already fits inside changes
+nothing, and a receiver that omits the fields gets the previous
+behavior (stream size follows the announced pixels and the sender's
+quality setting). Derive advertised ceilings from measured playback: a
+decode session that merely creates successfully proves nothing.
 
 ## 7. Coordinate spaces and units
 

--- a/Shared/StreamReceiver.swift
+++ b/Shared/StreamReceiver.swift
@@ -220,6 +220,11 @@ final class StreamReceiver: ObservableObject {
     /// "iPhone" / "iPad" / "Mac" — announced in the hello (the sender names
     /// the virtual display after it) and used in peer-update copy.
     private let deviceKind: String
+    // Decode ceiling advertised in hello (PROTOCOL.md 6.5): the largest
+    // stream this machine can actually sustain, which a big panel says
+    // nothing about. nil = advertise nothing (sender streams full size).
+    private let maxEncodeWide: Int?
+    private let maxEncodeHigh: Int?
     /// What to advertise when the user-set service name is empty.
     private let fallbackServiceName: String
 
@@ -290,10 +295,13 @@ final class StreamReceiver: ObservableObject {
     }
 
     init(displayLayer: AVSampleBufferDisplayLayer, deviceKind: String,
-         fallbackServiceName: String) {
+         fallbackServiceName: String,
+         maxEncodeWide: Int? = nil, maxEncodeHigh: Int? = nil) {
         self.displayLayer = displayLayer
         self.deviceKind = deviceKind
         self.fallbackServiceName = fallbackServiceName
+        self.maxEncodeWide = maxEncodeWide
+        self.maxEncodeHigh = maxEncodeHigh
         displayLayer.videoGravity = .resizeAspect
     }
 
@@ -832,6 +840,12 @@ final class StreamReceiver: ObservableObject {
         // Additive capability: only offered while the UDP listener is bound,
         // so a sender never dials a port nobody answers on.
         if cursorListenerReady { hello["cursorPort"] = Int(cursorPort) }
+        // Additive: decode ceiling (PROTOCOL.md 6.5) — ask for the full
+        // desktop but a stream no larger than this machine can decode.
+        if let maxEncodeWide, let maxEncodeHigh {
+            hello["maxEncodeWide"] = maxEncodeWide
+            hello["maxEncodeHigh"] = maxEncodeHigh
+        }
         // Additive: the addresses this receiver can be reached on, so the
         // sender can probe for a better (cabled) path and migrate a WiFi
         // session onto it — mDNS resolution under an interface-restricted


### PR DESCRIPTION
Lifts the two sender-side fixes from https://github.com/peetzweg/opendisplay/pull/253 onto the shipped shared-core receiver, with credit to @Venelinhr for the diagnosis and the hardware measurements.

**Why:** mirror mode captured at point resolution, so Retina senders threw away half the raster before encoding. And stream size was welded to the announced panel size, so a 5K receiver forced a 5K H.264 stream that no Mac can hardware-decode (measured end to end in PR 253: the cutoff is below 5120 wide even on an M4 Pro).

**How:** mirror capture now reads CGDisplayMode.pixelWidth/Height. New additive hello fields maxEncodeWide/High (PROTOCOL.md 6.5, no pv bump) let a receiver cap the stream while keeping the full desktop; the sender scales the capture to fit. Judgment call: the Mac receiver advertises a fixed 4096x2304 ceiling (H.264's measured practical limit) rather than probing per machine; revisit when HEVC lands and the ceiling stops mattering.

Old receivers omit the fields and get exactly the previous behavior. Mirror at full pixels roughly quadruples encode area on Retina senders, which the encoder already handles for extend sessions at the same sizes.