### PR TITLE
fix(mac): pace large H.264 streams below the level limit

### DIFF
--- a/5K_RECEIVER_WORKAROUND.md
+++ b/5K_RECEIVER_WORKAROUND.md
@@ -1,4 +1,4 @@
-# Experimental workaround for Best quality on a 5K Mac receiver
+# Proposed fix for Best quality on a 5K Mac receiver
 
 This branch proposes a sender-side workaround for [issue #271](https://github.com/peetzweg/opendisplay/issues/271). It preserves a 4096×2304 stream and reduces the nominal encoder frame rate to 55 fps. It does **not** enable native 5120×2880 streaming or guarantee 55 delivered fps.
 
@@ -70,7 +70,9 @@ To revert, quit OpenDisplay Dev and open your normal OpenDisplay sender. Balance
 
 - The initial prototype was built on an M4 MacBook Pro running macOS 26.3 with Xcode 26.6 and used with a 2015 5K iMac over Wi-Fi. It established a 4096×2304 extended stream, sustained approximately 35–40 delivered fps in the observed intervals, and reconnected successfully.
 - The prototype still logged isolated `nil buffer despite noErr` events at startup/reconnect. The sustained near-every-frame rejection pattern did not recur during the short observed sessions. This is not a claim of zero dropped frames or a long-duration soak test.
-- This public revision additionally routes replay/reconnect frames through the limiter and schedules delivery of a deferred final update. It has been built and has passed all 44 macOS unit tests, including ten new rate-policy tests. The completed public revision has **not yet had a fresh end-to-end receiver test**; the above hardware measurements belong to the initial prototype.
+- The completed public revision was independently tested by the issue reporter using an M2 Pro Mac mini on macOS 26.5.2 and a 2015 5K iMac on macOS Monterey 12.7.6 over wired Ethernet. Best quality at 4096×2304 remained connected for several minutes without a drop. Two isolated nil-buffer events occurred during encoder startup and none persisted afterward. Delivered frame rate varied from roughly 15–57 fps, with occasional brief stalls.
+- In that everyday-productivity test, the reporter found the image noticeably sharper than Balanced quality and did not perceive added latency. The workload covered terminal windows and web browsing rather than video playback or another stress test.
+- The public revision routes replay/reconnect frames through the limiter and schedules delivery of a deferred final update. It has been built and has passed all 44 macOS unit tests, including ten new rate-policy tests.
 - Unit tests cover rate selection, macroblock rounding, a 60 Hz source paced to 55 fps, deferred-frame eligibility, long idle gaps, reset, invalid timestamps, early admission, and duplicate prevention near a later slot. They do not emulate VideoToolbox or prove actual timer delivery to a physical receiver.
 - The workaround does not change receiver decode limits, codec, bitrate, or network handling. Lowering a nominal frame rate does not guarantee compatibility with every encoder, display, or transport.
 
@@ -87,4 +89,4 @@ xcodebuild test \
   CODE_SIGNING_ALLOWED=NO
 ```
 
-Feedback is welcome on issue #271 and the linked draft PR. Please include sender/receiver models, macOS versions, transport, selected quality, encoded resolution, target fps, and whether repeated nil-buffer errors persist. Remove device names, network addresses, and other personal information before sharing logs.
+Feedback is welcome on issue #271 and the linked pull request. Please include sender/receiver models, macOS versions, transport, selected quality, encoded resolution, target fps, and whether repeated nil-buffer errors persist. Remove device names, network addresses, and other personal information before sharing logs.

--- a/5K_RECEIVER_WORKAROUND.md
+++ b/5K_RECEIVER_WORKAROUND.md
@@ -1,0 +1,90 @@
+# Experimental workaround for Best quality on a 5K Mac receiver
+
+This branch proposes a sender-side workaround for [issue #271](https://github.com/peetzweg/opendisplay/issues/271). It preserves a 4096×2304 stream and reduces the nominal encoder frame rate to 55 fps. It does **not** enable native 5120×2880 streaming or guarantee 55 delivered fps.
+
+## What changes
+
+- Calculate a conservative H.264 rate from the encoded raster's 16×16 macroblocks and the Level 5.2 macroblock-rate budget.
+- Use that rate for `ExpectedFrameRate` and gate submissions at the shared encoder entry point, including replay and reconnect paths.
+- Keep the latest skipped frame and use the existing 30 ms replay timer, so an isolated final screen change is not lost when capture goes idle.
+- Preserve the existing unpaced 60 fps behavior for smaller rasters that fit the budget.
+
+For 4096×2304, there are 36,864 macroblocks per frame. The budget of 2,073,600 macroblocks/second allows 56 whole frames/second; this workaround leaves one additional frame/second of headroom and selects 55. This is a conservative workaround for the reported symptom, not general hardware-capability detection.
+
+## Build on the sender Mac
+
+Requirements: a Mac running macOS 14 or later, full Xcode with its license and required components initialized, Git, and XcodeGen. If Homebrew is installed, install XcodeGen with `brew install xcodegen`.
+
+1. Download this branch into a new folder:
+
+   ```sh
+   git clone --branch fix/h264-large-stream-pacing --single-branch https://github.com/vipstanley/opendisplay.git opendisplay-5k-workaround
+   cd opendisplay-5k-workaround
+   ```
+
+2. Generate and build the sender:
+
+   ```sh
+   xcodegen generate
+   xcodebuild build \
+     -project OpenSidecar.xcodeproj \
+     -scheme OpenSidecarMac \
+     -configuration Debug \
+     -destination 'platform=macOS' \
+     -derivedDataPath build \
+     CODE_SIGNING_ALLOWED=NO
+   ```
+
+   Xcode will fetch the upstream Sparkle dependency on the first build. If this fails during package resolution, resolve the download/network error before retrying; it is separate from the video patch.
+
+3. Disable automatic updates in this experimental build and sign it for local use:
+
+   ```sh
+   APP="$PWD/build/Build/Products/Debug/OpenDisplay Dev.app"
+   /usr/libexec/PlistBuddy -c 'Set :SUEnableAutomaticChecks false' "$APP/Contents/Info.plist"
+   /usr/libexec/PlistBuddy -c 'Delete :SUFeedURL' "$APP/Contents/Info.plist"
+   codesign --force --deep --sign - "$APP"
+   codesign --verify --deep --strict "$APP"
+   ```
+
+4. Quit the normal OpenDisplay sender, then launch this build:
+
+   ```sh
+   open "$APP"
+   ```
+
+   This is a locally built, ad-hoc-signed application, not an official notarized release. The Debug app has its own bundle identity, so macOS may request Screen Recording, Accessibility, or Local Network permission again. Grant the permissions needed for your use through System Settings.
+
+5. Keep the existing OpenDisplay Receiver running on the iMac. Connect from the sender with **Extend → Best (native)**. No receiver rebuild is needed for this workaround.
+
+The sender log is at `~/Library/Logs/OpenDisplay Dev/opendisplay.log`. For a 4096×2304 stream, look for:
+
+```text
+H.264 L5.2 rate cap: 4096x2304 -> 55fps
+encoder ready: 4096x2304 H.264 18Mbps fps=55 quality=best lowLatencyRC=true
+```
+
+To revert, quit OpenDisplay Dev and open your normal OpenDisplay sender. Balanced remains the existing workaround if this experimental branch does not work on your hardware.
+
+## Validation and limitations
+
+- The initial prototype was built on an M4 MacBook Pro running macOS 26.3 with Xcode 26.6 and used with a 2015 5K iMac over Wi-Fi. It established a 4096×2304 extended stream, sustained approximately 35–40 delivered fps in the observed intervals, and reconnected successfully.
+- The prototype still logged isolated `nil buffer despite noErr` events at startup/reconnect. The sustained near-every-frame rejection pattern did not recur during the short observed sessions. This is not a claim of zero dropped frames or a long-duration soak test.
+- This public revision additionally routes replay/reconnect frames through the limiter and schedules delivery of a deferred final update. It has been built and has passed all 44 macOS unit tests, including ten new rate-policy tests. The completed public revision has **not yet had a fresh end-to-end receiver test**; the above hardware measurements belong to the initial prototype.
+- Unit tests cover rate selection, macroblock rounding, a 60 Hz source paced to 55 fps, deferred-frame eligibility, long idle gaps, reset, invalid timestamps, early admission, and duplicate prevention near a later slot. They do not emulate VideoToolbox or prove actual timer delivery to a physical receiver.
+- The workaround does not change receiver decode limits, codec, bitrate, or network handling. Lowering a nominal frame rate does not guarantee compatibility with every encoder, display, or transport.
+
+## Reproduce the automated tests
+
+After generating the project:
+
+```sh
+xcodebuild test \
+  -project OpenSidecar.xcodeproj \
+  -scheme OpenSidecarMac \
+  -destination 'platform=macOS' \
+  -derivedDataPath build \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Feedback is welcome on issue #271 and the linked draft PR. Please include sender/receiver models, macOS versions, transport, selected quality, encoded resolution, target fps, and whether repeated nil-buffer errors persist. Remove device names, network addresses, and other personal information before sharing logs.

--- a/Mac/H264FrameRatePolicy.swift
+++ b/Mac/H264FrameRatePolicy.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Conservative sender-side workaround for large H.264 streams (issue #271).
+/// This is a rate policy, not a guarantee of encoder/decoder capabilities.
+struct H264FrameRatePolicy {
+    let framesPerSecond: Int
+    private var nextDeadline: Double?
+
+    init(width: Int, height: Int) {
+        // High@L5.2 permits 2,073,600 macroblocks/sec. Leave one fps of
+        // headroom when 60 fps exceeds that budget: 4096x2304 becomes 55 fps.
+        let macroblocks = max(1, ((width + 15) / 16) * ((height + 15) / 16))
+        let levelRate = max(1, min(60, 2_073_600 / macroblocks))
+        framesPerSecond = levelRate < 60 ? max(1, levelRate - 1) : 60
+    }
+
+    /// False means defer the latest frame, including when capture goes idle.
+    /// All calls use the same capture/host clock as the encoder timestamps.
+    mutating func shouldSubmit(at time: Double) -> Bool {
+        // Preserve existing behavior for streams that fit the 60 fps budget.
+        guard framesPerSecond < 60, time.isFinite else { return true }
+        let interval = 1.0 / Double(framesPerSecond)
+        if let next = nextDeadline {
+            guard time + 0.0005 >= next else { return false }
+            // Keep the fractional cadence instead of setting time + interval,
+            // which would turn a 60 Hz source into a 30 fps stream. Skip idle
+            // gaps in constant time, never submitting a burst to catch up.
+            // Include the early-admission tolerance when advancing. Otherwise
+            // a late frame that lands just before the next slot could be
+            // admitted twice with the same timestamp.
+            let steps = max(1, floor((time + 0.0005 - next) / interval) + 1)
+            nextDeadline = next + steps * interval
+        } else {
+            nextDeadline = time + interval
+        }
+        return true
+    }
+}

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -326,6 +326,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     // tell "Mac rendered 45fps" from "frames got lost" — count deliveries here.
     private var capFrames = 0
     private var capWindowStart = Date()
+    private var encodeFrameRate = H264FrameRatePolicy(width: 1, height: 1)
 
     private var framesSent = 0
     private var bytesSent = 0
@@ -1900,6 +1901,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                     "This Mac's video encoder could not be started (VideoToolbox error \(status))"
             ])
         }
