### PR TITLE
feat(audio): forward Mac audio to the device over a typed frame header (#12)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -163,11 +163,21 @@ the floor once a force-capable build has spread.
 - **Silent breaking changes.** Never change framing or field semantics without
   the two-phase dance — the failure mode is an invisible reconnect loop, not a
   message.
-- **Control frames ≥ 32 KB or containing a NUL byte on the video channel.** The
-  phone disambiguates JSON control vs. H.264 frames heuristically (`< 32 KB,
-  starts with '{', no NUL`). A large or binary control message would be fed to
-  the video decoder. A typed frame header is a future protocol item, unlocked
-  only because this handshake exists.
+- **Control frames ≥ 32 KB or containing a NUL byte on the video channel, when
+  talking to a `pv <= 3` peer.** Those peers disambiguate JSON control vs. H.264
+  frames heuristically (`< 32 KB, starts with '{', no NUL`), so a large or
+  binary control message would be fed to the video decoder. `pv` 4 replaces the
+  heuristic with a typed frame header (PROTOCOL.md 4.1) — the change this
+  handshake existed to unlock — and lifts the constraint for tagged frames only.
+  Phase one: the heuristic is still spoken to every peer below 4, so the limit
+  remains real for as long as those peers are supported.
+- **Tagging a frame before the peer's `pv` is known.** `hello` and `welcome`
+  carry the versions, so they necessarily precede knowing them and must go out
+  untagged; the switch happens only after reading the peer's version, and resets
+  per connection because a reconnect may be a different device. Getting this
+  ordering wrong fails in the least visible way available — it can work on the
+  first connection and break on the reconnect, or work only when the handshake
+  arrives in a single TCP segment.
 - **Forcing the pre-handshake tail via the app.** Installs older than the first
   force-capable build have no lever — they are reachable only by the Mac's
   in-session `updateRequired` (if they connect to a new-enough Mac) or they

--- a/Mac/AudioEncoder.swift
+++ b/Mac/AudioEncoder.swift
@@ -56,9 +56,74 @@ final class AudioEncoder {
         self.sourceFormat = format
         self.outputFormat = output
         self.configData = converter.outputFormat.magicCookie
+        self.pending = nil
         self.needsConfigFlag = true
         Log.info("audio: encoding \(Int(format.sampleRate))Hz \(format.channelCount)ch AAC-LC @ \(Self.bitRate / 1000)kbps")
         return true
+    }
+
+    /// AAC-LC's fixed frame size. The converter needs this many samples per
+    /// channel before it can emit a real packet.
+    private static let framesPerPacket: AVAudioFrameCount = 1024
+
+    /// Samples carried over from previous chunks, waiting to complete a frame.
+    private var pending: AVAudioPCMBuffer?
+
+    /// Stage `pcm` and return exactly one AAC frame's worth of samples once
+    /// enough have accumulated, or nil while still short.
+    ///
+    /// Any remainder past the frame boundary is kept for the next call, so no
+    /// audio is dropped at chunk edges — a gap there would be an audible click.
+    private func append(_ pcm: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        let format = pcm.format
+        let carried = pending?.frameLength ?? 0
+        let total = carried + pcm.frameLength
+
+        guard let combined = AVAudioPCMBuffer(pcmFormat: format,
+                                              frameCapacity: total) else { return nil }
+        combined.frameLength = total
+        if let pending, carried > 0 { copy(pending, into: combined, at: 0, count: carried) }
+        copy(pcm, into: combined, at: carried, count: pcm.frameLength)
+
+        guard total >= Self.framesPerPacket else {
+            pending = combined          // still short — carry it all forward
+            return nil
+        }
+
+        guard let frame = AVAudioPCMBuffer(pcmFormat: format,
+                                           frameCapacity: Self.framesPerPacket) else { return nil }
+        frame.frameLength = Self.framesPerPacket
+        copy(combined, into: frame, at: 0, count: Self.framesPerPacket, sourceOffset: 0)
+
+        let leftover = total - Self.framesPerPacket
+        if leftover > 0, let rest = AVAudioPCMBuffer(pcmFormat: format,
+                                                     frameCapacity: leftover) {
+            rest.frameLength = leftover
+            copy(combined, into: rest, at: 0, count: leftover,
+                 sourceOffset: Self.framesPerPacket)
+            pending = rest
+        } else {
+            pending = nil
+        }
+        return frame
+    }
+
+    /// Copy `count` frames between buffers of the same format.
+    ///
+    /// Handles both interleaved and deinterleaved layouts: ScreenCaptureKit
+    /// hands over deinterleaved float, where each channel lives in its own
+    /// buffer, so copying only channel 0 would silently drop the right channel.
+    private func copy(_ source: AVAudioPCMBuffer, into destination: AVAudioPCMBuffer,
+                      at destinationOffset: AVAudioFrameCount, count: AVAudioFrameCount,
+                      sourceOffset: AVAudioFrameCount = 0) {
+        guard let src = source.floatChannelData, let dst = destination.floatChannelData else { return }
+        let channels = Int(source.format.channelCount)
+        let stride = source.stride            // 1 when deinterleaved
+        for channel in 0..<channels {
+            let from = src[channel].advanced(by: Int(sourceOffset) * stride)
+            let to = dst[channel].advanced(by: Int(destinationOffset) * stride)
+            to.update(from: from, count: Int(count) * stride)
+        }
     }
 
     /// One encoded packet, or nil when this buffer produced no output.
@@ -80,6 +145,15 @@ final class AudioEncoder {
             packetCapacity: 1,
             maximumPacketSize: converter.maximumOutputPacketSize)
 
+        // Accumulate until a full AAC frame's worth of samples is available.
+        //
+        // ScreenCaptureKit delivers audio in whatever chunk size it likes, and
+        // AAC-LC is framed in fixed 1024-sample blocks. Handing the converter a
+        // short chunk makes it emit a stub packet a few bytes long instead of
+        // nothing, and those went out as undecodable 6-byte payloads. Feeding
+        // it only whole frames is what makes the output real AAC.
+        guard let staged = append(pcm) else { return nil }
+
         var supplied = false
         var conversionError: NSError?
         let status = converter.convert(to: out, error: &conversionError) { _, outStatus in
@@ -92,7 +166,7 @@ final class AudioEncoder {
             }
             supplied = true
             outStatus.pointee = .haveData
-            return pcm
+            return staged
         }
 
         switch status {
@@ -107,7 +181,12 @@ final class AudioEncoder {
             return nil
         }
 
-        guard out.byteLength > 0 else { return nil }
+        // A real AAC-LC frame at 128 kbps is a few hundred bytes. Anything tiny
+        // is the converter emitting a stub because it did not have a full 1024
+        // samples to work with — sending those produced a stream of 6-byte
+        // payloads that failed to decode on every single packet. Drop them
+        // rather than putting undecodable audio on the wire.
+        guard out.byteLength >= 16 else { return nil }
         let data = Data(bytes: out.data, count: Int(out.byteLength))
 
         // Flag the config on the first packet after a (re)configuration so a
@@ -119,6 +198,7 @@ final class AudioEncoder {
 
     func reset() {
         converter?.reset()
+        pending = nil   // stale samples would click on reconnect
         needsConfigFlag = true
     }
 }

--- a/Mac/AudioEncoder.swift
+++ b/Mac/AudioEncoder.swift
@@ -1,0 +1,124 @@
+import AVFoundation
+import Foundation
+
+/// PCM → AAC-LC for the audio channel, kept out of MacSender so the sender
+/// stays about streaming and this stays about codecs.
+///
+/// ScreenCaptureKit hands us system audio as PCM; this converts it to AAC-LC
+/// at a fixed bitrate. Audio is ~1% of video's bandwidth, so there is nothing
+/// to gain from adapting it to the quality setting the way the video encoder
+/// does — a fixed rate is one less thing to get wrong.
+final class AudioEncoder {
+
+    /// AAC-LC, 128 kbps stereo. Comfortably transparent for desktop audio and
+    /// hardware-decodable on every receiver we target.
+    private static let bitRate = 128_000
+
+    private var converter: AVAudioConverter?
+    private var sourceFormat: AVAudioFormat?
+    private var outputFormat: AVAudioFormat?
+    /// AAC's AudioSpecificConfig (the "magic cookie"). The decoder cannot start
+    /// without it, and a receiver may connect mid-stream, so it is re-sent
+    /// whenever the format changes rather than once at startup.
+    private(set) var configData: Data?
+    private var needsConfigFlag = true
+
+    var sampleRate: Int { Int(outputFormat?.sampleRate ?? 0) }
+    var channels: Int { Int(outputFormat?.channelCount ?? 0) }
+
+    /// Build (or rebuild) the converter for `format`. Returns false if the
+    /// format cannot be encoded, in which case the caller drops audio rather
+    /// than sending something no receiver can read.
+    @discardableResult
+    func prepare(for format: AVAudioFormat) -> Bool {
+        if let sourceFormat, sourceFormat == format, converter != nil { return true }
+
+        var description = AudioStreamBasicDescription(
+            mSampleRate: format.sampleRate,
+            mFormatID: kAudioFormatMPEG4AAC,
+            mFormatFlags: 0,
+            mBytesPerPacket: 0,
+            mFramesPerPacket: 1024,      // AAC-LC's fixed frame size
+            mBytesPerFrame: 0,
+            mChannelsPerFrame: format.channelCount,
+            mBitsPerChannel: 0,
+            mReserved: 0)
+
+        guard let output = AVAudioFormat(streamDescription: &description),
+              let converter = AVAudioConverter(from: format, to: output) else {
+            Log.info("audio: no AAC converter for \(format.sampleRate)Hz \(format.channelCount)ch — audio disabled")
+            self.converter = nil
+            return false
+        }
+        converter.bitRate = Self.bitRate
+
+        self.converter = converter
+        self.sourceFormat = format
+        self.outputFormat = output
+        self.configData = converter.outputFormat.magicCookie
+        self.needsConfigFlag = true
+        Log.info("audio: encoding \(Int(format.sampleRate))Hz \(format.channelCount)ch AAC-LC @ \(Self.bitRate / 1000)kbps")
+        return true
+    }
+
+    /// One encoded packet, or nil when this buffer produced no output.
+    struct Encoded {
+        let data: Data
+        let hasConfig: Bool
+    }
+
+    /// Encode one PCM buffer.
+    ///
+    /// AAC is framed in 1024-sample blocks, so a PCM buffer that does not fill
+    /// one yields nothing and the converter keeps the remainder — returning nil
+    /// here is ordinary, not an error.
+    func encode(_ pcm: AVAudioPCMBuffer) -> Encoded? {
+        guard let converter, let outputFormat else { return nil }
+
+        let out = AVAudioCompressedBuffer(
+            format: outputFormat,
+            packetCapacity: 1,
+            maximumPacketSize: converter.maximumOutputPacketSize)
+
+        var supplied = false
+        var conversionError: NSError?
+        let status = converter.convert(to: out, error: &conversionError) { _, outStatus in
+            // Hand the converter this buffer exactly once. Returning it again
+            // would re-encode the same audio; reporting .noDataNow instead lets
+            // the converter emit what it has and ask again next call.
+            if supplied {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            supplied = true
+            outStatus.pointee = .haveData
+            return pcm
+        }
+
+        switch status {
+        case .haveData:
+            break
+        case .inputRanDry, .endOfStream:
+            return nil          // not enough samples for a full AAC frame yet
+        case .error:
+            if let conversionError { Log.info("audio encode error: \(conversionError)") }
+            return nil
+        @unknown default:
+            return nil
+        }
+
+        guard out.byteLength > 0 else { return nil }
+        let data = Data(bytes: out.data, count: Int(out.byteLength))
+
+        // Flag the config on the first packet after a (re)configuration so a
+        // receiver knows the cookie it holds applies to what follows.
+        let hasConfig = needsConfigFlag
+        needsConfigFlag = false
+        return Encoded(data: data, hasConfig: hasConfig)
+    }
+
+    func reset() {
+        converter?.reset()
+        needsConfigFlag = true
+    }
+}

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -2059,8 +2059,13 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // Capture time on our own clock, matching the units the video path
         // stamps frames with, so the receiver can align the two with the
         // ping/pong offset it already maintains.
-        let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
-        let ptsMs = pts.isValid ? pts.seconds * 1000 : Date().timeIntervalSince1970 * 1000
+        // Wall clock, matching the video path's `cap` stamp (see the telemetry
+        // prefix in the capture callback). CMSampleBuffer presentation stamps
+        // are mach uptime — seconds since boot — so using them here put audio
+        // on a different epoch from video: the receiver's latency calculation
+        // landed far outside its sanity window, was discarded, and both
+        // aE2e50 and avSkew read a permanent 0.
+        let ptsMs = Date().timeIntervalSince1970 * 1000
 
         let packet = AudioPacket(codec: .aacLC,
                                  hasConfig: encoded.hasConfig,

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -17,6 +17,7 @@ import ScreenCaptureKit
 import VideoToolbox
 import Network
 import CoreMedia
+import AVFoundation
 import AppKit
 
 enum CaptureMode: String {
@@ -134,6 +135,10 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private var connection: NWConnection?
     private var virtualDisplay: VirtualDisplay?
     private let queue = DispatchQueue(label: "sender.video")
+    /// Audio runs on its own queue: sharing the video queue would let an
+    /// encode hiccup on either stream stall the other, and video is the one
+    /// with a frame deadline.
+    private let audioQueue = DispatchQueue(label: "sender.audio")
     private let startCode: [UInt8] = [0, 0, 0, 1]
 
     // The dial target. Written on `queue` only (after init): the controller
@@ -188,6 +193,29 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private var dropsNetTotal = 0
     private var needsKeyframe = true
     private var connectionReady = false
+    /// System-audio capture and encode. Nil until a session enables audio.
+    /// Touched only on `audioQueue`.
+    private var audioEncoder: AudioEncoder?
+    /// Whether the user wants audio streamed. Off by default: an update should
+    /// never surprise anyone with sudden sound coming out of their iPad.
+    ///
+    /// Read-only here, and read fresh at capture setup rather than cached:
+    /// SenderController owns the setting and restarts capture when it changes,
+    /// so this always sees the current value and there is only ever one writer.
+    private var audioEnabled: Bool {
+        UserDefaults.standard.bool(forKey: "audioEnabled")
+    }
+    private var audioPacketsSent = 0
+    private var audioDropsThisWindow = 0
+    private var loggedAudioUnsupportedPeer = false
+    /// Whether this connection's receiver speaks tagged framing (protocol 4+).
+    ///
+    /// Per-connection, and false until the receiver's `hello` proves otherwise:
+    /// the handshake itself cannot be tagged, because at the moment we send it
+    /// we do not yet know what the peer understands. Reset on every new
+    /// connection — a reconnect may reach a different device, and a stale true
+    /// here would tag frames at a receiver that cannot read them.
+    private var peerSpeaksTaggedFrames = false
     private var stopped = false
     // The liveness monitors are self-rescheduling chains guarded only by
     // `stopped`; arm them at most once per instance so a double start() can't
@@ -693,6 +721,13 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         // the encoder for ~13ms — headroom prevents SCK starvation drops.
         config.queueDepth = 8
         config.showsCursor = !localCursor
+        // System audio on the SAME stream as video, so both arrive stamped by
+        // one capture clock and stay in sync without a second mechanism.
+        // Excluding our own process keeps a Mac receiver's playback from being
+        // captured and sent back to itself.
+        let wantsAudio = audioEnabled
+        config.capturesAudio = wantsAudio
+        config.excludesCurrentProcessAudio = true
 
         invalidateCapturePipeline(discardingLastFrame: true)
         let generation = captureGenerationNow
@@ -700,6 +735,18 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
         let stream = SCStream(filter: filter, configuration: config, delegate: self)
         try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: queue)
+        if wantsAudio {
+            // A failure here must not cost the user their display: log it and
+            // stream video alone.
+            do {
+                try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: audioQueue)
+                audioQueue.sync { audioEncoder = AudioEncoder() }
+            } catch {
+                Log.info("audio: stream output unavailable (\(error)) — video only")
+            }
+        } else {
+            audioQueue.sync { audioEncoder = nil }
+        }
         self.stream = stream
         do {
             try await stream.startCapture()
@@ -1005,6 +1052,12 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         Log.info("connection ready to \(endpointName)")
         connectionReady = true
         cursorSeq = 0   // per-session; the receiver rewound its floor with the connection
+        // Back to legacy framing until this connection's receiver identifies
+        // itself: a reconnect can land on a different device than the last one.
+        peerSpeaksTaggedFrames = false
+        loggedAudioUnsupportedPeer = false
+        // A new receiver has no codec config, so the next packet must carry it.
+        audioQueue.async { [weak self] in self?.audioEncoder?.reset() }
         everConnected = true
         awaitingWake = false
         consecutiveRefusals = 0
@@ -1695,9 +1748,15 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
             // so one file holds both ends of the story.
             if let json = try? JSONSerialization.data(withJSONObject: obj),
                let line = String(data: json, encoding: .utf8) {
-                Log.info("PHONE-STATS \(line) | mac enc↓=\(dropsEncThisWindow) net↓=\(dropsNetThisWindow) pending=\(pendingSends)")
+                // The receiver's own audio counters ride in `line` (aPkt/aKB);
+                // ours are appended so a discrepancy between sent and arrived
+                // is visible on one line.
+                Log.info("PHONE-STATS \(line) | mac enc↓=\(dropsEncThisWindow) net↓=\(dropsNetThisWindow) pending=\(pendingSends)"
+                         + " aSent=\(audioPacketsSent) a↓=\(audioDropsThisWindow)")
                 dropsEncThisWindow = 0
                 dropsNetThisWindow = 0
+                audioPacketsSent = 0
+                audioDropsThisWindow = 0
             }
         case "cursorAck":
             // The receiver saw our first datagram: the side channel delivers,
@@ -1737,6 +1796,17 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                 // message types. Sending on every hello is idempotent — the
                 // phone dedupes by content.
                 sendWelcome()
+                // Only now, with `welcome` already handed to the connection
+                // untagged, may we start tagging. The receiver cannot know our
+                // protocol version until it reads that message, so a frame
+                // tagged before this point would arrive at a peer still
+                // deframing by the legacy rules and be misread as video.
+                // Ordering, not just the value, is what makes this correct.
+                let tagged = info.protocolVersion >= WireProtocol.taggedFrameVersion
+                if tagged != peerSpeaksTaggedFrames {
+                    peerSpeaksTaggedFrames = tagged
+                    Log.info("framing: \(tagged ? "tagged" : "legacy") (receiver pv \(info.protocolVersion))")
+                }
                 if info.protocolVersion < WireProtocol.minSupportedPeer {
                     Log.info("receiver protocol \(info.protocolVersion) below supported \(WireProtocol.minSupportedPeer) — requesting update")
                     sendUpdateRequired(kind: info.kind)
@@ -1921,6 +1991,14 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     func stream(_ stream: SCStream,
                 didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
                 of type: SCStreamOutputType) {
+        // Audio arrives on audioQueue, video on queue — dispatched by SCK to
+        // whichever queue the output was registered with, so this method runs
+        // on both and must route before touching any video state.
+        if type == .audio {
+            guard stream === self.stream, CMSampleBufferIsValid(sampleBuffer) else { return }
+            handleAudio(sampleBuffer)
+            return
+        }
         guard stream === self.stream,
               type == .screen,
               CMSampleBufferIsValid(sampleBuffer),
@@ -1939,6 +2017,85 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         if shouldDropFrame(reason: "pending_sends") { return }   // TCP send queue full
 
         encode(pixelBuffer, pts: CMSampleBufferGetPresentationTimeStamp(sampleBuffer), generation: generation)
+    }
+
+    // MARK: - Audio capture (runs on audioQueue)
+
+    /// Encode one captured audio buffer and put it on the wire.
+    ///
+    /// Everything here is best-effort by design: audio must never be able to
+    /// stall video or end a session. A receiver too old to understand audio
+    /// frames, an encoder that will not build, a backed-up socket — each drops
+    /// the audio and leaves the display running.
+    private func handleAudio(_ sampleBuffer: CMSampleBuffer) {
+        guard connectionReady, let encoder = audioEncoder else { return }
+
+        // Audio frames only exist in the tagged framing of protocol 4+. Sending
+        // one to an older receiver would be read as video and corrupt the
+        // decoder, so this gate is load-bearing, not an optimisation.
+        guard peerSpeaksTaggedFrames else {
+            if !loggedAudioUnsupportedPeer {
+                loggedAudioUnsupportedPeer = true
+                Log.info("audio: receiver predates tagged frames — audio not sent")
+            }
+            return
+        }
+
+        // Late audio is worse than absent audio: if the socket is already
+        // backed up, drop this packet rather than deepening the queue.
+        pipelineLock.lock()
+        let backedUp = pendingSends >= maxPendingSends
+        pipelineLock.unlock()
+        if backedUp {
+            audioDropsThisWindow += 1
+            return
+        }
+
+        guard let format = sampleBuffer.formatDescription.map({ AVAudioFormat(cmAudioFormatDescription: $0) }),
+              encoder.prepare(for: format),
+              let pcm = Self.pcmBuffer(from: sampleBuffer, format: format),
+              let encoded = encoder.encode(pcm) else { return }
+
+        // Capture time on our own clock, matching the units the video path
+        // stamps frames with, so the receiver can align the two with the
+        // ping/pong offset it already maintains.
+        let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        let ptsMs = pts.isValid ? pts.seconds * 1000 : Date().timeIntervalSince1970 * 1000
+
+        let packet = AudioPacket(codec: .aacLC,
+                                 hasConfig: encoded.hasConfig,
+                                 sampleRate: encoder.sampleRate,
+                                 channels: encoder.channels,
+                                 ptsMs: ptsMs,
+                                 payload: encoded.data)
+        sendAudio(packet.encoded())
+        audioPacketsSent += 1
+    }
+
+    /// Copy a captured audio buffer into a PCM buffer the converter accepts.
+    private static func pcmBuffer(from sampleBuffer: CMSampleBuffer,
+                                  format: AVAudioFormat) -> AVAudioPCMBuffer? {
+        let frames = CMSampleBufferGetNumSamples(sampleBuffer)
+        guard frames > 0,
+              let pcm = AVAudioPCMBuffer(pcmFormat: format,
+                                         frameCapacity: AVAudioFrameCount(frames)) else { return nil }
+        pcm.frameLength = AVAudioFrameCount(frames)
+        let status = CMSampleBufferCopyPCMDataIntoAudioBufferList(
+            sampleBuffer,
+            at: 0,
+            frameCount: Int32(frames),
+            into: pcm.mutableAudioBufferList)
+        guard status == noErr else { return nil }
+        return pcm
+    }
+
+    /// Frame and send an audio packet. Separate from `sendFramed` because
+    /// audio must not touch the video path's pending-send accounting, which
+    /// drives frame-drop decisions.
+    private func sendAudio(_ payload: Data) {
+        guard let connection, connectionReady else { return }
+        let frame = FrameCodec.encode(payload, type: .audio, tagged: peerSpeaksTaggedFrames)
+        connection.send(content: frame, completion: .contentProcessed { _ in })
     }
 
     private func isPipelineBackedUp() -> Bool {
@@ -2231,18 +2388,15 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     private func sendJSONFrame(_ json: String) {
         guard let connection, connectionReady else { return }
-        let payload = Data(json.utf8)
-        var header = UInt32(payload.count).bigEndian
-        var frame = Data(bytes: &header, count: 4)
-        frame.append(payload)
+        let frame = FrameCodec.encode(Data(json.utf8), type: .json,
+                                      tagged: peerSpeaksTaggedFrames)
         connection.send(content: frame, completion: .contentProcessed { _ in })
     }
 
     private func sendFramed(_ payload: Data) {
         guard let connection, connectionReady else { return }
-        var header = UInt32(payload.count).bigEndian
-        var frame = Data(bytes: &header, count: 4)
-        frame.append(payload)
+        let frame = FrameCodec.encode(payload, type: .video,
+                                      tagged: peerSpeaksTaggedFrames)
         pendingSends += 1
         connection.send(content: frame, completion: .contentProcessed { [weak self] error in
             guard let self else { return }

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -193,6 +193,12 @@ final class SenderController: ObservableObject {
     @Published var quality = StreamQuality(rawValue: UserDefaults.standard.string(forKey: "quality") ?? "") ?? .best {
         didSet { UserDefaults.standard.set(quality.rawValue, forKey: "quality") }
     }
+    /// Stream system audio alongside the picture. Off by default: an update
+    /// should never start sending sound to someone's iPad unasked. Changing it
+    /// restarts capture, because `capturesAudio` is fixed at stream creation.
+    @Published var audioEnabled = UserDefaults.standard.bool(forKey: "audioEnabled") {
+        didSet { UserDefaults.standard.set(audioEnabled, forKey: "audioEnabled") }
+    }
 
     var running: Bool { !sessions.isEmpty }
 
@@ -896,6 +902,14 @@ struct ContentView: View {
                     }
                     .onChange(of: controller.quality) { controller.restartAll() }
                     Text(controller.quality.explanation)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Stream audio", isOn: $controller.audioEnabled)
+                        .onChange(of: controller.audioEnabled) { controller.restartAll() }
+                    Text("Sends this Mac's audio to the connected device. Needs OpenDisplay 4 or newer on the receiving end; older devices keep showing the picture only.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/MacReceiver/ReceiverPanel.swift
+++ b/MacReceiver/ReceiverPanel.swift
@@ -29,6 +29,10 @@ struct ReceiverSections: View {
             Text("FPS, bitrate, frame timing, and latency graphs at the bottom of the video window while streaming — the same HUD the iPhone app has.")
         }
 
+        if let receiver = controller.receiver {
+            ReceiverAudioSection(receiver: receiver)
+        }
+
         Section("How to connect") {
             Label("Install and open OpenDisplay on the Mac whose screen you want to extend.",
                   systemImage: "macbook.and.macbook")
@@ -38,6 +42,23 @@ struct ReceiverSections: View {
                   systemImage: "arrow.up.left.and.arrow.down.right")
         }
         .font(.subheadline)
+    }
+}
+
+/// Mute for streamed desktop audio.
+///
+/// Its own subview for the same reason as the status section: a nested
+/// ObservableObject does not republish through its parent, so the toggle would
+/// not follow the receiver's state otherwise.
+struct ReceiverAudioSection: View {
+    @ObservedObject var receiver: StreamReceiver
+
+    var body: some View {
+        Section {
+            Toggle("Mute audio", isOn: $receiver.audioMuted)
+        } footer: {
+            Text("Silences audio sent from the other Mac. The stream keeps running, so unmuting resumes in sync. Audio arrives only if the sending Mac has it switched on.")
+        }
     }
 }
 

--- a/MacTests/AudioJitterBufferTests.swift
+++ b/MacTests/AudioJitterBufferTests.swift
@@ -1,0 +1,230 @@
+import XCTest
+
+/// The jitter buffer is where "packets arrived" becomes "audio played", and
+/// every one of its edge cases is audible: a gap, a blip of stale audio, or a
+/// latency that grows all session. Pure logic, so all of it is testable.
+final class AudioJitterBufferTests: XCTestCase {
+
+    private func packet(_ ptsMs: Double) -> AudioPacket {
+        AudioPacket(codec: .aacLC, hasConfig: false, sampleRate: 48_000,
+                    channels: 2, ptsMs: ptsMs, payload: Data([0x01]))
+    }
+
+    private func fill(_ buffer: inout AudioJitterBuffer, count: Int, from: Double = 0) {
+        for i in 0..<count { buffer.enqueue(packet(from + Double(i) * 21)) }
+    }
+
+    // MARK: - Pre-roll
+
+    func testNothingPlaysUntilTheTargetDepthIsReached() {
+        // Playing the first packet on arrival defeats the buffer: there is
+        // nothing held back to cover the next late one.
+        var buffer = AudioJitterBuffer(targetDepth: 3, capacity: 12)
+        buffer.enqueue(packet(0))
+        XCTAssertNil(buffer.dequeue())
+        buffer.enqueue(packet(21))
+        XCTAssertNil(buffer.dequeue())
+        buffer.enqueue(packet(42))
+        XCTAssertNotNil(buffer.dequeue())
+    }
+
+    func testPlaybackRunsInTimestampOrderOncePreRolled() {
+        var buffer = AudioJitterBuffer(targetDepth: 2, capacity: 12)
+        fill(&buffer, count: 4)
+        XCTAssertEqual(buffer.dequeue()?.ptsMs, 0)
+        XCTAssertEqual(buffer.dequeue()?.ptsMs, 21)
+        XCTAssertEqual(buffer.dequeue()?.ptsMs, 42)
+        XCTAssertEqual(buffer.dequeue()?.ptsMs, 63)
+    }
+
+    // MARK: - Underrun
+
+    func testDrainingCountsAnUnderrun() {
+        var buffer = AudioJitterBuffer(targetDepth: 1, capacity: 12)
+        buffer.enqueue(packet(0))
+        XCTAssertNotNil(buffer.dequeue())
+        XCTAssertNil(buffer.dequeue())
+        XCTAssertEqual(buffer.underruns, 1)
+    }
+
+    func testUnderrunReArmsPreRollInsteadOfPlayingEachArrival() {
+        // Without re-arming, a buffer that ran dry hands over every subsequent
+        // packet the instant it lands — underrunning again on the next one, and
+        // the one after. The recovery must rebuild a cushion.
+        var buffer = AudioJitterBuffer(targetDepth: 3, capacity: 12)
+        fill(&buffer, count: 3)
+        while buffer.dequeue() != nil {}
+        XCTAssertEqual(buffer.underruns, 1)
+
+        // Refill to the CURRENT target, which the underrun just raised — the
+        // pre-underrun depth is deliberately no longer enough.
+        let target = buffer.targetDepth
+        for i in 0..<(target - 1) {
+            buffer.enqueue(packet(100 + Double(i) * 21))
+            XCTAssertNil(buffer.dequeue(), "must re-fill to target before resuming")
+        }
+        buffer.enqueue(packet(100 + Double(target) * 21))
+        XCTAssertNotNil(buffer.dequeue())
+    }
+
+    // MARK: - Overrun
+
+    func testExceedingCapacityDropsTheOldest() {
+        // Dropping the newest would keep the stalest audio and grow latency;
+        // dropping the oldest keeps playback close to live.
+        var buffer = AudioJitterBuffer(targetDepth: 2, capacity: 4)
+        fill(&buffer, count: 6)
+        XCTAssertEqual(buffer.depth, 4)
+        XCTAssertEqual(buffer.dropped, 2)
+        XCTAssertEqual(buffer.dequeue()?.ptsMs, 42, "the two oldest should be gone")
+    }
+
+    func testSustainedOverrunKeepsDepthBounded() {
+        var buffer = AudioJitterBuffer(targetDepth: 3, capacity: 8)
+        fill(&buffer, count: 500)
+        XCTAssertEqual(buffer.depth, 8)
+    }
+
+    // MARK: - Reordering
+
+    func testOutOfOrderPacketIsPlacedByTimestamp() {
+        var buffer = AudioJitterBuffer(targetDepth: 1, capacity: 12)
+        buffer.enqueue(packet(0))
+        buffer.enqueue(packet(42))
+        buffer.enqueue(packet(21))     // late arrival
+
+        XCTAssertEqual(buffer.reordered, 1)
+        XCTAssertEqual(buffer.dequeue()?.ptsMs, 0)
+        XCTAssertEqual(buffer.dequeue()?.ptsMs, 21)
+        XCTAssertEqual(buffer.dequeue()?.ptsMs, 42)
+    }
+
+    func testInOrderArrivalsCountNoReordering() {
+        var buffer = AudioJitterBuffer(targetDepth: 1, capacity: 12)
+        fill(&buffer, count: 10)
+        XCTAssertEqual(buffer.reordered, 0)
+    }
+
+    // MARK: - Reset
+
+    func testResetDropsHeldAudioAndRearmsPreRoll() {
+        // Stale packets from a previous session would otherwise play as a blip
+        // of the old stream over the new one.
+        var buffer = AudioJitterBuffer(targetDepth: 2, capacity: 12)
+        fill(&buffer, count: 5)
+        buffer.reset()
+
+        XCTAssertTrue(buffer.isEmpty)
+        buffer.enqueue(packet(1000))
+        XCTAssertNil(buffer.dequeue(), "pre-roll must be re-armed after a reset")
+    }
+
+    func testResetCountersClearsWithoutDiscardingAudio() {
+        var buffer = AudioJitterBuffer(targetDepth: 1, capacity: 2)
+        fill(&buffer, count: 5)
+        XCTAssertGreaterThan(buffer.dropped, 0)
+
+        buffer.resetCounters()
+        XCTAssertEqual(buffer.dropped, 0)
+        XCTAssertEqual(buffer.underruns, 0)
+        XCTAssertEqual(buffer.reordered, 0)
+        XCTAssertEqual(buffer.depth, 2, "counters reset must not discard packets")
+    }
+
+    // MARK: - Adaptation
+
+    func testTargetGrowsAfterAnUnderrun() {
+        // The starting target is a guess about an unmeasured link. When it
+        // proves too shallow, the buffer should hold more rather than keep
+        // gapping at the same depth.
+        var buffer = AudioJitterBuffer(targetDepth: 2, capacity: 12)
+        XCTAssertEqual(buffer.targetDepth, 2)
+
+        fill(&buffer, count: 2)
+        while buffer.dequeue() != nil {}
+
+        XCTAssertEqual(buffer.targetDepth, 3)
+        XCTAssertEqual(buffer.adaptations, 1)
+    }
+
+    func testTargetStopsGrowingAtTheLatencyCeiling() {
+        // Unbounded growth would trade every gap for latency until audio
+        // visibly trailed the picture.
+        var buffer = AudioJitterBuffer(targetDepth: 2, capacity: 64)
+        for _ in 0..<50 {
+            fill(&buffer, count: buffer.targetDepth)
+            while buffer.dequeue() != nil {}
+        }
+        XCTAssertLessThanOrEqual(buffer.targetDepth, AudioJitterBuffer.maxAdaptiveTarget)
+    }
+
+    func testTargetNeverGrowsIntoCapacity() {
+        // A target at capacity could never pre-roll: the packet that would
+        // complete it evicts the oldest, so depth never reaches the target.
+        var buffer = AudioJitterBuffer(targetDepth: 2, capacity: 4)
+        for _ in 0..<50 {
+            fill(&buffer, count: buffer.targetDepth)
+            while buffer.dequeue() != nil {}
+        }
+        XCTAssertLessThan(buffer.targetDepth, buffer.capacity)
+
+        // And it must still be able to play after all that adaptation.
+        fill(&buffer, count: buffer.capacity)
+        XCTAssertNotNil(buffer.dequeue())
+    }
+
+    func testAStableLinkNeverAdapts() {
+        var buffer = AudioJitterBuffer(targetDepth: 3, capacity: 12)
+        fill(&buffer, count: 12)
+        for _ in 0..<9 { XCTAssertNotNil(buffer.dequeue()) }
+        XCTAssertEqual(buffer.adaptations, 0)
+        XCTAssertEqual(buffer.targetDepth, 3)
+    }
+
+    func testResetKeepsWhatTheLinkTaughtUs() {
+        // A resume is the same network: throwing away the learned depth would
+        // make it re-learn by underrunning again, audibly.
+        var buffer = AudioJitterBuffer(targetDepth: 2, capacity: 12)
+        fill(&buffer, count: 2)
+        while buffer.dequeue() != nil {}
+        let learned = buffer.targetDepth
+
+        buffer.reset()
+        XCTAssertEqual(buffer.targetDepth, learned)
+    }
+
+    func testNewSessionForgetsTheAdaptation() {
+        // A new peer may be on a cable where the WiFi-grown target is pure
+        // added latency.
+        var buffer = AudioJitterBuffer(targetDepth: 2, capacity: 12)
+        fill(&buffer, count: 2)
+        while buffer.dequeue() != nil {}
+        XCTAssertGreaterThan(buffer.targetDepth, 2)
+
+        buffer.resetForNewSession()
+        XCTAssertEqual(buffer.targetDepth, 2)
+        XCTAssertEqual(buffer.adaptations, 0)
+    }
+
+    // MARK: - Construction
+
+    func testCapacityBelowTargetIsRaisedSoPlaybackCanStart() {
+        // A capacity under the target would drop packets before pre-roll ever
+        // completed, and the buffer would never produce a sound.
+        var buffer = AudioJitterBuffer(targetDepth: 5, capacity: 2)
+        XCTAssertGreaterThanOrEqual(buffer.capacity, buffer.targetDepth)
+        fill(&buffer, count: 5)
+        XCTAssertNotNil(buffer.dequeue())
+    }
+
+    func testZeroTargetStillPlays() {
+        var buffer = AudioJitterBuffer(targetDepth: 0, capacity: 4)
+        buffer.enqueue(packet(0))
+        XCTAssertNotNil(buffer.dequeue())
+    }
+
+    func testDefaultsGiveRoomAboveTheTarget() {
+        let buffer = AudioJitterBuffer()
+        XCTAssertGreaterThan(buffer.capacity, buffer.targetDepth)
+    }
+}

--- a/MacTests/AudioPacketTests.swift
+++ b/MacTests/AudioPacketTests.swift
@@ -1,0 +1,172 @@
+import XCTest
+
+/// The audio packet header is pure byte layout, so it is fully testable
+/// without CoreAudio, a socket, or a device.
+final class AudioPacketTests: XCTestCase {
+
+    private func sample(payload: Data = Data([0xDE, 0xAD, 0xBE, 0xEF])) -> AudioPacket {
+        AudioPacket(codec: .aacLC, hasConfig: false, sampleRate: 48_000,
+                    channels: 2, ptsMs: 1234.5, payload: payload)
+    }
+
+    // MARK: - Round trips
+
+    func testRoundTripPreservesEveryField() {
+        let original = sample()
+        let decoded = AudioPacket.decode(original.encoded())
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testConfigFlagRoundTrips() {
+        var packet = sample()
+        packet.hasConfig = true
+        XCTAssertEqual(AudioPacket.decode(packet.encoded())?.hasConfig, true)
+
+        packet.hasConfig = false
+        XCTAssertEqual(AudioPacket.decode(packet.encoded())?.hasConfig, false)
+    }
+
+    func testFractionalSampleRateSurvives() {
+        // 44.1kHz is why the field is tenths of a kHz rather than whole kHz —
+        // a whole-kHz field would round it to 44000 and the decoder would
+        // drift against the sender.
+        var packet = sample()
+        packet.sampleRate = 44_100
+        XCTAssertEqual(AudioPacket.decode(packet.encoded())?.sampleRate, 44_100)
+    }
+
+    func testCommonSampleRatesRoundTrip() {
+        for rate in [8_000, 16_000, 22_050, 32_000, 44_100, 48_000, 96_000, 192_000] {
+            var packet = sample()
+            packet.sampleRate = rate
+            XCTAssertEqual(AudioPacket.decode(packet.encoded())?.sampleRate, rate,
+                           "sample rate \(rate) did not survive the wire")
+        }
+    }
+
+    func testMonoAndStereoRoundTrip() {
+        for channels in [1, 2] {
+            var packet = sample()
+            packet.channels = channels
+            XCTAssertEqual(AudioPacket.decode(packet.encoded())?.channels, channels)
+        }
+    }
+
+    // MARK: - Timestamps
+
+    func testTimestampSurvivesFullDoublePrecision() {
+        // ptsMs carries a wall-clock millisecond value that the receiver
+        // subtracts from its own clock; losing precision here shows up as
+        // audio/video misalignment, so it travels as a full double.
+        var packet = sample()
+        packet.ptsMs = 1_763_925_123_456.789
+        let decoded = AudioPacket.decode(packet.encoded())
+        XCTAssertEqual(decoded?.ptsMs, 1_763_925_123_456.789)
+    }
+
+    func testTimestampIsBigEndianOnTheWire() {
+        var packet = sample()
+        packet.ptsMs = 1.0     // 0x3FF0000000000000
+        let bytes = Array(packet.encoded())
+        XCTAssertEqual(Array(bytes[6..<14]), [0x3F, 0xF0, 0, 0, 0, 0, 0, 0])
+    }
+
+    func testSampleRateIsBigEndianHzOnTheWire() {
+        // Plain Hz, not a scaled unit: 48000 = 0x0000BB80. Asserted on the
+        // bytes because this is a cross-implementation contract, and a rate
+        // that round-trips through our own code could still be encoded in a
+        // unit another implementation would not expect.
+        let bytes = Array(sample().encoded())
+        XCTAssertEqual(Array(bytes[2..<6]), [0x00, 0x00, 0xBB, 0x80])
+    }
+
+    func testZeroTimestampRoundTrips() {
+        var packet = sample()
+        packet.ptsMs = 0
+        XCTAssertEqual(AudioPacket.decode(packet.encoded())?.ptsMs, 0)
+    }
+
+    // MARK: - Layout
+
+    func testHeaderIsExactlyFifteenBytes() {
+        // Pinned to a literal, not just to headerSize: the constant and the
+        // bytes encoded() actually writes are two different things, and the
+        // bug this caught was exactly them disagreeing.
+        let encoded = sample(payload: Data()).encoded()
+        XCTAssertEqual(encoded.count, AudioPacket.headerSize)
+        XCTAssertEqual(encoded.count, 15)
+    }
+
+    func testPayloadFollowsTheHeaderUntouched() {
+        let payload = Data((0..<64).map { UInt8($0) })
+        let encoded = sample(payload: payload).encoded()
+        XCTAssertEqual(encoded.count, AudioPacket.headerSize + payload.count)
+        XCTAssertEqual(encoded.suffix(from: AudioPacket.headerSize), payload)
+    }
+
+    func testChannelCountSitsAfterTheTimestamp() {
+        XCTAssertEqual(Array(sample().encoded())[14], 2)
+    }
+
+    // MARK: - Malformed input
+
+    func testTruncatedPacketsAreRejectedNotCrashed() {
+        // These arrive from the network ~50 times a second; a malformed one
+        // must be droppable, never fatal.
+        let encoded = sample().encoded()
+        for length in 0..<AudioPacket.headerSize {
+            XCTAssertNil(AudioPacket.decode(encoded.prefix(length)),
+                         "a \(length)-byte packet must not decode")
+        }
+    }
+
+    func testUnknownCodecIsRejected() {
+        var bytes = Array(sample().encoded())
+        bytes[0] = 0x7F
+        XCTAssertNil(AudioPacket.decode(Data(bytes)))
+    }
+
+    func testZeroSampleRateOrChannelsIsRejected() {
+        var zeroRate = Array(sample().encoded())
+        zeroRate[2] = 0; zeroRate[3] = 0; zeroRate[4] = 0; zeroRate[5] = 0
+        XCTAssertNil(AudioPacket.decode(Data(zeroRate)))
+
+        var zeroChannels = Array(sample().encoded())
+        zeroChannels[14] = 0
+        XCTAssertNil(AudioPacket.decode(Data(zeroChannels)))
+    }
+
+    func testEmptyPayloadIsValid() {
+        // A header with no audio is well-formed — a config-only packet uses it.
+        let decoded = AudioPacket.decode(sample(payload: Data()).encoded())
+        XCTAssertNotNil(decoded)
+        XCTAssertTrue(decoded?.payload.isEmpty ?? false)
+    }
+
+    // MARK: - Slicing
+
+    func testDecodingWorksOnANonZeroBasedSlice() {
+        // Payloads reach this parser as slices of the receive buffer, whose
+        // indices do not start at zero. Indexing from 0 instead of startIndex
+        // would read the wrong bytes — or trap.
+        let packet = sample()
+        var buffer = Data([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
+        buffer.append(packet.encoded())
+        let slice = buffer.suffix(from: 8)
+
+        XCTAssertNotEqual(slice.startIndex, 0, "slice no longer exercises non-zero indexing")
+        XCTAssertEqual(AudioPacket.decode(slice), packet)
+    }
+
+    // MARK: - Framing integration
+
+    func testAudioPacketSurvivesTaggedFraming() {
+        // End to end at the wire level: packet → tagged frame → deframe →
+        // packet, which is the whole phase-2 send path minus the codec.
+        let packet = sample()
+        let frame = FrameCodec.encode(packet.encoded(), type: .audio, tagged: true)
+        let decodedFrame = FrameCodec.decode(body: frame.dropFirst(4), tagged: true)
+        XCTAssertEqual(decodedFrame?.type, .audio)
+        XCTAssertEqual(decodedFrame.flatMap { AudioPacket.decode($0.payload) }, packet)
+    }
+}

--- a/MacTests/AudioPacketTests.swift
+++ b/MacTests/AudioPacketTests.swift
@@ -170,3 +170,39 @@ final class AudioPacketTests: XCTestCase {
         XCTAssertEqual(decodedFrame.flatMap { AudioPacket.decode($0.payload) }, packet)
     }
 }
+
+/// The AAC-LC AudioSpecificConfig the receiver reconstructs instead of
+/// receiving. Two bytes of bit-packing, and a wrong one makes the decoder
+/// reject every frame while still reporting a healthy stream.
+final class AACCookieTests: XCTestCase {
+
+    func test48kHzStereoMatchesTheSpec() {
+        // objectType 2, freqIndex 3 (48000), channels 2:
+        // 00010 0011 0010 000 -> 0x11 0x90
+        XCTAssertEqual(AudioPacket.aacLCCookie(sampleRate: 48_000, channels: 2),
+                       Data([0x11, 0x90]))
+    }
+
+    func test44_1kHzStereoMatchesTheSpec() {
+        // freqIndex 4 (44100): 00010 0100 0010 000 -> 0x12 0x10
+        XCTAssertEqual(AudioPacket.aacLCCookie(sampleRate: 44_100, channels: 2),
+                       Data([0x12, 0x10]))
+    }
+
+    func testMonoDiffersFromStereo() {
+        XCTAssertNotEqual(AudioPacket.aacLCCookie(sampleRate: 48_000, channels: 1),
+                          AudioPacket.aacLCCookie(sampleRate: 48_000, channels: 2))
+    }
+
+    func testEveryRateTheEncoderCanProduceHasACookie() {
+        for rate in [8_000, 11_025, 16_000, 22_050, 32_000, 44_100, 48_000, 88_200, 96_000] {
+            XCTAssertNotNil(AudioPacket.aacLCCookie(sampleRate: rate, channels: 2),
+                            "no cookie for \(rate)Hz — decoder would reject every frame")
+        }
+    }
+
+    func testUnsupportedInputIsRejectedRatherThanGuessed() {
+        XCTAssertNil(AudioPacket.aacLCCookie(sampleRate: 12_345, channels: 2))
+        XCTAssertNil(AudioPacket.aacLCCookie(sampleRate: 48_000, channels: 0))
+    }
+}

--- a/MacTests/FrameCodecTests.swift
+++ b/MacTests/FrameCodecTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+
+/// Framing is the one part of the wire both apps must agree on byte for byte,
+/// and protocol 4 changed it. These are pure-logic tests: no sockets, no
+/// display, no capture.
+final class FrameCodecTests: XCTestCase {
+
+    // MARK: - Round trips
+
+    func testTaggedRoundTripPreservesTypeAndPayload() {
+        let payloads: [(FrameType, Data)] = [
+            (.video, Data([0x00, 0x00, 0x00, 0x01, 0x65, 0x88])),
+            (.json, Data(#"{"type":"pong"}"#.utf8)),
+            (.audio, Data([0x00, 0x01, 0x01, 0xE0, 0x02, 0x00, 0xDE, 0xAD])),
+        ]
+        for (type, payload) in payloads {
+            let frame = FrameCodec.encode(payload, type: type, tagged: true)
+            let decoded = FrameCodec.decode(body: frame.dropFirst(4), tagged: true)
+            XCTAssertEqual(decoded?.type, type)
+            XCTAssertEqual(decoded?.payload, payload)
+        }
+    }
+
+    func testLengthCoversTypeByte() {
+        // The deframing loop reads the length then takes exactly that many
+        // bytes. If the tag were excluded from the count, every frame would be
+        // one byte short and the stream would desynchronise permanently.
+        let payload = Data([0xAA, 0xBB, 0xCC])
+        let frame = FrameCodec.encode(payload, type: .video, tagged: true)
+        let declared = frame.prefix(4).withUnsafeBytes {
+            Int(UInt32(bigEndian: $0.loadUnaligned(as: UInt32.self)))
+        }
+        XCTAssertEqual(declared, payload.count + 1)
+        XCTAssertEqual(frame.count, 4 + payload.count + 1)
+    }
+
+    // MARK: - Legacy compatibility
+
+    func testUntaggedFramingIsByteIdenticalToPreProtocol4() {
+        // A protocol-4 build must produce the exact bytes an older receiver
+        // expects, or every install in the field breaks on update.
+        let payload = Data(#"{"type":"hello"}"#.utf8)
+        let frame = FrameCodec.encode(payload, type: .json, tagged: false)
+
+        var expected = Data()
+        var header = UInt32(payload.count).bigEndian
+        withUnsafeBytes(of: &header) { expected.append(contentsOf: $0) }
+        expected.append(payload)
+
+        XCTAssertEqual(frame, expected)
+    }
+
+    func testLegacyDecodeStillInfersKindFromBytes() {
+        let json = Data(#"{"type":"pong","t":123}"#.utf8)
+        XCTAssertEqual(FrameCodec.decode(body: json, tagged: false)?.type, .json)
+
+        let annexB = Data([0x00, 0x00, 0x00, 0x01, 0x67, 0x42])
+        XCTAssertEqual(FrameCodec.decode(body: annexB, tagged: false)?.type, .video)
+    }
+
+    // MARK: - The heuristic's blind spot
+
+    func testTaggingSurvivesPayloadThatFoolsTheLegacyHeuristic() {
+        // The pre-protocol-4 sniffing rule reads "starts with { and has no NUL"
+        // as JSON. Audio can satisfy both by coincidence — this payload does —
+        // and would have been handed to the JSON parser. The tag is what makes
+        // it unambiguous, so assert both halves: the heuristic is still fooled,
+        // and tagging is not.
+        let deceptive = Data([UInt8(ascii: "{"), 0x11, 0x22, 0x33])
+        XCTAssertTrue(FrameCodec.looksLikeJSON(deceptive),
+                      "payload no longer exercises the blind spot this test exists for")
+
+        let frame = FrameCodec.encode(deceptive, type: .audio, tagged: true)
+        let decoded = FrameCodec.decode(body: frame.dropFirst(4), tagged: true)
+        XCTAssertEqual(decoded?.type, .audio)
+        XCTAssertEqual(decoded?.payload, deceptive)
+    }
+
+    func testVideoFrameWithTelemetryPrefixIsNotMistakenForJSON() {
+        // Video frames really do begin with '{'; the NUL in the start code is
+        // what saved the legacy path. Documented here because it is the reason
+        // the heuristic cannot simply be extended to a third kind.
+        var videoWithPrefix = Data(#"{"c":12.5}"#.utf8)
+        videoWithPrefix.append(contentsOf: [0x00, 0x00, 0x00, 0x01, 0x65])
+        XCTAssertFalse(FrameCodec.looksLikeJSON(videoWithPrefix))
+    }
+
+    // MARK: - Forward compatibility and malformed input
+
+    func testUnknownTypeDecodesAsNilRatherThanFailing() {
+        // An older build meeting a newer frame type must skip it, not treat the
+        // stream as corrupt — this is what keeps new types additive.
+        var frame = Data([0x00, 0x00, 0x00, 0x03])
+        frame.append(contentsOf: [0x7F, 0xAA, 0xBB])
+        let decoded = FrameCodec.decode(body: frame.dropFirst(4), tagged: true)
+        XCTAssertNotNil(decoded)
+        XCTAssertNil(decoded?.type)
+        XCTAssertEqual(decoded?.payload, Data([0xAA, 0xBB]))
+    }
+
+    func testEmptyTaggedBodyIsRejected() {
+        XCTAssertNil(FrameCodec.decode(body: Data(), tagged: true))
+    }
+
+    func testEmptyUntaggedBodyIsNotRejected() {
+        // Legacy framing has no type byte to be missing, so an empty body is
+        // merely an empty video payload, not malformed.
+        XCTAssertNotNil(FrameCodec.decode(body: Data(), tagged: false))
+    }
+
+    func testEmptyPayloadTagsAndDecodesCleanly() {
+        let frame = FrameCodec.encode(Data(), type: .audio, tagged: true)
+        XCTAssertEqual(frame.count, 5)
+        let decoded = FrameCodec.decode(body: frame.dropFirst(4), tagged: true)
+        XCTAssertEqual(decoded?.type, .audio)
+        XCTAssertTrue(decoded?.payload.isEmpty ?? false)
+    }
+
+    // MARK: - Deframing
+
+    /// The production drain loop, reproduced faithfully enough to test the
+    /// bounds arithmetic that the type byte changed. Slicing mirrors
+    /// StreamReceiver.drainFrames, including its non-zero-based indices.
+    private func drain(_ buffer: Data, tagged: Bool) -> [FrameCodec.Frame] {
+        var frames: [FrameCodec.Frame] = []
+        var cursor = buffer.startIndex
+        while buffer.distance(from: cursor, to: buffer.endIndex) >= 4 {
+            let len = buffer[cursor..<buffer.index(cursor, offsetBy: 4)]
+                .withUnsafeBytes { Int(UInt32(bigEndian: $0.loadUnaligned(as: UInt32.self))) }
+            guard buffer.distance(from: cursor, to: buffer.endIndex) >= 4 + len else { break }
+            let start = buffer.index(cursor, offsetBy: 4)
+            let end = buffer.index(start, offsetBy: len)
+            if let frame = FrameCodec.decode(body: Data(buffer[start..<end]), tagged: tagged) {
+                frames.append(frame)
+            }
+            cursor = end
+        }
+        return frames
+    }
+
+    func testBackToBackTaggedFramesDrainInOrder() {
+        var stream = Data()
+        stream.append(FrameCodec.encode(Data([0x01]), type: .video, tagged: true))
+        stream.append(FrameCodec.encode(Data(#"{"a":1}"#.utf8), type: .json, tagged: true))
+        stream.append(FrameCodec.encode(Data([0x02, 0x03]), type: .audio, tagged: true))
+
+        let frames = drain(stream, tagged: true)
+        XCTAssertEqual(frames.map(\.type), [.video, .json, .audio])
+        XCTAssertEqual(frames[2].payload, Data([0x02, 0x03]))
+    }
+
+    func testPartialFrameIsLeftForTheNextRead() {
+        // TCP splits wherever it likes; a frame arriving in pieces must wait
+        // rather than being parsed from a short buffer.
+        let whole = FrameCodec.encode(Data([0xAA, 0xBB, 0xCC]), type: .video, tagged: true)
+        XCTAssertTrue(drain(whole.dropLast(2), tagged: true).isEmpty)
+        XCTAssertEqual(drain(whole, tagged: true).count, 1)
+    }
+}

--- a/MacTests/ProtocolNegotiationTests.swift
+++ b/MacTests/ProtocolNegotiationTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+
+/// Tagged framing is negotiated, and the negotiation has an ordering hazard:
+/// the handshake that carries the peer's version cannot itself be tagged,
+/// because neither end knows what the other speaks until it has been read.
+///
+/// Getting that wrong produces a bug that hides — it works on WiFi, or only
+/// when the handshake happens to arrive in a single TCP segment, and fails on
+/// reconnect. These tests model the latch as the production code does (start
+/// legacy, flip on the peer's version, reset per connection) and pin the
+/// ordering, so the hazard is covered without needing a socket.
+final class ProtocolNegotiationTests: XCTestCase {
+
+    /// Mirrors the per-connection latch held by MacSender and StreamReceiver.
+    private struct Negotiator {
+        private(set) var tagged = false
+        private(set) var framesSentBeforeHandshake = 0
+
+        mutating func connectionEstablished() {
+            tagged = false      // a reconnect may be a different peer
+        }
+
+        mutating func peerAnnounced(pv: Int) {
+            tagged = pv >= WireProtocol.taggedFrameVersion
+        }
+
+        mutating func send(_ payload: Data, type: FrameType) -> Data {
+            if !tagged { framesSentBeforeHandshake += 1 }
+            return FrameCodec.encode(payload, type: type, tagged: tagged)
+        }
+    }
+
+    private func isTagged(_ frame: Data, payload: Data) -> Bool {
+        frame.count == 4 + payload.count + 1
+    }
+
+    // MARK: - The ordering hazard
+
+    func testHandshakeItselfGoesOutUntagged() {
+        // The peer cannot read a tag it does not yet know to expect.
+        var n = Negotiator()
+        n.connectionEstablished()
+        let hello = Data(#"{"type":"hello","pv":4}"#.utf8)
+        let frame = n.send(hello, type: .json)
+        XCTAssertFalse(isTagged(frame, payload: hello))
+    }
+
+    func testTaggingBeginsOnlyAfterThePeerVersionIsKnown() {
+        var n = Negotiator()
+        n.connectionEstablished()
+
+        let handshake = Data(#"{"type":"welcome","pv":4}"#.utf8)
+        XCTAssertFalse(isTagged(n.send(handshake, type: .json), payload: handshake))
+
+        n.peerAnnounced(pv: 4)
+
+        let video = Data([0x00, 0x00, 0x00, 0x01, 0x65])
+        XCTAssertTrue(isTagged(n.send(video, type: .video), payload: video))
+        XCTAssertEqual(n.framesSentBeforeHandshake, 1)
+    }
+
+    func testHandshakeSplitAcrossReadsDoesNotTagEarly() {
+        // A handshake delivered in two TCP reads must not flip the latch on the
+        // first fragment: the version is not known until the message parses.
+        var n = Negotiator()
+        n.connectionEstablished()
+
+        let full = Data(#"{"type":"welcome","pv":4}"#.utf8)
+        let firstHalf = full.prefix(10)     // arrives, does not parse
+        XCTAssertFalse(isTagged(n.send(firstHalf, type: .json), payload: firstHalf))
+        XCTAssertFalse(n.tagged)
+
+        n.peerAnnounced(pv: 4)              // rest arrived, message parsed
+        XCTAssertTrue(n.tagged)
+    }
+
+    // MARK: - Version gating
+
+    func testOldPeersNeverGetTaggedFrames() {
+        for pv in 1...3 {
+            var n = Negotiator()
+            n.connectionEstablished()
+            n.peerAnnounced(pv: pv)
+            let payload = Data([0xAA])
+            XCTAssertFalse(isTagged(n.send(payload, type: .video), payload: payload),
+                           "pv \(pv) must keep legacy framing")
+        }
+    }
+
+    func testFutureProtocolVersionsStillTag() {
+        // The gate is >=, not ==: a protocol-5 peer speaks tagged framing too.
+        var n = Negotiator()
+        n.connectionEstablished()
+        n.peerAnnounced(pv: WireProtocol.taggedFrameVersion + 1)
+        XCTAssertTrue(n.tagged)
+    }
+
+    func testPeerWithNoAdvertisedVersionIsTreatedAsProtocol1() {
+        var n = Negotiator()
+        n.connectionEstablished()
+        n.peerAnnounced(pv: WireProtocol.assumedWhenAbsent)
+        let payload = Data([0xAA])
+        XCTAssertFalse(isTagged(n.send(payload, type: .video), payload: payload))
+    }
+
+    // MARK: - Per-connection reset
+
+    func testLatchResetsWhenAnOlderPeerReconnects() {
+        // The regression this guards: a pv-4 session leaves the latch true, and
+        // a pv-3 device reconnecting inherits tagged frames it cannot read.
+        var n = Negotiator()
+        n.connectionEstablished()
+        n.peerAnnounced(pv: 4)
+        XCTAssertTrue(n.tagged)
+
+        n.connectionEstablished()
+        XCTAssertFalse(n.tagged, "a new connection must not inherit the last peer's framing")
+
+        n.peerAnnounced(pv: 3)
+        let payload = Data([0xAA])
+        XCTAssertFalse(isTagged(n.send(payload, type: .video), payload: payload))
+    }
+
+    func testReconnectToTheSamePeerRenegotiatesCleanly() {
+        var n = Negotiator()
+        for _ in 0..<3 {
+            n.connectionEstablished()
+            XCTAssertFalse(n.tagged)
+            n.peerAnnounced(pv: 4)
+            XCTAssertTrue(n.tagged)
+        }
+    }
+
+    // MARK: - Version constants
+
+    func testProtocolVersionSupportsTaggedFraming() {
+        XCTAssertGreaterThanOrEqual(WireProtocol.version, WireProtocol.taggedFrameVersion)
+    }
+
+    func testMinSupportedPeerStillAdmitsProtocol1() {
+        // Tagged framing is additive: it must not have raised the floor, or
+        // every pre-handshake install in the field is cut off.
+        XCTAssertEqual(WireProtocol.minSupportedPeer, 1)
+    }
+
+    func testPencilWireVersionUnchangedByTheFramingBump() {
+        XCTAssertEqual(WireProtocol.pencilWireVersion, 3)
+    }
+}

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,6 +1,6 @@
 # OpenDisplay Wire Protocol
 
-**Protocol version (`pv`): 3** &nbsp;|&nbsp; Status: **normative** for `pv <= 3`
+**Protocol version (`pv`): 4** &nbsp;|&nbsp; Status: **normative** for `pv <= 4`
 
 This document specifies the wire protocol spoken between an OpenDisplay
 *sender* (the machine whose desktop is extended, the Mac app today) and an
@@ -110,15 +110,25 @@ this has no protocol significance.
 
 ## 3. Framing
 
-Every message in **both directions** is length-prefixed:
+Every message in **both directions** is length-prefixed. At `pv <= 3`:
 
 ```
-[4-byte payload length, unsigned, big-endian][payload]
+[4-byte body length, unsigned, big-endian][payload]
 ```
 
-* The length counts the payload only, not the 4 header bytes.
-* A frame is either a **video frame** (section 5) or a **control message**
-  (section 6), distinguished as described in section 4.
+At `pv >= 4` the body carries an explicit type byte (section 4.1):
+
+```
+[4-byte body length, unsigned, big-endian][1-byte frame type][payload]
+```
+
+* The length counts the **body**: the payload alone at `pv <= 3`, and the
+  type byte plus the payload at `pv >= 4`. Deframing is therefore identical
+  in both eras — read 4 bytes, take that many, repeat — and only the
+  interpretation of the body changes.
+* A frame is a **video frame** (section 5), a **control message**
+  (section 6), or, at `pv >= 4`, an **audio packet**. Which one is
+  determined as described in section 4.
 * **Receiver to sender**, the payload MUST be `1` to `2^20 - 1` bytes. The
   official sender treats a length of 0 or `>= 2^20` as a protocol error and
   stops reading control messages on that connection.
@@ -159,14 +169,79 @@ Consequences that are **normative for senders**:
 
 **Deprecation.** This heuristic is a design debt, not a feature. It is
 specified here so that `pv <= 3` implementations agree on it, and it is
-**expected to be replaced by a typed frame header in `pv` 4** (a
-discriminator between the length prefix and the payload). The change will
-follow the two-phase procedure in COMPATIBILITY.md section 6: a release
-that understands both framings, then, after adoption, a release that
-requires the new one. Implementers SHOULD isolate the demux decision in
-their code so the swap is cheap, and MUST NOT build features that depend on
-the heuristic's edge cases (for example, deliberately sending binary
-control data to route it to the video path).
+**replaced by the typed frame header of `pv` 4** (section 4.1). Per the
+two-phase procedure in COMPATIBILITY.md section 6, this is phase one: a
+`pv` 4 implementation MUST still speak the heuristic to peers below 4.
+Implementers SHOULD isolate the demux decision in their code, and MUST NOT
+build features that depend on the heuristic's edge cases (for example,
+deliberately sending binary control data to route it to the video path).
+
+### 4.1 Typed frames (`pv >= 4`)
+
+At `pv >= 4` the first byte of the body names the payload's kind:
+
+| Value | Kind | Payload |
+|------:|------|---------|
+| `0` | Video | Annex B H.264 (section 5) |
+| `1` | Control | UTF-8 JSON (section 6) |
+| `2` | Audio | Compressed audio packet |
+
+* A receiver MUST ignore a frame whose type byte it does not recognize, and
+  MUST NOT treat it as a protocol error. This is what allows new frame types
+  to be added additively.
+* A tagged body MUST be at least 1 byte (the type). An empty body is
+  malformed and the frame MUST be discarded.
+* With an explicit type, the `pv <= 3` constraints on control messages
+  (under 32768 bytes, leading `{`, NUL-free) no longer apply to tagged
+  frames, and audio payloads — which satisfy none of them reliably — become
+  expressible. Senders MUST still honour those constraints when talking to a
+  `pv <= 3` peer.
+
+**Negotiation is ordered, and the order is normative.** A frame may be
+tagged only once the peer's `pv` is known to be `>= 4`, and `pv` is learned
+from `hello` (receiver to sender) and `welcome` (sender to receiver). Those
+two messages are themselves sent **before** the sender of each knows what
+its peer speaks, so:
+
+* `hello` and `welcome` MUST be sent untagged, regardless of either party's
+  own `pv`.
+* An implementation MUST NOT tag any frame until it has read the peer's
+  version, and MUST reset to untagged framing on every new connection: a
+  reconnect may reach a different peer than the last session did.
+
+A receiver therefore parses the opening frames of every connection by the
+section 4 heuristic, and switches to typed parsing only after `welcome`.
+
+### 4.2 Audio packets (`pv >= 4`)
+
+A frame of type `2` carries one compressed audio packet: a 15-byte header,
+big-endian throughout, followed by the compressed payload.
+
+| Offset | Size | Field | Meaning |
+|-------:|-----:|-------|---------|
+| 0 | 1 | `codec` | `0` = AAC-LC. Other values reserved. |
+| 1 | 1 | `flags` | bit 0 set = this packet begins a codec configuration |
+| 2 | 4 | `sampleRate` | Hz (e.g. `48000`, `44100`) |
+| 6 | 8 | `ptsMs` | IEEE 754 double: capture time on the **sender's** clock, in milliseconds |
+| 14 | 1 | `channels` | `1` = mono, `2` = stereo |
+| 15 | … | `payload` | compressed audio |
+
+* `sampleRate` is in **Hz**, not a scaled unit. Rates such as 22050 are not a
+  whole number of kHz, and a receiver decoding at a rounded rate drifts
+  against the sender for the length of the session.
+* `ptsMs` shares its clock and units with the video telemetry prefix's `cap`
+  (section 5.1). A receiver MUST map it onto its own clock with the offset
+  from section 8.1 rather than assuming a shared epoch; that shared timebase
+  is what keeps audio aligned with video without a second mechanism.
+* A receiver MUST tolerate a packet whose `codec` it does not recognize, and
+  a truncated packet, by discarding it. Audio arrives tens of times a second
+  and a malformed packet MUST NOT end the session.
+* A sender MUST NOT emit audio frames to a peer below `pv` 4: without the
+  type byte such a frame is indistinguishable from video and would be fed to
+  the video decoder.
+* Audio is **optional in both directions**. A sender may never send it, and a
+  receiver that cannot play it discards these frames and streams video
+  normally.
 
 ## 5. Video
 
@@ -641,7 +716,7 @@ Mechanics at a glance (the policy behind them lives in COMPATIBILITY.md):
 | 2 | Version handshake: `pv` in `hello` and TXT, `welcome`, `updateRequired`, `sleeping`, `closing` |
 | 3 | `pencil`, `proximity`; below pv 3 the receiver degrades stylus to `touch` |
 | 3 (additive) | `hello.cursorPort` and the UDP cursor side channel (6.3); optional, no bump |
-| 4 (reserved) | Typed frame header replacing the section 4 demux heuristic (two-phase migration) |
+| 4 | Typed frame header (4.1) replacing the section 4 demux heuristic; audio packets (4.2). Phase one: peers below 4 keep the heuristic |
 
 ---
 

--- a/Shared/AudioJitterBuffer.swift
+++ b/Shared/AudioJitterBuffer.swift
@@ -1,0 +1,146 @@
+// Compiled into the Mac sender, the iOS receiver and the Mac receiver (see
+// project.yml `sources`). Foundation-only and free of any API newer than the
+// receiver's deployment target.
+
+import Foundation
+
+/// Absorbs network jitter between arrival and playback.
+///
+/// Packets leave the Mac evenly spaced but arrive in bursts, and an audio
+/// device consumes them at a fixed rate: hand it packets exactly as they land
+/// and every late one is an audible gap. The buffer trades a little latency
+/// for continuity — it holds `targetDepth` packets before playback starts, so
+/// a burst has somewhere to go and a late packet has time to catch up.
+///
+/// Deliberately not a resampler or a clock-drift corrector. It reorders,
+/// bounds, and reports; long-run drift between the Mac's clock and the
+/// device's is left to the audio engine.
+///
+/// Not thread-safe: callers serialise on their own queue.
+struct AudioJitterBuffer {
+
+    /// Packets held before playback begins. At AAC-LC's 1024 samples per
+    /// packet and 48kHz, each packet is ~21ms, so 3 is ~64ms — enough to ride
+    /// out ordinary WiFi jitter without a latency people notice against video.
+    static let defaultTarget = 3
+    /// Hard ceiling. Past this the network is delivering faster than playback
+    /// consumes (or playback stalled); dropping the oldest keeps latency
+    /// bounded instead of letting the buffer grow into a delay.
+    static let defaultCapacity = 12
+
+    /// Ceiling for adaptive growth. At ~21ms per packet this is ~170ms, past
+    /// which audio lags the picture more than it gains in continuity — better
+    /// to accept the occasional gap than to drift visibly out of sync.
+    static let maxAdaptiveTarget = 8
+
+    private var packets: [AudioPacket] = []
+    private var started = false
+
+    /// Current pre-roll depth. Starts at `baseTarget` and grows when the link
+    /// proves too jittery for it — see `enqueue`. Never shrinks within a
+    /// session: a link that underran once will underrun again, and oscillating
+    /// the target is audible as repeated re-buffering.
+    private(set) var targetDepth: Int
+    private let baseTarget: Int
+    let capacity: Int
+    /// How many times the target has been raised — reported so a link that
+    /// needed help is distinguishable from one that never struggled.
+    private(set) var adaptations = 0
+
+    // Counters for the stats report; a silent buffer and a thrashing one look
+    // identical from outside without them.
+    private(set) var underruns = 0
+    private(set) var dropped = 0
+    private(set) var reordered = 0
+
+    var depth: Int { packets.count }
+    var isEmpty: Bool { packets.isEmpty }
+
+    init(targetDepth: Int = defaultTarget, capacity: Int = defaultCapacity) {
+        // A capacity below the target would drop packets before playback could
+        // ever start, so the buffer would never produce a sound.
+        let base = max(1, targetDepth)
+        self.baseTarget = base
+        self.targetDepth = base
+        self.capacity = max(base, capacity)
+    }
+
+    /// Raise the pre-roll depth after an underrun.
+    ///
+    /// The starting target is a guess about a link we have not measured. One
+    /// underrun is noise; repeated ones mean the guess is wrong for this
+    /// network, and the buffer should hold more before playing. Growth is
+    /// capped both by `maxAdaptiveTarget` (latency) and by `capacity` (there
+    /// must be room above the target to absorb a burst).
+    private mutating func adaptAfterUnderrun() {
+        let ceiling = min(Self.maxAdaptiveTarget, capacity - 1)
+        guard targetDepth < ceiling else { return }
+        targetDepth += 1
+        adaptations += 1
+    }
+
+    /// Queue a packet, ordering it by timestamp.
+    ///
+    /// Ordering matters because TCP guarantees byte order, not decode order
+    /// across a reconnect: a session that migrates transports can deliver a
+    /// packet from the old path after one from the new.
+    mutating func enqueue(_ packet: AudioPacket) {
+        if let last = packets.last, packet.ptsMs < last.ptsMs {
+            // Out of order: insert at the right position rather than appending.
+            let index = packets.firstIndex { $0.ptsMs > packet.ptsMs } ?? packets.count
+            packets.insert(packet, at: index)
+            reordered += 1
+        } else {
+            packets.append(packet)
+        }
+
+        while packets.count > capacity {
+            packets.removeFirst()
+            dropped += 1
+        }
+    }
+
+    /// The next packet to play, or nil while the buffer is still filling.
+    ///
+    /// Returns nil in two distinct situations that deliberately behave the
+    /// same way — pre-roll (not enough packets yet) and underrun (drained) —
+    /// because the caller's response is identical: play silence and wait. Only
+    /// the underrun counter tells them apart afterwards.
+    mutating func dequeue() -> AudioPacket? {
+        if !started {
+            guard packets.count >= targetDepth else { return nil }
+            started = true
+        }
+        guard !packets.isEmpty else {
+            underruns += 1
+            started = false     // re-fill before resuming, or we underrun every packet
+            adaptAfterUnderrun()
+            return nil
+        }
+        return packets.removeFirst()
+    }
+
+    /// Drop everything and re-arm pre-roll, keeping what has been learned
+    /// about this link. For a resume, where the held packets are stale but the
+    /// network is the same one that needed the deeper buffer.
+    mutating func reset() {
+        packets.removeAll(keepingCapacity: true)
+        started = false
+    }
+
+    /// Drop everything and forget the adaptation too. For a new session, whose
+    /// peer may be on an entirely different network — carrying over a target
+    /// grown for a bad WiFi link would add latency a cable does not need.
+    mutating func resetForNewSession() {
+        reset()
+        targetDepth = baseTarget
+        adaptations = 0
+    }
+
+    /// Zero the counters after they have been reported.
+    mutating func resetCounters() {
+        underruns = 0
+        dropped = 0
+        reordered = 0
+    }
+}

--- a/Shared/AudioPacket.swift
+++ b/Shared/AudioPacket.swift
@@ -95,4 +95,24 @@ struct AudioPacket: Equatable {
                            ptsMs: Double(bitPattern: bits),
                            payload: data.suffix(from: base + headerSize))
     }
+
+    /// The 2-byte AAC-LC AudioSpecificConfig for a sample rate and channel
+    /// count (ISO/IEC 14496-3).
+    ///
+    /// Reconstructed rather than carried on the wire: for AAC-LC it is fully
+    /// determined by these two values, both of which every packet already
+    /// carries, so sending it would be redundant bytes at ~47 packets a second.
+    ///
+    ///   5 bits  audioObjectType        2 = AAC-LC
+    ///   4 bits  samplingFrequencyIndex
+    ///   4 bits  channelConfiguration
+    ///   3 bits  zero
+    static func aacLCCookie(sampleRate: Int, channels: Int) -> Data? {
+        let rates = [96000, 88200, 64000, 48000, 44100, 32000,
+                     24000, 22050, 16000, 12000, 11025, 8000, 7350]
+        guard let index = rates.firstIndex(of: sampleRate),
+              (1...7).contains(channels) else { return nil }
+        let bits = (2 << 11) | (index << 7) | (channels << 3)
+        return Data([UInt8((bits >> 8) & 0xFF), UInt8(bits & 0xFF)])
+    }
 }

--- a/Shared/AudioPacket.swift
+++ b/Shared/AudioPacket.swift
@@ -1,0 +1,98 @@
+// Compiled into the Mac sender, the iOS receiver and the Mac receiver (see
+// project.yml `sources`). Foundation-only and free of any API newer than the
+// receiver's deployment target — the receiver app is pinned several majors
+// below the sender.
+
+import Foundation
+
+/// One compressed audio packet as it crosses the wire, inside a frame tagged
+/// `FrameType.audio` (PROTOCOL.md 4.1).
+///
+/// Layout, big-endian throughout, 15 bytes of header then the payload:
+///
+/// ```
+/// [1] codec        0 = AAC-LC
+/// [1] flags        bit0 = codec config present
+/// [4] sampleRate   Hz  (44100, 48000, …)
+/// [8] ptsMs        IEEE 754 double — capture time on the SENDER's clock
+/// [1] channels     1 = mono, 2 = stereo
+/// [.] payload      compressed audio
+/// ```
+///
+/// The sample rate is carried in plain Hz rather than a scaled unit. A
+/// narrower field tempts a kHz-based encoding, and rates like 22050 are not a
+/// whole number of any kHz unit — they round, and a receiver decoding at the
+/// rounded rate drifts against the sender for the length of the session.
+///
+/// `ptsMs` is deliberately on the sender's clock and in the same units as the
+/// video path's `cap` timestamp, so a receiver maps it to its own clock with
+/// the ping/pong offset it already computes for video. That shared timebase is
+/// what keeps audio and video aligned without a second synchronisation
+/// mechanism.
+struct AudioPacket: Equatable {
+
+    enum Codec: UInt8 {
+        case aacLC = 0
+    }
+
+    static let headerSize = 15
+
+    var codec: Codec = .aacLC
+    /// True when `payload` is preceded by, or accompanied by, codec setup the
+    /// decoder needs (AAC's AudioSpecificConfig). Re-sent on reconfiguration so
+    /// a receiver that joined late can still start decoding.
+    var hasConfig = false
+    var sampleRate: Int
+    var channels: Int
+    var ptsMs: Double
+    var payload: Data
+
+    // MARK: - Encoding
+
+    func encoded() -> Data {
+        var out = Data(capacity: Self.headerSize + payload.count)
+        out.append(codec.rawValue)
+        out.append(hasConfig ? 0x01 : 0x00)
+        var rate = UInt32(clamping: sampleRate).bigEndian
+        withUnsafeBytes(of: &rate) { out.append(contentsOf: $0) }
+        var bits = ptsMs.bitPattern.bigEndian
+        withUnsafeBytes(of: &bits) { out.append(contentsOf: $0) }
+        out.append(UInt8(clamping: channels))
+        out.append(payload)
+        return out
+    }
+
+    // MARK: - Decoding
+
+    /// Parse a packet, or nil if the bytes are too short or name a codec this
+    /// build does not know.
+    ///
+    /// Returning nil rather than throwing keeps the caller's job simple: an
+    /// undecodable packet is dropped like a late one, never fatal. A malformed
+    /// packet must not be able to take the session down — it arrives from the
+    /// network at ~50 packets a second.
+    static func decode(_ data: Data) -> AudioPacket? {
+        guard data.count >= headerSize else { return nil }
+        // Index from startIndex: a Data sliced out of the receive buffer does
+        // not start at zero, and assuming it does reads the wrong bytes.
+        let base = data.startIndex
+        func byte(_ offset: Int) -> UInt8 { data[base + offset] }
+
+        guard let codec = Codec(rawValue: byte(0)) else { return nil }
+        var rate: UInt32 = 0
+        for i in 0..<4 { rate = (rate << 8) | UInt32(byte(2 + i)) }
+        let sampleRate = Int(rate)
+        let channels = Int(byte(14))
+        guard sampleRate > 0, channels > 0 else { return nil }
+
+        var bits: UInt64 = 0
+        for i in 0..<8 { bits = (bits << 8) | UInt64(byte(6 + i)) }
+
+        return AudioPacket(codec: codec,
+                           hasConfig: byte(1) & 0x01 != 0,
+                           sampleRate: sampleRate,
+                           channels: channels,
+                           ptsMs: Double(bitPattern: bits),
+                           payload: data.suffix(from: base + headerSize))
+    }
+}

--- a/Shared/AudioPlayer.swift
+++ b/Shared/AudioPlayer.swift
@@ -42,6 +42,13 @@ final class AudioPlayer {
     private var running = false
     private var loggedFormat = false
     private var loggedStartFailure = false
+    /// Packets handed to the player node and not yet consumed by it. See
+    /// `maxScheduled` — this is the backpressure that paces playback.
+    private var scheduled = 0
+    private var decodeFailures = 0
+    private var loggedFirstPlayback = false
+    private var loggedDryStatus = false
+    private var loggedNoDescriptions = false
 
     /// User-facing mute. Packets keep flowing and the buffer keeps draining —
     /// muting only silences output, so unmuting resumes in sync instead of
@@ -56,6 +63,7 @@ final class AudioPlayer {
             guard let self, !self.running else { return }
             self.running = true
             self.buffer.reset()
+            self.scheduled = 0
             self.startDrainTimer()
         }
     }
@@ -80,9 +88,12 @@ final class AudioPlayer {
             self.player.stop()
             if self.engine.isRunning { self.engine.stop() }
             self.buffer.reset()
+            self.scheduled = 0
             self.converter = nil
             self.sourceFormat = nil
             self.loggedFormat = false
+            self.loggedFirstPlayback = false
+            self.decodeFailures = 0
         }
     }
 
@@ -92,6 +103,7 @@ final class AudioPlayer {
         queue.async { [weak self] in
             guard let self else { return }
             self.buffer.reset()
+            self.scheduled = 0
             self.player.stop()
             if self.engine.isRunning { self.player.play() }
         }
@@ -136,12 +148,11 @@ final class AudioPlayer {
 
     // MARK: - Playback
 
-    /// Move packets from the buffer into the engine.
+    /// Wake up often enough to keep the engine topped up.
     ///
-    /// A timer rather than a pull callback: `scheduleBuffer` is push-driven, so
-    /// something has to decide when to push. The interval is shorter than one
-    /// AAC packet's duration (~21ms at 48kHz) so the engine is topped up before
-    /// it drains rather than after.
+    /// The tick only decides *when to look*; `maxScheduled` decides how much is
+    /// actually handed over, so a fast tick costs nothing and simply means the
+    /// engine is refilled promptly once it has room.
     private func startDrainTimer() {
         drainTimer?.cancel()
         let timer = DispatchSource.makeTimerSource(queue: queue)
@@ -151,23 +162,50 @@ final class AudioPlayer {
         drainTimer = timer
     }
 
+    /// How many packets may sit scheduled inside the player node at once.
+    ///
+    /// This, not the timer, is what paces playback: a packet is pulled only
+    /// when the engine has room, so the buffer drains at exactly the rate the
+    /// hardware consumes audio. The earlier version pulled a fixed two packets
+    /// per 10 ms tick — 200/s against an arrival rate of ~47/s (1024 samples at
+    /// 48 kHz is ~21 ms of audio) — so it emptied the buffer roughly four times
+    /// faster than it filled and underran continuously.
+    private static let maxScheduled = 3
+
     private func drain() {
         guard running else { return }
-        // Bounded per tick: after a stall the buffer may hold many packets, and
-        // scheduling all of them at once would hand the engine a burst it plays
-        // as fast as it can. Two per 10ms tick outruns real-time (~21ms per
-        // packet) enough to recover without racing.
-        for _ in 0..<2 {
+        while scheduled < Self.maxScheduled {
             guard let packet = buffer.dequeue() else { return }
             play(packet)
         }
     }
 
     private func play(_ packet: AudioPacket) {
-        guard let pcm = decode(packet) else { return }
+        guard let pcm = decode(packet) else {
+            // Silence with a full buffer means every packet is failing to
+            // decode; without this the two are indistinguishable from outside.
+            decodeFailures += 1
+            if decodeFailures == 1 || decodeFailures % 200 == 0 {
+                Log.info("audio: decode failed (\(decodeFailures) so far) — no sound")
+            }
+            return
+        }
         guard ensureEngineRunning(for: pcm.format) else { return }
+        if !loggedFirstPlayback {
+            loggedFirstPlayback = true
+            Log.info("audio: playing \(Int(pcm.format.sampleRate))Hz "
+                     + "\(pcm.format.channelCount)ch, engine running=\(engine.isRunning) "
+                     + "volume=\(player.volume) muted=\(isMuted)")
+        }
         if isMuted { return }   // decoded and dequeued, just not heard
-        player.scheduleBuffer(pcm, completionHandler: nil)
+        // The completion handler is the pacing signal: it fires when the engine
+        // has consumed this buffer, which is what lets `drain` pull the next
+        // one at the hardware's rate instead of a timer's.
+        scheduled += 1
+        player.scheduleBuffer(pcm) { [weak self] in
+            guard let self else { return }
+            self.queue.async { self.scheduled = max(0, self.scheduled - 1) }
+        }
         if !player.isPlaying { player.play() }
     }
 
@@ -189,13 +227,25 @@ final class AudioPlayer {
         }
         // AAC-LC is 1024 samples per packet; the description tells the decoder
         // how much of `data` this packet occupies.
+        // A nil descriptor array means the decoder gets no packet boundary and
+        // rejects the frame — worth knowing, since it fails identically to a
+        // malformed payload.
+        if compressed.packetDescriptions == nil, !loggedNoDescriptions {
+            loggedNoDescriptions = true
+            Log.info("audio: compressed buffer has no packetDescriptions — decoder will reject frames")
+        }
         compressed.packetDescriptions?.pointee = AudioStreamPacketDescription(
             mStartOffset: 0,
             mVariableFramesInPacket: 0,
             mDataByteSize: UInt32(packet.payload.count))
 
         guard let pcm = AVAudioPCMBuffer(pcmFormat: outputFormat,
-                                         frameCapacity: 2048) else { return nil }
+        // Exactly one AAC-LC frame: 1024 samples, which is what one packet
+        // decodes to. Asking for more (this was 2048) makes the converter
+        // consume the packet, find it cannot fill the request, and return
+        // inputRanDry having produced no PCM at all — a silent failure on every
+        // single packet, with a perfectly valid frame going in.
+                                         frameCapacity: 1024) else { return nil }
 
         var supplied = false
         var error: NSError?
@@ -213,6 +263,14 @@ final class AudioPlayer {
         case .haveData:
             return pcm.frameLength > 0 ? pcm : nil
         case .inputRanDry, .endOfStream:
+            // Not an error in AVAudioConverter's eyes, so the `.error` branch
+            // never fires and nothing was logged — which is why a decode that
+            // fails on every packet looked silent from outside.
+            if !loggedDryStatus {
+                loggedDryStatus = true
+                Log.info("audio: converter returned \(status == .inputRanDry ? "inputRanDry" : "endOfStream")"
+                         + " for a \(packet.payload.count)B packet — no PCM produced")
+            }
             return nil
         case .error:
             if let error { Log.info("audio decode error: \(error)") }
@@ -236,6 +294,14 @@ final class AudioPlayer {
             mReserved: 0)
         guard let inFormat = AVAudioFormat(streamDescription: &description) else { return nil }
 
+        // AAC needs its AudioSpecificConfig before it can decode anything, and
+        // an ASBD alone does not carry one — without it the decoder builds
+        // happily and then rejects every frame, which is exactly what it did.
+        //
+        // For AAC-LC the config is two bytes fully determined by the sample
+        // rate and channel count, so it is reconstructed below rather than
+        // sent, and applied to the converter once it exists.
+
         if let converter, let sourceFormat, sourceFormat == inFormat { return converter }
 
         // Float32 deinterleaved is what AVAudioEngine wants; letting it convert
@@ -245,6 +311,11 @@ final class AudioPlayer {
               let made = AVAudioConverter(from: inFormat, to: outFormat) else {
             Log.info("audio: no decoder for \(packet.sampleRate)Hz \(packet.channels)ch")
             return nil
+        }
+
+        if let cookie = AudioPacket.aacLCCookie(sampleRate: packet.sampleRate,
+                                                channels: packet.channels) {
+            made.magicCookie = cookie
         }
 
         converter = made

--- a/Shared/AudioPlayer.swift
+++ b/Shared/AudioPlayer.swift
@@ -1,0 +1,290 @@
+// Compiled into the iOS receiver and the Mac receiver (see project.yml
+// `sources`). Everything here must exist on the RECEIVER's deployment target,
+// which is several majors below the sender's — CI builds the receiver app to
+// catch a newer API sneaking in.
+
+import AVFoundation
+import Foundation
+
+/// A snapshot of the audio path's health, for the overlay and the wire report.
+struct AudioStats {
+    var depth = 0          // packets held right now
+    var target = 0         // pre-roll depth, which adapts upward on underruns
+    var underruns = 0
+    var dropped = 0
+    var reordered = 0
+    var adaptations = 0    // times the target grew this session
+}
+
+/// Decodes AAC audio packets and plays them.
+///
+/// Feeding is decoupled from playback by a jitter buffer: packets arrive in
+/// network bursts, the engine consumes them at a fixed rate. A drain timer
+/// moves packets between the two, so a late packet costs latency rather than
+/// a gap.
+///
+/// Every failure here is non-fatal by construction. Audio is an optional
+/// addition to a display, and a device that cannot decode it must still show
+/// the picture.
+final class AudioPlayer {
+
+    private let engine = AVAudioEngine()
+    private let player = AVAudioPlayerNode()
+    private var converter: AVAudioConverter?
+    private var sourceFormat: AVAudioFormat?
+    private var outputFormat: AVAudioFormat?
+
+    /// Serialises the buffer and the engine; packets arrive on the network
+    /// queue and the drain timer fires on its own.
+    private let queue = DispatchQueue(label: "receiver.audio")
+    private var buffer = AudioJitterBuffer()
+    private var drainTimer: DispatchSourceTimer?
+    private var running = false
+    private var loggedFormat = false
+    private var loggedStartFailure = false
+
+    /// User-facing mute. Packets keep flowing and the buffer keeps draining —
+    /// muting only silences output, so unmuting resumes in sync instead of
+    /// playing a backlog.
+    var isMuted = false
+
+    // MARK: - Lifecycle
+
+    /// Prepare the engine. Safe to call repeatedly.
+    func start() {
+        queue.async { [weak self] in
+            guard let self, !self.running else { return }
+            self.running = true
+            self.buffer.reset()
+            self.startDrainTimer()
+        }
+    }
+
+    /// Start a new session: drop held audio and forget the buffer depth
+    /// learned from the previous peer, which may have been on a different
+    /// network entirely.
+    func startNewSession() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.buffer.resetForNewSession()
+        }
+        start()
+    }
+
+    func stop() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.running = false
+            self.drainTimer?.cancel()
+            self.drainTimer = nil
+            self.player.stop()
+            if self.engine.isRunning { self.engine.stop() }
+            self.buffer.reset()
+            self.converter = nil
+            self.sourceFormat = nil
+            self.loggedFormat = false
+        }
+    }
+
+    /// Drop buffered audio without tearing the engine down — for a new session
+    /// or a resume, where held packets are stale.
+    func flush() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.buffer.reset()
+            self.player.stop()
+            if self.engine.isRunning { self.player.play() }
+        }
+    }
+
+    // MARK: - Feeding
+
+    func enqueue(_ packet: AudioPacket) {
+        queue.async { [weak self] in
+            guard let self, self.running else { return }
+            self.buffer.enqueue(packet)
+        }
+    }
+
+    /// Counters for the stats report, and the current buffer depth.
+    ///
+    /// Consuming: the counters are zeroed, so each reported figure covers the
+    /// interval since the last call. Use `peekStats` for anything that reads
+    /// more often, or it will starve this of counts.
+    func drainStats() -> AudioStats {
+        queue.sync {
+            let stats = currentStats
+            buffer.resetCounters()
+            return stats
+        }
+    }
+
+    /// The same figures without clearing them — for the live overlay, which
+    /// samples every second while the wire report drains every five.
+    func peekStats() -> AudioStats {
+        queue.sync { currentStats }
+    }
+
+    private var currentStats: AudioStats {
+        AudioStats(depth: buffer.depth,
+                   target: buffer.targetDepth,
+                   underruns: buffer.underruns,
+                   dropped: buffer.dropped,
+                   reordered: buffer.reordered,
+                   adaptations: buffer.adaptations)
+    }
+
+    // MARK: - Playback
+
+    /// Move packets from the buffer into the engine.
+    ///
+    /// A timer rather than a pull callback: `scheduleBuffer` is push-driven, so
+    /// something has to decide when to push. The interval is shorter than one
+    /// AAC packet's duration (~21ms at 48kHz) so the engine is topped up before
+    /// it drains rather than after.
+    private func startDrainTimer() {
+        drainTimer?.cancel()
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now(), repeating: .milliseconds(10))
+        timer.setEventHandler { [weak self] in self?.drain() }
+        timer.resume()
+        drainTimer = timer
+    }
+
+    private func drain() {
+        guard running else { return }
+        // Bounded per tick: after a stall the buffer may hold many packets, and
+        // scheduling all of them at once would hand the engine a burst it plays
+        // as fast as it can. Two per 10ms tick outruns real-time (~21ms per
+        // packet) enough to recover without racing.
+        for _ in 0..<2 {
+            guard let packet = buffer.dequeue() else { return }
+            play(packet)
+        }
+    }
+
+    private func play(_ packet: AudioPacket) {
+        guard let pcm = decode(packet) else { return }
+        guard ensureEngineRunning(for: pcm.format) else { return }
+        if isMuted { return }   // decoded and dequeued, just not heard
+        player.scheduleBuffer(pcm, completionHandler: nil)
+        if !player.isPlaying { player.play() }
+    }
+
+    // MARK: - Decoding
+
+    private func decode(_ packet: AudioPacket) -> AVAudioPCMBuffer? {
+        guard let converter = converter(for: packet),
+              let outputFormat else { return nil }
+
+        let compressed = AVAudioCompressedBuffer(
+            format: converter.inputFormat,
+            packetCapacity: 1,
+            maximumPacketSize: max(packet.payload.count, 1))
+        compressed.byteLength = UInt32(packet.payload.count)
+        compressed.packetCount = 1
+        packet.payload.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress else { return }
+            compressed.data.copyMemory(from: base, byteCount: packet.payload.count)
+        }
+        // AAC-LC is 1024 samples per packet; the description tells the decoder
+        // how much of `data` this packet occupies.
+        compressed.packetDescriptions?.pointee = AudioStreamPacketDescription(
+            mStartOffset: 0,
+            mVariableFramesInPacket: 0,
+            mDataByteSize: UInt32(packet.payload.count))
+
+        guard let pcm = AVAudioPCMBuffer(pcmFormat: outputFormat,
+                                         frameCapacity: 2048) else { return nil }
+
+        var supplied = false
+        var error: NSError?
+        let status = converter.convert(to: pcm, error: &error) { _, outStatus in
+            if supplied {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            supplied = true
+            outStatus.pointee = .haveData
+            return compressed
+        }
+
+        switch status {
+        case .haveData:
+            return pcm.frameLength > 0 ? pcm : nil
+        case .inputRanDry, .endOfStream:
+            return nil
+        case .error:
+            if let error { Log.info("audio decode error: \(error)") }
+            return nil
+        @unknown default:
+            return nil
+        }
+    }
+
+    /// Build (or reuse) the decoder for this packet's format.
+    private func converter(for packet: AudioPacket) -> AVAudioConverter? {
+        var description = AudioStreamBasicDescription(
+            mSampleRate: Double(packet.sampleRate),
+            mFormatID: kAudioFormatMPEG4AAC,
+            mFormatFlags: 0,
+            mBytesPerPacket: 0,
+            mFramesPerPacket: 1024,
+            mBytesPerFrame: 0,
+            mChannelsPerFrame: UInt32(packet.channels),
+            mBitsPerChannel: 0,
+            mReserved: 0)
+        guard let inFormat = AVAudioFormat(streamDescription: &description) else { return nil }
+
+        if let converter, let sourceFormat, sourceFormat == inFormat { return converter }
+
+        // Float32 deinterleaved is what AVAudioEngine wants; letting it convert
+        // again downstream would be a second resample for nothing.
+        guard let outFormat = AVAudioFormat(standardFormatWithSampleRate: Double(packet.sampleRate),
+                                            channels: AVAudioChannelCount(packet.channels)),
+              let made = AVAudioConverter(from: inFormat, to: outFormat) else {
+            Log.info("audio: no decoder for \(packet.sampleRate)Hz \(packet.channels)ch")
+            return nil
+        }
+
+        converter = made
+        sourceFormat = inFormat
+        outputFormat = outFormat
+        if !loggedFormat {
+            loggedFormat = true
+            Log.info("audio: decoding \(packet.sampleRate)Hz \(packet.channels)ch")
+        }
+        // The graph is wired for the old format; rebuild it for this one.
+        teardownGraph()
+        return made
+    }
+
+    // MARK: - Engine
+
+    private func ensureEngineRunning(for format: AVAudioFormat) -> Bool {
+        if engine.isRunning, player.engine != nil { return true }
+
+        if player.engine == nil { engine.attach(player) }
+        engine.connect(player, to: engine.mainMixerNode, format: format)
+        do {
+            try engine.start()
+            player.play()
+            loggedStartFailure = false
+            return true
+        } catch {
+            // Log once: this is called per packet, and a device that refuses to
+            // start the engine refuses every time.
+            if !loggedStartFailure {
+                loggedStartFailure = true
+                Log.info("audio: engine would not start (\(error)) — no playback")
+            }
+            return false
+        }
+    }
+
+    private func teardownGraph() {
+        player.stop()
+        if engine.isRunning { engine.stop() }
+        if player.engine != nil { engine.disconnectNodeOutput(player) }
+    }
+}

--- a/Shared/FrameCodec.swift
+++ b/Shared/FrameCodec.swift
@@ -1,0 +1,69 @@
+// Compiled into the Mac sender, the iOS receiver and the Mac receiver (see
+// project.yml `sources`). Keep this Foundation-only so it stays platform-
+// neutral, and keep it free of any API newer than the receiver's deployment
+// target — the receiver app is pinned several majors below the sender.
+
+import Foundation
+
+/// Wire framing, owned in one place so the sender and receiver cannot drift
+/// apart on it.
+///
+/// Legacy (protocol < 4):  [4-byte big-endian length][payload]
+/// Tagged (protocol 4+):   [4-byte big-endian length][1-byte type][payload]
+///
+/// The length covers the type byte, so the deframing loop's bounds arithmetic
+/// is identical in both eras: read 4, read that many, repeat. Only the
+/// interpretation of the bytes that follow changes.
+enum FrameCodec {
+
+    /// Frame `payload` for a peer that speaks `tagged` framing or not.
+    ///
+    /// The tag is a *negotiated* capability, never assumed: passing
+    /// `tagged: false` reproduces the pre-protocol-4 wire byte for byte, which
+    /// is what lets a protocol-4 build talk to every install already in the
+    /// field.
+    static func encode(_ payload: Data, type: FrameType, tagged: Bool) -> Data {
+        let bodyCount = tagged ? payload.count + 1 : payload.count
+        var frame = Data(capacity: bodyCount + 4)
+        var header = UInt32(bodyCount).bigEndian
+        withUnsafeBytes(of: &header) { frame.append(contentsOf: $0) }
+        if tagged { frame.append(type.rawValue) }
+        frame.append(payload)
+        return frame
+    }
+
+    /// One deframed frame: its declared kind and its bytes.
+    struct Frame {
+        let type: FrameType?    // nil = tagged frame carrying an unknown type
+        let payload: Data
+    }
+
+    /// Split a frame body into its type and payload.
+    ///
+    /// `tagged` says how to read it, and is the caller's negotiated per-
+    /// connection state rather than anything inferred from these bytes. When
+    /// false, the kind is recovered with the legacy heuristic — see
+    /// `looksLikeJSON`.
+    ///
+    /// Returns nil only for a tagged body that is empty (no room for the type
+    /// byte), which is a malformed frame.
+    static func decode(body: Data, tagged: Bool) -> Frame? {
+        guard tagged else {
+            return Frame(type: looksLikeJSON(body) ? .json : .video, payload: body)
+        }
+        guard let first = body.first else { return nil }
+        return Frame(type: FrameType(rawValue: first),
+                     payload: body.dropFirst())
+    }
+
+    /// The pre-protocol-4 heuristic, preserved exactly as it behaved when it
+    /// was the only way to tell a frame's kind.
+    ///
+    /// It is retained *only* for peers below protocol 4. Tagged frames never
+    /// consult it, which is the point of the tag: the ambiguity it papers over
+    /// (a video frame's leading `{`, ruled out by the NUL bytes in Annex B
+    /// start codes) has no equivalent answer once audio is on the wire.
+    static func looksLikeJSON(_ data: Data) -> Bool {
+        data.count < 32_768 && data.first == UInt8(ascii: "{") && !data.contains(0x00)
+    }
+}

--- a/Shared/PerfOverlay.swift
+++ b/Shared/PerfOverlay.swift
@@ -45,6 +45,20 @@ struct PerfOverlay: View {
                     // the render+capture wait and one e2e on top.
                     metric("input", String(format: "%.0f ms", stats.inputP50))
                 }
+                if stats.audioE2eP50 > 0 {
+                    metric("audio", String(format: "%.0f ms", stats.audioE2eP50))
+                    // The sync number: audio latency minus video latency.
+                    // Signed, because which one leads matters — a viewer
+                    // tolerates sound slightly late far better than early.
+                    metric("A/V skew", String(format: "%+.0f ms", stats.avSkewMs))
+                    metric("buffer", "\(stats.audioDepth)/\(stats.audioTarget)")
+                    if stats.audioUnderruns > 0 {
+                        metric("a-under", "\(stats.audioUnderruns)")
+                    }
+                    if stats.audioDrops > 0 {
+                        metric("a↓", "\(stats.audioDrops)")
+                    }
+                }
                 metric("rtt", String(format: "%.0f ms", stats.rttMs))
                 metric("FPS", "\(stats.fps)")
                 if stats.capFps > 0 {

--- a/Shared/Protocol.swift
+++ b/Shared/Protocol.swift
@@ -11,11 +11,16 @@ import Foundation
 /// protocol 1 — that's every install in the field that predates the handshake.
 enum WireProtocol {
     /// The protocol version this build speaks.
-    static let version = 3
+    static let version = 4
 
     /// Protocol version that introduced Apple Pencil / proximity wire messages.
     /// Peers below this get pencil input as legacy `touch` events.
     static let pencilWireVersion = 3
+
+    /// Protocol version that introduced tagged frames (see `FrameType`). Below
+    /// this, a frame's kind is inferred from its bytes; at or above it, the
+    /// frame carries an explicit type byte and audio becomes expressible.
+    static let taggedFrameVersion = 4
 
     /// Oldest peer protocol version this build still supports. Stays at 1
     /// (support everything) until a deliberate two-phase breaking change
@@ -24,6 +29,26 @@ enum WireProtocol {
 
     /// A peer that advertises no `pv` is defined as protocol 1.
     static let assumedWhenAbsent = 1
+}
+
+/// What a frame carries, as the explicit type byte of a tagged frame
+/// (protocol 4+, PROTOCOL.md 5).
+///
+/// Before protocol 4 the kind was *inferred*: a payload starting with `{` and
+/// containing no NUL byte was control JSON, anything else was video. That
+/// worked only because the two kinds happened to be distinguishable — video
+/// frames also begin with `{` (a telemetry prefix) and were told apart by the
+/// NUL bytes in their Annex B start codes. Compressed audio has neither
+/// property reliably, so a third kind cannot join that scheme: an audio packet
+/// whose first byte is `{` and which contains no NUL would be parsed as JSON.
+/// Hence the explicit tag.
+///
+/// Unknown raw values are skipped by the receiver rather than treated as an
+/// error, which is what keeps a future type additive for older peers.
+enum FrameType: UInt8 {
+    case video = 0      // Annex B H.264
+    case json = 1       // control message
+    case audio = 2      // compressed audio packet (AudioPacket)
 }
 
 /// Control-message `type` strings introduced with the handshake. The pre-

--- a/Shared/StreamReceiver.swift
+++ b/Shared/StreamReceiver.swift
@@ -51,6 +51,18 @@ struct PerfStats: Equatable {
     var decodeP50 = 0.0          // VTDecompressionSession decode, ms
     var photonP50 = 0.0          // Mac capture → frame actually on glass, ms
     var photonP95 = 0.0
+    // Audio, measured on the same clock as e2eP50 above (Mac capture →
+    // arrival here, via the ping/pong offset), so the two are comparable.
+    var audioE2eP50 = 0.0
+    // Audio latency minus video latency. Positive = audio is behind the
+    // picture, negative = ahead. This is the number that says whether the two
+    // are in sync; the individual latencies only say how far behind live
+    // everything is.
+    var avSkewMs = 0.0
+    var audioDepth = 0           // jitter buffer occupancy, packets
+    var audioTarget = 0          // pre-roll depth; grows if the link underruns
+    var audioUnderruns = 0       // buffer ran dry (this report)
+    var audioDrops = 0           // packets dropped at capacity (this report)
 }
 
 // MARK: - Peer-driven update signals (issue #132)
@@ -81,6 +93,34 @@ final class StreamReceiver: ObservableObject {
     private var listener: NWListener?
     private var listenerHealthy = false
     private var connection: NWConnection?
+    /// Whether this connection's sender tags its frames (protocol 4+).
+    ///
+    /// Per-connection, and false until `welcome` says otherwise: our own
+    /// `hello` goes out before we know what the sender speaks, and its
+    /// `welcome` arrives as a legacy frame for the same reason. Reset when a
+    /// connection is adopted, so a session inherits nothing from the last one.
+    private var senderSpeaksTaggedFrames = false
+    /// Log-once guards: an unreadable frame kind repeats at frame rate, and a
+    /// per-frame log would bury the rest of the session's diagnostics.
+    private var loggedUnknownFrameType = false
+    private var loggedAudioFormat = false
+    private var loggedAudioMalformed = false
+    /// Audio arrival counters, reported alongside the video stats so the
+    /// audio path is visible in the same place as the rest of the pipeline.
+    private var audioPacketsThisWindow = 0
+    private var audioBytesThisWindow = 0
+    /// Per-packet audio latencies, same units and clock as `e2eWindow`.
+    private var audioE2eWindow: [Double] = []
+    /// Decode and playback for the audio channel. Created eagerly but idle
+    /// until packets arrive, so a session that never carries audio pays only
+    /// the allocation.
+    private let audioPlayer = AudioPlayer()
+
+    /// Silence audio without interrupting the stream. Published so the UI can
+    /// bind a toggle to it.
+    @Published var audioMuted = false {
+        didSet { audioPlayer.isMuted = audioMuted }
+    }
     // Cursor side channel: UDP on port+1. Cursor positions ride TCP behind
     // multi-hundred-KB video frames, so over WiFi one late frame stalls the
     // cursor with it (head-of-line blocking). UDP datagrams skip that queue.
@@ -354,6 +394,16 @@ final class StreamReceiver: ObservableObject {
             guard paused != self.renderingPaused else { return }
             self.renderingPaused = paused
             Log.info(paused ? "rendering paused (backgrounded)" : "rendering resumed")
+            // Audio follows video: this build claims no background audio mode,
+            // so continuing to play while backgrounded is not available to us
+            // anyway. Flushing on resume drops what buffered while hidden
+            // rather than replaying it late against a fresh picture.
+            if paused {
+                self.audioPlayer.stop()
+            } else {
+                self.audioPlayer.flush()
+                self.audioPlayer.start()
+            }
             if !paused {
                 self.displayLayer.flush()
                 if self.connection?.state == .ready {
@@ -396,6 +446,7 @@ final class StreamReceiver: ObservableObject {
                 self.listener = nil
                 self.listenerHealthy = false
                 self.stopCursorListener()
+                self.audioPlayer.stop()
                 self.setConnected(false)
                 self.setStatus(status)
                 completion?()
@@ -632,6 +683,19 @@ final class StreamReceiver: ObservableObject {
         resetStreamState()
         lastCursorSeq = 0   // the sender restarts its cursor sequence per session
         cursorPortAnnounced = false
+        // Assume legacy framing until this session's sender identifies itself;
+        // a new session may be a different, older Mac than the last one.
+        senderSpeaksTaggedFrames = false
+        loggedUnknownFrameType = false
+        loggedAudioFormat = false
+        loggedAudioMalformed = false
+        audioPacketsThisWindow = 0
+        audioBytesThisWindow = 0
+        // Any audio still buffered belongs to the previous sender; playing it
+        // would be an audible blip of the old session over the new one. A new
+        // peer also gets a fresh buffer target — it may be on a different
+        // network than the one the last target was grown for.
+        audioPlayer.startNewSession()
         // Hide the previous sender's cursor: replayed into a fresh video view
         // it would ghost over a new sender that never sends one (mirror mode
         // hides no local cursor and streams no sprite).
@@ -771,6 +835,15 @@ final class StreamReceiver: ObservableObject {
             let macPV = obj["pv"] as? Int ?? WireProtocol.assumedWhenAbsent
             DispatchQueue.main.async {
                 self.macProtocolVersion = macPV
+            }
+            // This message itself arrived untagged — the sender could not know
+            // what we speak until it read our `hello`. Every frame after it may
+            // be tagged, so the switch happens here, on the connection's queue,
+            // before the next frame is drained.
+            let tagged = macPV >= WireProtocol.taggedFrameVersion
+            if tagged != senderSpeaksTaggedFrames {
+                senderSpeaksTaggedFrames = tagged
+                Log.info("framing: \(tagged ? "tagged" : "legacy") (sender pv \(macPV))")
             }
             if macPV < WireProtocol.minSupportedPeer {
                 let msg = "The OpenDisplay app on your Mac is too old for this \(deviceKind) app. Update OpenDisplay on your Mac to reconnect."
@@ -946,9 +1019,12 @@ final class StreamReceiver: ObservableObject {
             completion?()
             return
         }
-        var header = UInt32(payload.count).bigEndian
-        var frame = Data(bytes: &header, count: 4)
-        frame.append(payload)
+        // Deliberately untagged, at every protocol version: receiver-to-sender
+        // frames are all JSON control messages (PROTOCOL.md 4 — "the sender
+        // needs no demux"), so there is nothing for a type byte to
+        // disambiguate. Tagging this direction would be a wire change with no
+        // reader, and would break every sender below pv 4.
+        let frame = FrameCodec.encode(payload, type: .json, tagged: false)
         conn.send(content: frame, completion: .contentProcessed { error in
             if let error { Log.info("control send error: \(error)") }
             completion?()
@@ -991,24 +1067,85 @@ final class StreamReceiver: ObservableObject {
             guard buffer.distance(from: cursor, to: buffer.endIndex) >= 4 + len else { break }
             let start = buffer.index(cursor, offsetBy: 4)
             let end = buffer.index(start, offsetBy: len)
-            handleAnnexB(Data(buffer[start..<end]))
+            route(body: Data(buffer[start..<end]))
             cursor = end
         }
         buffer.removeSubrange(buffer.startIndex..<cursor)
     }
 
+    /// Send one deframed body to whatever handles its kind.
+    ///
+    /// How the kind is determined depends on the sender: a protocol-4 sender
+    /// tags it explicitly, an older one leaves it to be inferred. Which of the
+    /// two applies is `senderSpeaksTaggedFrames`, latched from `welcome` — it
+    /// is never guessed from the bytes, because the whole reason for the tag
+    /// is that guessing stops working once audio shares the wire.
+    private func route(body: Data) {
+        guard let frame = FrameCodec.decode(body: body, tagged: senderSpeaksTaggedFrames) else {
+            Log.info("dropping malformed empty tagged frame")
+            return
+        }
+        switch frame.type {
+        case .json:
+            handleVideoChannelJSON(frame.payload)
+        case .video:
+            handleAnnexB(frame.payload)
+        case .audio:
+            handleAudioPacket(frame.payload)
+        case nil:
+            // A type this build does not know: skip it. This is what makes a
+            // future frame type additive rather than a breaking change.
+            if !loggedUnknownFrameType {
+                loggedUnknownFrameType = true
+                Log.info("ignoring frame of unknown type (sender speaks a newer protocol)")
+            }
+        }
+    }
+
+    // MARK: - Audio
+
+    /// Parse an audio packet and account for it.
+    ///
+    /// Phase 2 verifies the whole path — capture, encode, frame, deframe,
+    /// parse — with nothing audible to get wrong; phase 3 adds the decoder and
+    /// playback. Counting packets and logging the format once is what makes
+    /// the path observable in the meantime.
+    private func handleAudioPacket(_ data: Data) {
+        guard let packet = AudioPacket.decode(data) else {
+            if !loggedAudioMalformed {
+                loggedAudioMalformed = true
+                Log.info("audio: undecodable packet (\(data.count) bytes) — ignoring")
+            }
+            return
+        }
+        audioPacketsThisWindow += 1
+        audioBytesThisWindow += packet.payload.count
+
+        // Audio's own end-to-end latency, computed exactly as video's is
+        // (StreamReceiver.enqueueFrame) so the two are directly comparable:
+        // the packet's sender-clock capture time against our clock, mapped
+        // through the ping/pong offset. Comparing them is what turns two
+        // latencies into an A/V sync measurement.
+        if let offset = clockOffsetMs {
+            let e2e = (nowMs + offset) - packet.ptsMs
+            // Same sanity window as the video path: a wild value means the
+            // offset is not settled yet, not that audio is 4 seconds late.
+            if e2e > -50, e2e < 5000 {
+                audioE2eWindow.append(e2e)
+                if audioE2eWindow.count > maxSamples { audioE2eWindow.removeFirst() }
+            }
+        }
+        if !loggedAudioFormat {
+            loggedAudioFormat = true
+            Log.info("audio: receiving \(packet.sampleRate)Hz \(packet.channels)ch, "
+                     + "\(packet.payload.count)B packets")
+        }
+        audioPlayer.enqueue(packet)
+    }
+
     // MARK: - Annex B -> CMSampleBuffer
 
     private func handleAnnexB(_ data: Data) {
-        // Pure JSON payload = control message (pong, cursor sprite etc.).
-        // Video frames also begin with '{' (telemetry prefix) but always
-        // contain start codes — the null bytes make them unambiguous even
-        // against multi-KB JSON (cursor sprites are base64, NUL-free).
-        if data.count < 32_768, data.first == UInt8(ascii: "{"), !data.contains(0x00) {
-            handleVideoChannelJSON(data)
-            return
-        }
-
         // Split on 4-byte start codes (our sender only emits 00 00 00 01).
         // Bytes before the FIRST start code are the telemetry prefix
         // ({"cap":…,"snd":…} stamped by the Mac).
@@ -1225,6 +1362,19 @@ final class StreamReceiver: ObservableObject {
             stats.decodeP50 = percentile(decodeWindow, 0.5)
             stats.photonP50 = percentile(photonWindow, 0.5)
             stats.photonP95 = percentile(photonWindow, 0.95)
+            stats.audioE2eP50 = percentile(audioE2eWindow, 0.5)
+            // Peek, not drain: the 5s wire report owns the consuming read.
+            let audioLive = audioPlayer.peekStats()
+            stats.audioDepth = audioLive.depth
+            stats.audioTarget = audioLive.target
+            stats.audioUnderruns = audioLive.underruns
+            stats.audioDrops = audioLive.dropped
+            // Skew only means something when both halves were actually
+            // measured; with no audio (or before the clock offset settles) a
+            // difference against zero would read as a huge false skew.
+            stats.avSkewMs = (stats.audioE2eP50 > 0 && stats.e2eP50 > 0)
+                ? stats.audioE2eP50 - stats.e2eP50
+                : 0
             framesThisWindow = 0
             bytesThisWindow = 0
             stallsThisWindow = 0
@@ -1237,6 +1387,9 @@ final class StreamReceiver: ObservableObject {
             statsReportCounter += 1
             if statsReportCounter >= 5 {
                 statsReportCounter = 0
+                // Safe from this queue: the player serialises on its own
+                // ("receiver.audio"), so this is a hop, not reentrancy.
+                let audioStats = audioPlayer.drainStats()
                 sendControl([
                     "type": "stats",
                     "transport": transport,
@@ -1255,7 +1408,29 @@ final class StreamReceiver: ObservableObject {
                     "ph50": stats.photonP50.rounded(),
                     "ph95": stats.photonP95.rounded(),
                     "offsetKnown": clockOffsetMs != nil,
+                    // Audio arrivals over the same 5s the rest of this report
+                    // covers, so a silent channel is visible in the Mac's log
+                    // as a zero rather than as an absent field.
+                    "aPkt": audioPacketsThisWindow,
+                    "aKB": audioBytesThisWindow / 1024,
+                    // Buffer health: packets arriving is not the same as
+                    // packets heard, and these are what tell the two apart.
+                    "aDepth": audioStats.depth,
+                    "aUnder": audioStats.underruns,
+                    "aDrop": audioStats.dropped,
+                    "aReord": audioStats.reordered,
+                    // Target and adaptation count together say whether the
+                    // starting guess of 3 packets was right for this link.
+                    "aTgt": audioStats.target,
+                    "aAdapt": audioStats.adaptations,
+                    // The sync measurement itself: audio latency, and how far
+                    // it sits from video's. Both on the Mac's clock.
+                    "aE2e50": stats.audioE2eP50.rounded(),
+                    "avSkew": stats.avSkewMs.rounded(),
                 ])
+                audioE2eWindow.removeAll(keepingCapacity: true)
+                audioPacketsThisWindow = 0
+                audioBytesThisWindow = 0
                 e2eWindow.removeAll(keepingCapacity: true)
                 encodeWindow.removeAll(keepingCapacity: true)
                 decodeWindow.removeAll(keepingCapacity: true)

--- a/iOS/OpenSidecarPhoneApp.swift
+++ b/iOS/OpenSidecarPhoneApp.swift
@@ -344,6 +344,14 @@ struct SettingsView: View {
                 }
 
                 Section {
+                    Toggle("Mute audio", isOn: $receiver.audioMuted)
+                } header: {
+                    Text("Audio")
+                } footer: {
+                    Text("Your Mac can send its audio along with the picture — switch it on in the Mac app. Muting here silences it without interrupting the stream, and audio from other apps keeps playing either way.")
+                }
+
+                Section {
                     Toggle("Performance overlay", isOn: $showAnalytics)
                     Toggle("Metal renderer (experimental)", isOn: $metalRenderer)
                 } header: {
@@ -497,8 +505,29 @@ final class ReceiverModel: ObservableObject {
 
     func sceneDidActivate() {
         endBackgroundAssertion()
+        configureAudioSession()
         receiver.setRenderingPaused(false)
         receiver.ensureListening()
+    }
+
+    /// Put the audio session in a state where streamed desktop audio can play.
+    ///
+    /// `.mixWithOthers` is deliberate: using this as a second display should
+    /// not stop whatever the user already had playing. Someone who wants the
+    /// Mac's audio to take over can pause the other app; the reverse — being
+    /// silently interrupted by plugging in a display — is not recoverable by
+    /// the user at all.
+    ///
+    /// Failure is non-fatal. Audio is an optional addition to a display, and
+    /// the picture must keep working on a device that refuses the session.
+    private func configureAudioSession() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
+            try session.setActive(true)
+        } catch {
+            Log.info("audio session unavailable (\(error)) — video only")
+        }
     }
 
     func deviceWillLock() {

--- a/project.yml
+++ b/project.yml
@@ -154,6 +154,10 @@ targets:
       - Mac/Log.swift
       - Mac/LogPolicies.swift
       - Shared/LogSnapshot.swift
+      - Shared/Protocol.swift
+      - Shared/FrameCodec.swift
+      - Shared/AudioPacket.swift
+      - Shared/AudioJitterBuffer.swift
     settings:
       base:
         # A hostless test bundle: the sources under test are compiled straight


### PR DESCRIPTION
Closes #12.

Audio forwarding, built to the approach in that issue: ScreenCaptureKit
`capturesAudio`, AAC-LC, a second message type on the existing connection,
`AVAudioEngine` on the device, opt-in.

Getting there needed the frame-type header that PROTOCOL.md §4 has reserved
for `pv` 4 since the spec was written, so that lands here too — as its own
commit, with no audio depending on it.

**Verified on hardware**: Mac → iPhone 16 Pro Max over WiFi, audible, with
0 decode failures, 0 underruns and 0 drops across a sustained session.

---

## Why the typed frame header comes first

§4 specifies the demux heuristic (`< 32 KB`, leading `{`, no NUL) and calls it
"a design debt, not a feature", expected to be replaced by "a typed frame
header in `pv` 4". Audio is what forces the issue: compressed audio satisfies
neither half of that test reliably, so an AAC packet beginning `0x7B` with no
NUL byte would be handed to the JSON parser. A third payload kind cannot join
the scheme — it needs a real tag.

So `pv` 4 puts one byte at the front of the body:

```
[4-byte length][1-byte type][payload]     type 0 = video, 1 = JSON, 2 = audio
```

The length counts the type byte, so deframing is unchanged: read 4, take that
many, repeat.

**Negotiation is ordered, and the order is load-bearing.** `hello` and
`welcome` carry the versions, so they necessarily go out before either side
knows the peer's — they are always untagged, and the latch flips only after the
peer's `pv` is read, resetting per connection because a reconnect may reach a
different device. Get this wrong and it fails in the least visible way
available: works on the first connection, breaks on the reconnect, or works
only when the handshake happens to arrive in a single TCP segment.
`ProtocolNegotiationTests` covers that case, including a split read.

Peers below 4 keep the heuristic, per the two-phase procedure in
COMPATIBILITY.md §6. A `pv` 3 receiver sees byte-identical frames — asserted
directly by `testUntaggedFramingIsByteIdenticalToPreProtocol4`.

## Audio

* **Capture** on the *existing* `SCStream` rather than a second one, so audio
  and video share a capture clock and stay in sync without a second mechanism.
  `excludesCurrentProcessAudio` keeps a Mac receiver's own playback out of the
  capture.
* **Encode** AAC-LC at a fixed 128 kbps on its own queue. Audio is ~1% of
  video's bandwidth, so adapting it to `StreamQuality` buys little.
* **Playback** through `AVAudioEngine` behind a jitter buffer whose target
  depth grows on underruns, capped so latency stays bounded.
* **Opt-in**: "Stream audio" on the sender, off by default. No existing install
  starts sending audio on update. Mute lives on both receivers.
* **A/V sync is measured, not assumed**: the receiver already computes a clock
  offset from ping/pong for video latency, and audio reuses it, so `avSkew`
  (audio latency − video latency) reads out in the perf overlay alongside
  buffer depth and underruns.

Audio never costs the display: separate queues on both ends, drop-oldest under
send pressure, and every failure path (no encoder, no stream output, no audio
engine) logs and continues with video alone. It is also gated on the peer
speaking `pv` 4 — an untagged audio frame would be read as video and wreck the
decoder, so that guard is correctness, not optimisation.

## Compatibility

* `pv` → 4. `minSupportedPeer` and `pencilWireVersion` untouched; the floor
  still admits protocol 1.
* No behaviour change against a `pv` 3 peer, in either direction.
* Receiver-to-sender frames stay untagged at every version — they are all JSON,
  so there is nothing for a type byte to disambiguate (§4).
* PROTOCOL.md gains §4.1 (typed frames) and §4.2 (audio packets); the version
  table's "4 (reserved)" row is filled in.

## Tests

99 tests, all green; the Mac, Mac receiver (at its macOS 12 floor) and iOS
targets all build.

New coverage is pure logic — no sockets, no CoreAudio, no display — and runs in
the existing hostless bundle:

| Suite | Covers |
|---|---|
| `FrameCodecTests` | round trips, length arithmetic with the type byte, byte-identical legacy output, unknown types skipped, the payload that fools the old heuristic |
| `ProtocolNegotiationTests` | untagged handshake, split-read handshake, per-connection reset, version gating |
| `AudioPacketTests` | header round trip, big-endian fields, truncated/malformed input, non-zero-based slices, AAC config bit-packing |
| `AudioJitterBufferTests` | pre-roll, underrun recovery, drop-oldest at capacity, reordering, adaptation ceiling |

## Hardware bring-up

Everything above passed compile checks and unit tests while producing no sound
at all. Five faults, each hiding the next, all documented in the final commit:

| Fault | Symptom |
|---|---|
| Decoder output buffer sized 2048 when one AAC packet yields 1024 | `inputRanDry`, no PCM — **the silence** |
| Encoder handed short SCK chunks to a converter needing 1024-sample frames | 6-byte stub packets on the wire |
| AAC `AudioSpecificConfig` never sent | decoder built, then rejected every frame |
| Drain pulled 200 packets/s against ~47/s arriving | continuous underruns |
| `ptsMs` from mach uptime vs video's wall clock | `avSkew` stuck at 0 |

The first one is worth calling out for anyone touching `AVAudioConverter`:
`inputRanDry` is not an error status, so a total decode failure logged nothing.
That case is now logged rather than swallowed.

## Notes for review

* **Overlaps #249 (HEVC).** Both touch `Shared/StreamReceiver.swift`,
  `Mac/MacSender.swift` and `PROTOCOL.md`. They compose without Swift
  conflicts — #249 rewrites `handleAnnexB`'s NAL loop while this moves routing
  out of that function into `route(body:)`, and a tagged video frame still
  carries exactly the Annex B bytes #249 parses. Only the PROTOCOL.md version
  table and §6.6's "identical framing" sentence need reconciling. Happy to
  rebase onto #249 whenever it lands.
* **The HAL driver is deliberately not here.** ScreenCaptureKit needs no
  installer, no admin rights and no separate bundle, and it shares the video
  capture clock. A `AudioServerPlugIn` would add per-app routing at the cost of
  a signed installer package and losing in-place Sparkle updates — worth doing
  if per-app routing is wanted, not worth blocking audio on. The wire format is
  capture-source agnostic, so it would be a backend swap behind an unchanged
  protocol.
* **Not yet exercised**: audio over USB (WiFi only so far) and the Mac receiver
  as the audio sink (iOS only so far). Both use the same code path, but neither
  has been run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Y9Uj1DG1P8LeUyLZUHkCu
