### PR TITLE
feat(mac): user-configurable frame rate (30/60/90/120 FPS)

### DIFF
--- a/Mac/FrameRate.swift
+++ b/Mac/FrameRate.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Capture-resolution / bitrate trade-off. The virtual display always runs at
+/// native size — only the captured/encoded stream is scaled, so lower presets
+/// cut encode, transmit, and decode time at the cost of sharpness.
+enum StreamQuality: String, CaseIterable {
+    case best, balanced, fast
+
+    var scale: Double {
+        switch self {
+        case .best: return 1.0
+        case .balanced: return 0.75
+        case .fast: return 0.5
+        }
+    }
+
+    var bitrate: Int {
+        switch self {
+        case .best: return 18_000_000
+        case .balanced: return 10_000_000
+        case .fast: return 6_000_000
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .best: return "Best (native)"
+        case .balanced: return "Balanced (75%)"
+        case .fast: return "Fast (50%)"
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .best: return "Pixel-perfect at the device's native resolution. Highest bandwidth and latency."
+        case .balanced: return "75% capture resolution — noticeably lower latency, slight softness."
+        case .fast: return "Half resolution — lowest latency and bandwidth, visibly softer. Good for WiFi."
+        }
+    }
+}
+
+/// User-selectable target frame rate for the capture stream and virtual display.
+/// Supports high-refresh ProMotion displays (120 Hz) on iPad Pro and iPhone Pro.
+enum FrameRate: Int, CaseIterable, Identifiable {
+    case fps30 = 30
+    case fps60 = 60
+    case fps90 = 90
+    case fps120 = 120
+
+    var id: Int { rawValue }
+
+    var label: String {
+        switch self {
+        case .fps30: return "30 FPS (Low Power)"
+        case .fps60: return "60 FPS (Default)"
+        case .fps90: return "90 FPS"
+        case .fps120: return "120 FPS (ProMotion)"
+        }
+    }
+
+    var explanation: String {
+        switch self {
+        case .fps30: return "Lowest CPU and power usage. Best for static content or saving battery."
+        case .fps60: return "Standard smooth frame rate for general use."
+        case .fps90: return "High refresh rate with balanced CPU and bandwidth overhead."
+        case .fps120: return "Ultra-smooth ProMotion 120 Hz for compatible iPad Pro and iPhone Pro displays."
+        }
+    }
+
+    /// Auto-scaled bitrate to ensure picture clarity is preserved at higher frame rates.
+    /// Boosts up to ~28.8 Mbps at 120 FPS for Best quality.
+    func bitrate(for quality: StreamQuality) -> Int {
+        let base = quality.bitrate
+        switch self {
+        case .fps30:
+            return Int(Double(base) * 0.75)
+        case .fps60:
+            return base
+        case .fps90:
+            return Int(Double(base) * 1.25)
+        case .fps120:
+            return Int(Double(base) * 1.6)
+        }
+    }
+}

--- a/Mac/MacSender.swift
+++ b/Mac/MacSender.swift
@@ -24,45 +24,6 @@ enum CaptureMode: String {
     case extend   // virtual display (Milestone 2)
 }
 