+        encodeFrameRate = H264FrameRatePolicy(width: width, height: height)
+        if encodeFrameRate.framesPerSecond < 60 {
+            Log.info("H.264 L5.2 rate cap: \(width)x\(height) -> \(encodeFrameRate.framesPerSecond)fps")
+        }
+
         // Low-latency settings: real-time, no B-frames, periodic keyframes.
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_RealTime, value: kCFBooleanTrue)
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_AllowFrameReordering, value: kCFBooleanFalse)
@@ -1910,10 +1916,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration, value: 60 as CFNumber)
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_MaxFrameDelayCount, value: 0 as CFNumber)
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_AverageBitRate, value: quality.bitrate as CFNumber)
-        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ExpectedFrameRate, value: 60 as CFNumber)
+        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ExpectedFrameRate,
+                             value: encodeFrameRate.framesPerSecond as CFNumber)
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_PrioritizeEncodingSpeedOverQuality, value: kCFBooleanTrue)
         VTCompressionSessionPrepareToEncodeFrames(encoder)
-        Log.info("encoder ready: \(width)x\(height) H.264 \(quality.bitrate / 1_000_000)Mbps quality=\(quality.rawValue) lowLatencyRC=\(lowLatency && !usedFallback)\(usedFallback ? " (fallback)" : "")")
+        Log.info("encoder ready: \(width)x\(height) H.264 \(quality.bitrate / 1_000_000)Mbps fps=\(encodeFrameRate.framesPerSecond) quality=\(quality.rawValue) lowLatencyRC=\(lowLatency && !usedFallback)\(usedFallback ? " (fallback)" : "")")
     }
 
     // MARK: - Capture callback
@@ -2010,6 +2017,13 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
 
     private func encode(_ pixelBuffer: CVPixelBuffer, pts: CMTime, generation: UInt64) {
         guard generation == captureGenerationNow, let encoder else { return }
+        // Gate every submission, including reconnect and backpressure replays.
+        // Reuse the existing latest-frame replay so a rate-limited final screen
+        // update is eventually delivered even if ScreenCaptureKit goes idle.
+        guard encodeFrameRate.shouldSubmit(at: CMTimeGetSeconds(pts)) else {
+            scheduleDropReplayTimer()
+            return
+        }
         pipelineLock.lock()
         pendingEncodes += 1
         pipelineLock.unlock()

--- a/MacTests/H264FrameRatePolicyTests.swift
+++ b/MacTests/H264FrameRatePolicyTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+
+final class H264FrameRatePolicyTests: XCTestCase {
+    func testLargeRasterUses55FPSAndSmallerRastersRemain60FPS() {
+        XCTAssertEqual(H264FrameRatePolicy(width: 4096, height: 2304).framesPerSecond, 55)
+        XCTAssertEqual(H264FrameRatePolicy(width: 3840, height: 2160).framesPerSecond, 60)
+        XCTAssertEqual(H264FrameRatePolicy(width: 3072, height: 1728).framesPerSecond, 60)
+    }
+
+    func testMacroblockDimensionsRoundUp() {
+        XCTAssertEqual(H264FrameRatePolicy(width: 4097, height: 2305).framesPerSecond, 54)
+    }
+
+    func testFractionalCadenceDoesNotCollapse60HzCaptureTo30FPS() {
+        var policy = H264FrameRatePolicy(width: 4096, height: 2304)
+        let accepted = (0..<600).filter { policy.shouldSubmit(at: Double($0) / 60) }
+        XCTAssertEqual(accepted.count, 550)
+    }
+
+    func testDeferredLastFrameCanBeReplayedWithoutAnotherCapture() {
+        var policy = H264FrameRatePolicy(width: 4096, height: 2304)
+        XCTAssertTrue(policy.shouldSubmit(at: 0))
+        XCTAssertFalse(policy.shouldSubmit(at: 1.0 / 60))
+        // The existing drop replay timer supplies the latest frame after 30 ms.
+        XCTAssertTrue(policy.shouldSubmit(at: 1.0 / 60 + 0.030))
+        XCTAssertFalse(policy.shouldSubmit(at: 1.0 / 60 + 0.030))
+    }
+
+    func testLongIdleGapDoesNotAccumulateCatchUpSubmissions() {
+        var policy = H264FrameRatePolicy(width: 4096, height: 2304)
+        XCTAssertTrue(policy.shouldSubmit(at: 0))
+        XCTAssertTrue(policy.shouldSubmit(at: 86400))
+        XCTAssertFalse(policy.shouldSubmit(at: 86400))
+        XCTAssertTrue(policy.shouldSubmit(at: 86400 + 1.0 / 55))
+    }
+
+    func testEarlyAdmissionConsumesOneDeadlineSlot() {
+        var policy = H264FrameRatePolicy(width: 4096, height: 2304)
+        XCTAssertTrue(policy.shouldSubmit(at: 0))
+        let slightlyEarly = 1.0 / 55 - 0.0004
+        XCTAssertTrue(policy.shouldSubmit(at: slightlyEarly))
+        XCTAssertFalse(policy.shouldSubmit(at: slightlyEarly))
+    }
+
+    func testLateFrameNearFollowingSlotCannotBeSubmittedTwice() {
+        var policy = H264FrameRatePolicy(width: 4096, height: 2304)
+        XCTAssertTrue(policy.shouldSubmit(at: 0))
+        XCTAssertTrue(policy.shouldSubmit(at: 0.0362))
+        XCTAssertFalse(policy.shouldSubmit(at: 0.0362))
+    }
+
+    func testNewEncoderResetsDeadline() {
+        var policy = H264FrameRatePolicy(width: 4096, height: 2304)
+        XCTAssertTrue(policy.shouldSubmit(at: 10))
+        XCTAssertFalse(policy.shouldSubmit(at: 10))
+        policy = H264FrameRatePolicy(width: 4096, height: 2304)
+        XCTAssertTrue(policy.shouldSubmit(at: 0))
+    }
+
+    func testInvalidTimestampDoesNotPoisonDeadline() {
+        var policy = H264FrameRatePolicy(width: 4096, height: 2304)
+        XCTAssertTrue(policy.shouldSubmit(at: .nan))
+        XCTAssertTrue(policy.shouldSubmit(at: .infinity))
+        XCTAssertTrue(policy.shouldSubmit(at: 0))
+        XCTAssertFalse(policy.shouldSubmit(at: 0))
+    }
+
+    func testSafeRastersKeepExistingUnpacedBehavior() {
+        var policy = H264FrameRatePolicy(width: 1920, height: 1080)
+        XCTAssertTrue(policy.shouldSubmit(at: 0))
+        XCTAssertTrue(policy.shouldSubmit(at: 0))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -151,6 +151,7 @@ targets:
     sources:
       - MacTests
       - Mac/DisplayArrangement.swift
+      - Mac/H264FrameRatePolicy.swift
       - Mac/Log.swift
       - Mac/LogPolicies.swift
       - Shared/LogSnapshot.swift


### PR DESCRIPTION
Best quality can initialize a 4096×2304 Mac-receiver stream at 60 fps. On the reported 2015 5K iMac setup, VideoToolbox then returns `noErr` with a nil output buffer for nearly every frame, leaving the receiver effectively frozen. This change keeps the 4096×2304 raster and selects a conservative 55 fps target from the H.264 Level 5.2 macroblock-rate budget.

What changes:

- compute a rate policy from the encoded raster's 16×16 macroblocks;
- use the selected rate for `ExpectedFrameRate`;
- gate every encoder entry path, including replay and reconnect submissions;
- reuse the existing latest-frame replay timer when pacing defers a frame, so a final static-screen update is eventually delivered;
- keep existing 60 fps behavior for smaller rasters that fit the budget.

Before:

```text
encoder ready: 4096x2304 H.264 18Mbps quality=best
encoder output rejected: nil buffer despite noErr
```

After:

```text
H.264 L5.2 rate cap: 4096x2304 -> 55fps
encoder ready: 4096x2304 H.264 18Mbps fps=55 quality=best
```

Validation:

- Xcode 26.6 builds successfully on an M4 MacBook Pro running macOS 26.3.
- All 44 macOS unit tests pass, including ten new rate-policy tests.
- The completed public code was independently tested by the issue reporter using an M2 Pro Mac mini on macOS 26.5.2 and a 2015 5K iMac on macOS Monterey 12.7.6 over wired Ethernet. Best quality at 4096×2304 remained connected for several minutes without a drop.
- That test logged two isolated nil-buffer events during encoder startup and none persisted afterward. Delivered frame rate varied from roughly 15–57 fps, with occasional brief stalls.
- For terminal and web-browsing use, the reporter found the image noticeably sharper than Balanced quality and did not perceive added latency.
- A separate M4-to-2015-iMac Wi-Fi run delivered roughly 35–40 fps and likewise avoided the sustained near-every-frame rejection pattern.

Limitations:

- This does not enable native 5120×2880 streaming; it targets the existing 4096×2304 receiver ceiling.
- It does not claim zero dropped frames or universal compatibility across every encoder, display, and transport.
- Balanced remains the fallback for untested hardware.

The English build, rollback, log-checking, and feedback guide is in `5K_RECEIVER_WORKAROUND.md`.

Fixes #271.