-/// Capture-resolution / bitrate trade-off. The virtual display always runs at
-/// native size — only the captured/encoded stream is scaled, so lower presets
-/// cut encode, transmit, and decode time at the cost of sharpness.
-enum StreamQuality: String, CaseIterable {
-    case best, balanced, fast
-
-    var scale: Double {
-        switch self {
-        case .best: return 1.0
-        case .balanced: return 0.75
-        case .fast: return 0.5
-        }
-    }
-
-    var bitrate: Int {
-        switch self {
-        case .best: return 18_000_000
-        case .balanced: return 10_000_000
-        case .fast: return 6_000_000
-        }
-    }
-
-    var label: String {
-        switch self {
-        case .best: return "Best (native)"
-        case .balanced: return "Balanced (75%)"
-        case .fast: return "Fast (50%)"
-        }
-    }
-
-    var explanation: String {
-        switch self {
-        case .best: return "Pixel-perfect at the device's native resolution. Highest bandwidth and latency."
-        case .balanced: return "75% capture resolution — noticeably lower latency, slight softness."
-        case .fast: return "Half resolution — lowest latency and bandwidth, visibly softer. Good for WiFi."
-        }
-    }
-}
-
 struct PhoneInfo: Decodable {
     let pixelsWide: Int   // landscape-oriented (long edge)
     let pixelsHigh: Int
@@ -340,13 +301,17 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     /// At most one timer is active; each new drop resets the 30ms deadline.
     private var dropReplayTimer: DispatchSourceTimer?
 
+    let frameRate: FrameRate
+
     init(transport: SenderTransport, name: String, mode: CaptureMode,
-         quality: StreamQuality = .best, displaySerial: UInt32 = 0x0001,
+         quality: StreamQuality = .best, frameRate: FrameRate = .fps60,
+         displaySerial: UInt32 = 0x0001,
          identityOffset: UInt32 = 0, awaitingWake: Bool = false) {
         self.transport = transport
         self.endpointName = name
         self.mode = mode
         self.quality = quality
+        self.frameRate = frameRate
         self.displaySerial = displaySerial
         self.baseIdentityOffset = identityOffset
         self.awaitingWake = awaitingWake
@@ -500,6 +465,7 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
                     return VirtualDisplay(name: displayName,
                                           pointsWide: pointsWide, pointsHigh: pointsHigh,
                                           sizeInMillimeters: mm,
+                                          targetFPS: Double(self.frameRate.rawValue),
                                           serialNum: serial &+ totalOffset,
                                           productID: 0x4F53 &+ totalOffset,
                                           restoreOrigin: restoreOrigin,
@@ -680,10 +646,11 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         let config = SCStreamConfiguration()
         config.width = pixelsWide
         config.height = pixelsHigh
-        // Ask for 120 even though the virtual display is 60Hz: requesting
-        // exactly 1/60 makes SCK's rate limiter skip frames that arrive a
-        // hair early (beat frequency) — measured ~51fps instead of 60.
-        config.minimumFrameInterval = CMTime(value: 1, timescale: 120)
+        // Ask for double the target frame rate so SCK's rate limiter does not
+        // skip frames that arrive a hair early (beat frequency) — measured
+        // ~51fps instead of 60 when requested at 1/60.
+        let targetFPS = frameRate.rawValue
+        config.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(max(120, targetFPS * 2)))
         // 420v matches the encoder's native input — skips a BGRA→YUV conversion
         // inside VideoToolbox. (`-pixfmt bgra` reverts for A/B testing.)
         config.pixelFormat = UserDefaults.standard.string(forKey: "pixfmt") == "bgra"
@@ -1906,14 +1873,16 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ProfileLevel, value: kVTProfileLevel_H264_High_AutoLevel)
         // No periodic IDRs: each one is a bitrate spike → transmit-time hiccup.
         // TCP never loses data, and we force a keyframe on reconnect/drop.
-        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_MaxKeyFrameInterval, value: 3600 as CFNumber)
+        let targetFPS = frameRate.rawValue
+        let effectiveBitrate = frameRate.bitrate(for: quality)
+        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_MaxKeyFrameInterval, value: (targetFPS * 60) as CFNumber)
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration, value: 60 as CFNumber)
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_MaxFrameDelayCount, value: 0 as CFNumber)
-        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_AverageBitRate, value: quality.bitrate as CFNumber)
-        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ExpectedFrameRate, value: 60 as CFNumber)
+        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_AverageBitRate, value: effectiveBitrate as CFNumber)
+        VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_ExpectedFrameRate, value: targetFPS as CFNumber)
         VTSessionSetProperty(encoder, key: kVTCompressionPropertyKey_PrioritizeEncodingSpeedOverQuality, value: kCFBooleanTrue)
         VTCompressionSessionPrepareToEncodeFrames(encoder)
-        Log.info("encoder ready: \(width)x\(height) H.264 \(quality.bitrate / 1_000_000)Mbps quality=\(quality.rawValue) lowLatencyRC=\(lowLatency && !usedFallback)\(usedFallback ? " (fallback)" : "")")
+        Log.info("encoder ready: \(width)x\(height) H.264 \(effectiveBitrate / 1_000_000)Mbps @\(targetFPS)fps quality=\(quality.rawValue) lowLatencyRC=\(lowLatency && !usedFallback)\(usedFallback ? " (fallback)" : "")")
     }
 
     // MARK: - Capture callback
@@ -1951,7 +1920,8 @@ final class MacSender: NSObject, SCStreamOutput, SCStreamDelegate {
     private func scheduleDropReplayTimer() {
         dropReplayTimer?.cancel()
         let timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(deadline: .now() + .milliseconds(30))
+        let replayDelayMs = max(15, 1000 / frameRate.rawValue)
+        timer.schedule(deadline: .now() + .milliseconds(replayDelayMs))
         timer.setEventHandler { [weak self] in
             guard let self else { return }
             self.dropReplayTimer = nil

--- a/Mac/OpenSidecarMacApp.swift
+++ b/Mac/OpenSidecarMacApp.swift
@@ -193,6 +193,9 @@ final class SenderController: ObservableObject {
     @Published var quality = StreamQuality(rawValue: UserDefaults.standard.string(forKey: "quality") ?? "") ?? .best {
         didSet { UserDefaults.standard.set(quality.rawValue, forKey: "quality") }
     }
+    @Published var frameRate = FrameRate(rawValue: UserDefaults.standard.integer(forKey: "frameRate")) ?? .fps60 {
+        didSet { UserDefaults.standard.set(frameRate.rawValue, forKey: "frameRate") }
+    }
 
     var running: Bool { !sessions.isEmpty }
 
@@ -541,7 +544,8 @@ final class SenderController: ObservableObject {
 
         let name = label(for: target)
         let sender = MacSender(transport: transport, name: name, mode: mode,
-                               quality: quality, displaySerial: Self.displaySerial(for: id),
+                               quality: quality, frameRate: frameRate,
+                               displaySerial: Self.displaySerial(for: id),
                                identityOffset: identityOffset(for: id),
                                awaitingWake: awaitingWake)
         let session = DeviceSession(id: id, target: target, name: name, sender: sender)
@@ -896,6 +900,18 @@ struct ContentView: View {
                     }
                     .onChange(of: controller.quality) { controller.restartAll() }
                     Text(controller.quality.explanation)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Picker("Frame Rate", selection: $controller.frameRate) {
+                        ForEach(FrameRate.allCases) { r in
+                            Text(r.label).tag(r)
+                        }
+                    }
+                    .onChange(of: controller.frameRate) { controller.restartAll() }
+                    Text(controller.frameRate.explanation)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/Mac/VirtualDisplay.swift
+++ b/Mac/VirtualDisplay.swift
@@ -11,6 +11,7 @@ final class VirtualDisplay {
     private let maxPointsPerAxis: Int
     private(set) var pointsWide: Int
     private(set) var pointsHigh: Int
+    private let targetFPS: Double
 
     private var restoreTarget: CGPoint?
     private var restoreUntil: Date
@@ -27,11 +28,13 @@ final class VirtualDisplay {
     /// `onOriginChange` reports where the display sits afterwards, so the
     /// caller can persist user drags.
     init?(name: String, pointsWide: Int, pointsHigh: Int, sizeInMillimeters: CGSize,
+          targetFPS: Double = 60,
           serialNum: UInt32 = 0x0001, productID: UInt32 = 0x4F53,
           restoreOrigin: CGPoint? = nil,
           onOriginChange: ((CGPoint, CGSize) -> Void)? = nil) {
         self.pointsWide = pointsWide
         self.pointsHigh = pointsHigh
+        self.targetFPS = targetFPS
         // Reserve the longer orientation on both axes. That lets a phone or
         // tablet change orientation by applying a new mode to this *same*
         // virtual monitor instead of removing it and stranding its windows.
@@ -60,13 +63,13 @@ final class VirtualDisplay {
         settings = CGVirtualDisplaySettings()
         settings.hiDPI = 1
         settings.modes = [
-            CGVirtualDisplayMode(width: UInt(pointsWide), height: UInt(pointsHigh), refreshRate: 60)
+            CGVirtualDisplayMode(width: UInt(pointsWide), height: UInt(pointsHigh), refreshRate: targetFPS)
         ]
         guard display.apply(settings) else {
             Log.info("CGVirtualDisplay applySettings FAILED")
             return nil
         }
-        Log.info("virtual display created: id=\(display.displayID) \(pointsWide)x\(pointsHigh)pt @2x")
+        Log.info("virtual display created: id=\(display.displayID) \(pointsWide)x\(pointsHigh)pt @2x @\(Int(targetFPS))Hz")
 
         // macOS defaults the new display to its 1x mode AND can restore a
         // stale saved mode for this serial asynchronously, seconds after the
@@ -108,7 +111,7 @@ final class VirtualDisplay {
         let newSettings = CGVirtualDisplaySettings()
         newSettings.hiDPI = 1
         newSettings.modes = [
-            CGVirtualDisplayMode(width: UInt(pointsWide), height: UInt(pointsHigh), refreshRate: 60)
+            CGVirtualDisplayMode(width: UInt(pointsWide), height: UInt(pointsHigh), refreshRate: targetFPS)
         ]
         guard display.apply(newSettings) else {
             Log.info("virtual display \(display.displayID) applySettings FAILED during resize")
@@ -153,6 +156,9 @@ final class VirtualDisplay {
         let opts = [kCGDisplayShowDuplicateLowResolutionModes: kCFBooleanTrue] as CFDictionary
         guard let modes = CGDisplayCopyAllDisplayModes(display.displayID, opts) as? [CGDisplayMode],
               let hidpi = modes.first(where: {
+                  $0.width == pointsWide && $0.pixelWidth == pointsWide * 2 &&
+                  (abs($0.refreshRate - targetFPS) < 1.0 || $0.refreshRate == 0)
+              }) ?? modes.first(where: {
                   $0.width == pointsWide && $0.pixelWidth == pointsWide * 2
               }) else {
             if recover {
@@ -162,14 +168,15 @@ final class VirtualDisplay {
             return false
         }
         if let current = CGDisplayCopyDisplayMode(display.displayID),
-           current.width == hidpi.width, current.pixelWidth == hidpi.pixelWidth {
+           current.width == hidpi.width, current.pixelWidth == hidpi.pixelWidth,
+           (abs(current.refreshRate - hidpi.refreshRate) < 1.0 || hidpi.refreshRate == 0) {
             return true
         }
         var config: CGDisplayConfigRef?
         CGBeginDisplayConfiguration(&config)
         CGConfigureDisplayWithDisplayMode(config, display.displayID, hidpi, nil)
         let err = CGCompleteDisplayConfiguration(config, .permanently)
-        Log.info("HiDPI mode (re)selected: \(hidpi.width)x\(hidpi.height)@2x (result \(err.rawValue))")
+        Log.info("HiDPI mode (re)selected: \(hidpi.width)x\(hidpi.height)@2x @\(Int(hidpi.refreshRate))Hz (result \(err.rawValue))")
         return err == .success
     }
 

--- a/MacTests/FrameRateTests.swift
+++ b/MacTests/FrameRateTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+
+final class FrameRateTests: XCTestCase {
+
+    func testRawValuesAndCases() {
+        XCTAssertEqual(FrameRate.allCases.count, 4)
+        XCTAssertEqual(FrameRate.fps30.rawValue, 30)
+        XCTAssertEqual(FrameRate.fps60.rawValue, 60)
+        XCTAssertEqual(FrameRate.fps90.rawValue, 90)
+        XCTAssertEqual(FrameRate.fps120.rawValue, 120)
+    }
+
+    func testLabelsContainProMotion() {
+        XCTAssertTrue(FrameRate.fps120.label.contains("ProMotion"))
+        XCTAssertTrue(FrameRate.fps60.label.contains("Default"))
+        XCTAssertTrue(FrameRate.fps30.label.contains("Low Power"))
+    }
+
+    func testBitrateScaling() {
+        let bestBase = StreamQuality.best.bitrate // 18_000_000
+        let balancedBase = StreamQuality.balanced.bitrate // 10_000_000
+        let fastBase = StreamQuality.fast.bitrate // 6_000_000
+
+        // 60 FPS should preserve base bitrate
+        XCTAssertEqual(FrameRate.fps60.bitrate(for: .best), bestBase)
+        XCTAssertEqual(FrameRate.fps60.bitrate(for: .balanced), balancedBase)
+        XCTAssertEqual(FrameRate.fps60.bitrate(for: .fast), fastBase)
+
+        // 120 FPS should boost bitrate by 1.6x (28.8 Mbps for best)
+        XCTAssertEqual(FrameRate.fps120.bitrate(for: .best), 28_800_000)
+        XCTAssertEqual(FrameRate.fps120.bitrate(for: .balanced), 16_000_000)
+        XCTAssertEqual(FrameRate.fps120.bitrate(for: .fast), 9_600_000)
+
+        // 90 FPS should scale by 1.25x
+        XCTAssertEqual(FrameRate.fps90.bitrate(for: .best), Int(Double(bestBase) * 1.25))
+
+        // 30 FPS should scale down to 0.75x to conserve bandwidth
+        XCTAssertEqual(FrameRate.fps30.bitrate(for: .best), Int(Double(bestBase) * 0.75))
+    }
+
+    func testInitFromRawValueFallback() {
+        XCTAssertEqual(FrameRate(rawValue: 120), .fps120)
+        XCTAssertEqual(FrameRate(rawValue: 60), .fps60)
+        XCTAssertNil(FrameRate(rawValue: 144))
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -151,6 +151,7 @@ targets:
     sources:
       - MacTests
       - Mac/DisplayArrangement.swift
+      - Mac/FrameRate.swift
       - Mac/Log.swift
       - Mac/LogPolicies.swift
       - Shared/LogSnapshot.swift

--- a/run.sh
+++ b/run.sh
@@ -5,11 +5,13 @@
 set -e
 cd "$(dirname "$0")"
 
-APP=build/Build/Products/Debug/OpenDisplay.app
+# Debug builds are named "OpenDisplay Dev" (own bundle ID and TCC identity,
+# so they never clobber the release app's permission grants).
+APP=build/Build/Products/Debug/OpenDisplay\ Dev.app
 if [[ ! -d $APP ]]; then
-  echo "Mac app not built — run: xcodegen generate && xcodebuild -project OpenSidecar.xcodeproj -scheme OpenSidecarMac -configuration Debug -derivedDataPath build build"
+  echo "Mac app not built — run: ./generate.sh && xcodebuild -project OpenSidecar.xcodeproj -scheme OpenSidecarMac -configuration Debug -derivedDataPath build build"
   exit 1
 fi
 
 open "$APP"
-echo "OpenDisplay running — logs at ~/Library/Logs/OpenDisplay/opendisplay.log."
+echo "OpenDisplay Dev running — logs at ~/Library/Logs/OpenDisplay Dev/opendisplay.log."


### PR DESCRIPTION
Adds a **Frame Rate** picker to the Mac app's settings with four presets:

| Preset | Use case |
|---|---|
| 30 FPS (Low Power) | Static content, saving battery |
| 60 FPS (Default) | Standard smoothness — the previous behavior |
| 90 FPS | High refresh, moderate overhead |
| 120 FPS (ProMotion) | Ultra-smooth on iPad Pro / iPhone Pro |

## Why

The capture pipeline was hardcoded to 60 FPS. Devices with 90/120 Hz panels
couldn't make use of their refresh rate, and users who prefer battery life
had no way to slow the stream down.

## How

- New `FrameRate` enum with a bitrate helper that auto-scales quality
  presets (30 FPS → 0.75×, 90 FPS → 1.25×, 120 FPS → 1.6×, e.g. Best at
  120 FPS ≈ 28.8 Mbps) so higher frame rates don't look blurry.
- The virtual display (`CGVirtualDisplay` mode and HiDPI recovery),
  ScreenCaptureKit pacing (`minimumFrameInterval`), and the
  `VTCompressionSession` (expected frame rate, average bitrate, keyframe
  interval) all read from the selected value.
- Selecting a new rate saves to `UserDefaults` and restarts running
  sessions, matching the existing "Show app in" / quality pickers.

Mac sender only — the phone receiver and the wire protocol are unchanged,
so this PR touches no shared protocol code.

## Phone-side tip: enable the Metal renderer at 90/120 FPS

At high frame rates the default video output (the system
`AVSampleBufferDisplayLayer`) can feel laggy: it paces presentation like a
media player and buffers frames internally, so a fast, bursty stream queues
up inside the layer and latency grows.

The phone app's Settings has a **Metal renderer (experimental)** toggle that
decodes with `VTDecompressionSession` and presents the *newest* frame
directly to a `CAMetalLayer` (latest-frame-wins, no queue), keeping latency
bounded at 90/120 FPS.

- **30/60 FPS:** leave it off — at 60 FPS the system video layer measured
  faster in this project's A/B tests (dedicated compositor plane).
- **90/120 FPS:** turn it on if the stream feels laggy.
- 90/120 FPS is best over USB — the 120 FPS "Best" preset runs ~28.8 Mbps,
  more than many WiFi links sustain.

Measured on-device with the Metal renderer at 120 FPS: median capture→glass
latency ~45–50 ms (`ph50`) even during delivery bursts.

## Testing

- New unit tests (`FrameRateTests`): raw values, labels, bitrate scaling
  (120 FPS Best = 28,800,000), and raw-value fallback.
- All 38 Mac tests pass.
- Manual: USB session with an iPhone Pro at each preset; the encoder log
  line now reports the rate, e.g.
  `encoder ready: 2556x1176 H.264 28Mbps @120fps quality=best`.